### PR TITLE
README: positive framing for the kit's scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Lakebase-backed application development kit. The shared foundation that the [`la
 - **`lakebase-tdd-workflows`** — test-driven development against paired branches. (Coming — FEIP-7066.)
 - Future domains include deploying to Databricks Apps and beyond.
 
-This is NOT [`@databricks/sdk`](https://www.npmjs.com/package/@databricks/sdk) (REST client) and the "app dev" framing is generic: it covers apps deployed to Databricks Apps, services, libraries, and any other software that uses Lakebase.
+The "app dev" framing covers applications, services, libraries, and any other software that uses Lakebase — including projects deployed to Databricks Apps.
 
 ## What this is
 


### PR DESCRIPTION
## Summary

Dropped the \"this is NOT @databricks/sdk\" disambiguation in the README's opening paragraphs. Frame what the kit IS, not what it isn't — anyone confused can read further.

## Diff
\`\`\`diff
-This is NOT [\`@databricks/sdk\`](https://www.npmjs.com/package/@databricks/sdk) (REST client) and the \"app dev\" framing is generic: it covers apps deployed to Databricks Apps, services, libraries, and any other software that uses Lakebase.
+The \"app dev\" framing covers applications, services, libraries, and any other software that uses Lakebase — including projects deployed to Databricks Apps.
\`\`\`

This pull request and its description were written by Isaac.