### PR TITLE
[lakebase-app-dev-kit] Implement Flyway runner (FEIP-7098)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 coverage/
 .vitest/
 .venv-live-tests/
+.tools-live-tests/

--- a/README.md
+++ b/README.md
@@ -109,18 +109,22 @@ Hermetic `npm test` skips every test that needs a real Databricks workspace. To 
 
 | Mode | Required env + tools | What runs | Creates resources? |
 |---|---|---|---|
-| default (migrate) | `DATABRICKS_HOST`, `LAKEBASE_TEST_E2E=1`, authenticated `databricks` CLI, `python3` | `tests/bdd/migrate-live.test.ts` | **Yes**: a `migrate-7091-<timestamp>` Lakebase project on `$DATABRICKS_HOST`, deleted in `afterAll()` |
+| default (migrate) | `DATABRICKS_HOST`, `LAKEBASE_TEST_E2E=1`, authenticated `databricks` CLI, `python3`, `java`, `flyway` | `tests/bdd/migrate-live.test.ts` (alembic) + `tests/bdd/migrate-live-flyway.test.ts` | **Yes**: a `migrate-7091-<timestamp>` and a `migrate-7098-<timestamp>` Lakebase project on `$DATABRICKS_HOST`, each deleted in their suite's `afterAll()` |
 | `--read-only` | `LAKEBASE_TEST_INSTANCE`, `LAKEBASE_TEST_BRANCH` | Read-only schema / endpoint / DSN suites against the configured branch | No |
 | `--all` | both of the above | Everything vitest discovers when gating env is satisfied | Yes (default mode) |
 
 ```bash
-# Default mode: self-provisions a test project on $DATABRICKS_HOST.
-# On first run the script creates .venv-live-tests/ with alembic +
-# sqlalchemy + psycopg2-binary; subsequent runs reuse it.
+# Default mode: self-provisions test projects on $DATABRICKS_HOST.
+# On first run the script creates:
+#   .venv-live-tests/                    (alembic + sqlalchemy + psycopg2-binary)
+#   .tools-live-tests/flyway-<version>/  (Flyway Community CLI; skipped when a `flyway` is already on PATH)
+# Subsequent runs reuse both.
 export DATABRICKS_HOST=https://<your-workspace>.cloud.databricks.com
 export LAKEBASE_TEST_E2E=1
 npm run test:live
 ```
+
+If your network blocks Maven Central (where the Flyway CLI is hosted), install Flyway separately (`brew install flyway`, your internal mirror, etc.) and put it on `PATH` before invoking `npm run test:live`. The script's preflight checks find the pre-installed binary and skips the download.
 
 **Consent model.** Setting `LAKEBASE_TEST_E2E=1 + DATABRICKS_HOST` authorizes the suite to create a Lakebase project on your workspace. The helper script pauses for 5 seconds before the create call with a notice showing the workspace + project name pattern; ctrl-c aborts. Set `LAKEBASE_TEST_NO_PROMPT=1` in CI to skip the pause.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.1-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.2.0-alpha.1",
+      "version": "0.2.1-alpha.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.1-alpha.0",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/scripts/lakebase/migrate-runners/flyway.ts
+++ b/scripts/lakebase/migrate-runners/flyway.ts
@@ -1,45 +1,229 @@
-// Flyway runner for Java + Kotlin projects. Stub for FEIP-7098.
+// Flyway runner for Java + Kotlin projects (FEIP-7098).
 //
-// Listing migrations from disk (without DB connection) already works via
-// listMigrations() in migrate.ts since it just scans
-// src/main/resources/db/migration/V*.sql.
+// Shells to the standalone Flyway Community Edition CLI in JSON output
+// mode. The runner reads the project's migration files from
+// `src/main/resources/db/migration/` (Flyway's standard layout). It
+// passes connection info through FLYWAY_URL / FLYWAY_USER /
+// FLYWAY_PASSWORD env vars rather than command-line flags so the
+// secret never appears in `ps`.
 //
-// Applying, rolling back, and reading status against a real Lakebase
-// branch is deferred to FEIP-7098. The bundled
-// templates/project/common/scripts/flyway-migrate.sh still works for
-// Java/Kotlin projects via the post-merge hook; the kit-level primitive
-// just is not callable for those languages yet.
+// The runner does NOT use `mvn flyway:migrate`. Reasons:
+//   - Avoids dragging a project-specific Maven/Spring Boot build into
+//     primitives that should be runtime-light.
+//   - Lets the primitive work on Maven projects that have not
+//     configured the flyway-maven-plugin yet.
+//   - JSON output mode gives a stable parse target.
+//
+// Real-world Maven users still get Flyway migrations executed on app
+// startup via spring-boot-starter-data-jpa + flyway-core; this runner
+// is what programmatic callers (CLI, MCP, e2e tests) drive.
+//
+// Rollback is intentionally unimplemented: Flyway Community Edition
+// does not support `undo`. Users must roll forward with a compensating
+// migration.
 
+import { spawn } from "node:child_process";
+import * as path from "node:path";
 import {
   MigrationError,
   type ApplyMigrationsResult,
   type RollbackMigrationResult,
   type MigrationStatusResult,
+  type AppliedMigration,
+  type PendingMigration,
 } from "../migrate.js";
-
-const NOT_IMPLEMENTED =
-  "Flyway runner not yet implemented in the kit primitive. " +
-  "For now use the bundled templates/project/common/scripts/flyway-migrate.sh " +
-  "via the post-merge hook, or shell out to `mvn flyway:migrate` directly. " +
-  "Tracking ticket: FEIP-7098.";
 
 interface FlywayCtx {
   projectDir: string;
   dsn: string;
 }
 
-export async function applyFlyway(_ctx: FlywayCtx): Promise<ApplyMigrationsResult> {
-  throw new MigrationError(NOT_IMPLEMENTED);
+/** Convert a Lakebase postgresql:// DSN into the parts Flyway expects. */
+function dsnToFlywayEnv(dsn: string): { url: string; user: string; password: string } {
+  const u = new URL(dsn);
+  const user = decodeURIComponent(u.username);
+  const password = decodeURIComponent(u.password);
+  // Strip credentials from the URL, prefix with `jdbc:`. Preserve port,
+  // path, and query (sslmode=require etc.).
+  const portPart = u.port ? `:${u.port}` : "";
+  const url = `jdbc:postgresql://${u.hostname}${portPart}${u.pathname}${u.search}`;
+  return { url, user, password };
 }
 
-export async function rollbackFlyway(_ctx: FlywayCtx & { target: string }): Promise<RollbackMigrationResult> {
+function migrationsLocation(projectDir: string): string {
+  return `filesystem:${path.join(projectDir, "src", "main", "resources", "db", "migration")}`;
+}
+
+interface FlywayRun {
+  stdout: string;
+  stderr: string;
+}
+
+function runFlyway(ctx: FlywayCtx, args: string[]): Promise<FlywayRun> {
+  const { url, user, password } = dsnToFlywayEnv(ctx.dsn);
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "flyway",
+      ["-outputType=json", `-locations=${migrationsLocation(ctx.projectDir)}`, ...args],
+      {
+        cwd: ctx.projectDir,
+        env: {
+          ...process.env,
+          FLYWAY_URL: url,
+          FLYWAY_USER: user,
+          FLYWAY_PASSWORD: password,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      }
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (err) => {
+      reject(
+        new MigrationError(
+          `Could not spawn flyway. Is the Flyway Community CLI installed and on PATH? ${err.message}`,
+          err
+        )
+      );
+    });
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(
+          new MigrationError(
+            `flyway ${args.join(" ")} exited with code ${code}.\n` +
+              `stdout: ${stdout}\nstderr: ${stderr}`
+          )
+        );
+      }
+    });
+  });
+}
+
+/**
+ * Flyway -outputType=json emits a top-level object whose useful keys
+ * include `migrations` (array of objects). Different commands populate
+ * slightly different fields:
+ *
+ *   - `migrate`: each entry has { version, description, type, filepath,
+ *                                  executionTime, category } for what was
+ *                                  executed in this run.
+ *   - `info`:    each entry has { version, description, type, filepath,
+ *                                  state } for the full inventory.
+ *
+ * We accept either and let the caller assert the keys it cares about.
+ */
+interface FlywayJson {
+  migrations?: Array<{
+    version?: string;
+    description?: string;
+    type?: string;
+    filepath?: string;
+    state?: string;
+    category?: string;
+    executionTime?: number;
+  }>;
+  // Flyway also emits a top-level "error" object on failure, but
+  // non-zero exit codes already surface that path via runFlyway.
+  [key: string]: unknown;
+}
+
+function parseFlywayJson(stdout: string): FlywayJson {
+  // Flyway sometimes prints license / banner text before the JSON when
+  // -outputType=json is set in older versions. Find the first '{'.
+  const start = stdout.indexOf("{");
+  if (start === -1) {
+    throw new MigrationError(`flyway JSON output missing: ${stdout.slice(0, 200)}`);
+  }
+  try {
+    return JSON.parse(stdout.slice(start)) as FlywayJson;
+  } catch (err) {
+    throw new MigrationError(
+      `flyway JSON parse failed: ${err instanceof Error ? err.message : String(err)}.\n` +
+        `Body (first 400 chars): ${stdout.slice(start, start + 400)}`
+    );
+  }
+}
+
+export async function applyFlyway(ctx: FlywayCtx): Promise<ApplyMigrationsResult> {
+  // Lakebase's default Postgres database always has a non-empty `public`
+  // schema (system tables, extensions). Without these flags Flyway 9+
+  // refuses to migrate against it: `NON_EMPTY_SCHEMA_WITHOUT_SCHEMA_HISTORY_TABLE`.
+  // baselineOnMigrate=true creates the schema history table on the
+  // first migrate; baselineVersion=0 ensures every user migration
+  // (V1, V2, ...) is treated as pending instead of being shadowed by
+  // an auto-baseline at V1.
+  const { stdout } = await runFlyway(ctx, [
+    "-baselineOnMigrate=true",
+    "-baselineVersion=0",
+    "migrate",
+  ]);
+  const json = parseFlywayJson(stdout);
+  const entries = json.migrations ?? [];
+
+  const applied: AppliedMigration[] = [];
+  for (const m of entries) {
+    if (m.category === "INIT") continue; // baseline placeholder
+    if (m.state && m.state !== "SUCCESS") continue;
+    if (!m.version) continue;
+    applied.push({
+      version: m.version,
+      description: m.description ?? "",
+      ...(typeof m.executionTime === "number" ? { executionTimeMs: m.executionTime } : {}),
+    });
+  }
+
+  return {
+    applied,
+    alreadyAtLatest: applied.length === 0,
+    tool: "flyway",
+  };
+}
+
+export async function rollbackFlyway(
+  _ctx: FlywayCtx & { target: string }
+): Promise<RollbackMigrationResult> {
   throw new MigrationError(
-    NOT_IMPLEMENTED +
-      " Additional caveat: Flyway Community Edition does not support rollback. " +
-      "Roll-forward with a compensating migration."
+    "Flyway Community Edition does not support undo / rollback. " +
+      "Roll forward with a compensating migration. " +
+      "(Flyway Teams Edition has `flyway undo`, but the kit targets Community.)"
   );
 }
 
-export async function statusFlyway(_ctx: FlywayCtx): Promise<MigrationStatusResult> {
-  throw new MigrationError(NOT_IMPLEMENTED);
+export async function statusFlyway(ctx: FlywayCtx): Promise<MigrationStatusResult> {
+  const { stdout } = await runFlyway(ctx, ["info"]);
+  const json = parseFlywayJson(stdout);
+  const entries = json.migrations ?? [];
+
+  let current: string | undefined;
+  const pending: PendingMigration[] = [];
+
+  for (const m of entries) {
+    if (!m.version) continue;
+    // Flyway info states we care about: SUCCESS, PENDING, BASELINE,
+    // ABOVE_TARGET, MISSING_SUCCESS, MISSING_FAILED, FUTURE_*, IGNORED,
+    // OUTDATED, UNDONE. We treat anything applied (SUCCESS, BASELINE)
+    // as the new current head; anything PENDING goes into the pending
+    // list.
+    const state = (m.state ?? "").toUpperCase();
+    if (state === "SUCCESS" || state === "BASELINE") {
+      current = m.version;
+    } else if (state === "PENDING") {
+      const filename = m.filepath ? path.basename(m.filepath) : `V${m.version}__migration.sql`;
+      pending.push({
+        version: m.version,
+        filename,
+        description: m.description ?? "",
+      });
+    }
+  }
+
+  return { current, pending, tool: "flyway" };
 }

--- a/scripts/run-live-tests.sh
+++ b/scripts/run-live-tests.sh
@@ -2,20 +2,24 @@
 # Run the kit's live integration tests against a real Databricks workspace.
 #
 # Usage:
-#   scripts/run-live-tests.sh              # migrate-live only (self-provisioning, default)
+#   scripts/run-live-tests.sh              # migrate-live (alembic + flyway), default
 #   scripts/run-live-tests.sh --read-only  # tier 1 read-only suite against an existing branch
 #   scripts/run-live-tests.sh --all        # both of the above + any other live suites
 #
 # Modes:
 #
 #   (default) migrate-live
-#     Provisions its own Lakebase project on $DATABRICKS_HOST, runs the
-#     four migrate primitives (apply / rollback / status / list), and
-#     deletes the project on teardown. Project name is timestamp-suffixed.
+#     Provisions its own Lakebase projects on $DATABRICKS_HOST and runs
+#     the four migrate primitives (apply / rollback / status / list)
+#     once with the Alembic runner against a Python project layout and
+#     once with the Flyway runner against a Maven/Spring project layout.
+#     Each test creates and tears down its own project, suffixed with a
+#     timestamp.
 #     Required env: DATABRICKS_HOST, LAKEBASE_TEST_E2E=1
-#     Required tools: databricks CLI (authenticated), python3
-#     (the script auto-provisions a Python venv at .venv-live-tests/ with
-#     alembic + sqlalchemy + psycopg2-binary on first run)
+#     Required tools: databricks CLI (authenticated), python3, java
+#     The script auto-provisions on first run:
+#       - .venv-live-tests/ (Python venv with alembic, sqlalchemy, psycopg2-binary)
+#       - .tools-live-tests/flyway-<version>/ (Flyway Community Edition CLI)
 #
 #   --read-only
 #     Read-only checks against an existing Lakebase branch. Mints
@@ -31,6 +35,8 @@
 #   databricks postgres delete-project <projectId>
 
 set -euo pipefail
+
+FLYWAY_VERSION="10.20.1"
 
 MODE="migrate"
 case "${1:-}" in
@@ -82,6 +88,9 @@ if [[ "$MODE" == "migrate" || "$MODE" == "all" ]]; then
   fi
   require_cmd databricks "install: https://docs.databricks.com/dev-tools/cli/install.html"
   require_cmd python3    "install: https://www.python.org/downloads/"
+  require_cmd java       "install JDK 17+: https://adoptium.net/  (needed to run the Flyway CLI)"
+  require_cmd curl       "install curl (used to download the Flyway CLI on first run)"
+  require_cmd unzip      "install unzip (used to extract the Flyway CLI on first run)"
 fi
 
 if [[ "$MODE" == "read-only" || "$MODE" == "all" ]]; then
@@ -112,6 +121,44 @@ if [[ "$MODE" == "migrate" || "$MODE" == "all" ]]; then
   export PATH="$VENV/bin:$PATH"
 fi
 
+# Provision the Flyway Community Edition CLI for the migrate-live-flyway
+# suite. Idempotent: skips download if .tools-live-tests/flyway-<version>
+# already exists. Prepends the bin dir to PATH so the test subprocess
+# finds `flyway`.
+if [[ "$MODE" == "migrate" || "$MODE" == "all" ]]; then
+  FLYWAY_HOME="$REPO_ROOT/.tools-live-tests/flyway-$FLYWAY_VERSION"
+  if command -v flyway >/dev/null 2>&1; then
+    green "  using flyway from $(command -v flyway) (pre-installed)"
+  elif [[ -x "$FLYWAY_HOME/flyway" ]]; then
+    green "  using flyway from $FLYWAY_HOME/flyway (cached)"
+    export PATH="$FLYWAY_HOME:$PATH"
+  else
+    blue ""
+    blue "==> Provisioning Flyway CLI $FLYWAY_VERSION at $FLYWAY_HOME (one-time setup)"
+    mkdir -p "$REPO_ROOT/.tools-live-tests"
+    ZIP="$REPO_ROOT/.tools-live-tests/flyway-commandline-$FLYWAY_VERSION.zip"
+    URL="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.zip"
+    if [[ ! -f "$ZIP" ]]; then
+      if ! curl --fail --silent --show-error --location -o "$ZIP" "$URL"; then
+        red ""
+        red "  Could not download Flyway from Maven Central ($URL)."
+        yellow "  Workarounds:"
+        yellow "    - Install Flyway manually (e.g. brew install flyway) and re-run."
+        yellow "    - Pre-extract a Flyway tree at $FLYWAY_HOME with an executable flyway/ bin."
+        exit 1
+      fi
+    fi
+    unzip -q -d "$REPO_ROOT/.tools-live-tests" "$ZIP"
+    rm -f "$ZIP"
+    if [[ ! -x "$FLYWAY_HOME/flyway" ]]; then
+      red "  flyway extracted but $FLYWAY_HOME/flyway is missing or not executable"
+      exit 1
+    fi
+    green "  using flyway from $FLYWAY_HOME/flyway"
+    export PATH="$FLYWAY_HOME:$PATH"
+  fi
+fi
+
 # Build dist so the test fixtures import the latest compiled substrate.
 blue ""
 blue "==> Building dist/"
@@ -119,10 +166,12 @@ npm run build >/dev/null
 
 if [[ "$MODE" == "migrate" || "$MODE" == "all" ]]; then
   yellow ""
-  yellow "==> About to create a Lakebase project on your workspace"
+  yellow "==> About to create Lakebase projects on your workspace"
   yellow "    workspace:    $DATABRICKS_HOST"
-  yellow "    project name: migrate-7091-<timestamp>"
-  yellow "    cleanup:      automatic in afterAll() with 3-attempt retry"
+  yellow "    project names:"
+  yellow "      migrate-7091-<timestamp>  (Alembic suite)"
+  yellow "      migrate-7098-<timestamp>  (Flyway suite)"
+  yellow "    cleanup:      automatic in each suite's afterAll() with 3-attempt retry"
   yellow "    manual fix:   databricks postgres delete-project <id>  (if cleanup leaks)"
   yellow ""
   yellow "    Press Ctrl-C in the next 5 seconds to abort. Setting LAKEBASE_TEST_NO_PROMPT=1"
@@ -137,7 +186,9 @@ blue "==> Running live tests (mode: $MODE)"
 
 case "$MODE" in
   migrate)
-    npx vitest run tests/bdd/migrate-live.test.ts
+    npx vitest run \
+      tests/bdd/migrate-live.test.ts \
+      tests/bdd/migrate-live-flyway.test.ts
     ;;
   read-only)
     npx vitest run \

--- a/tests/bdd/migrate-live-flyway.test.ts
+++ b/tests/bdd/migrate-live-flyway.test.ts
@@ -1,0 +1,184 @@
+// Live integration test for the Flyway migrate runner (FEIP-7098).
+//
+// Provisions its own Lakebase project on the configured Databricks
+// workspace, scaffolds a minimal Maven-style Flyway project layout,
+// runs the migrate primitives that Flyway Community Edition supports
+// (apply / status / list) against the default branch, verifies via
+// pg.Pool that the migration landed, and tears the project down.
+//
+// Rollback is intentionally NOT exercised: Flyway Community Edition
+// does not implement `undo`. The runner throws a clear MigrationError;
+// the hermetic test in tests/bdd/migrate.test.ts covers that path.
+//
+// Gating:
+//   LAKEBASE_TEST_E2E=1          must be set; the suite skips otherwise
+//   DATABRICKS_HOST              workspace URL to provision against
+//   databricks CLI               authenticated to that workspace
+//   flyway                       command on PATH (Java 17+ runtime)
+//   java                         command on PATH (flyway runs as a JVM tool)
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  applyMigrations,
+  listMigrations,
+  migrationStatus,
+} from "../../scripts/lakebase/migrate.js";
+import { getConnection } from "../../scripts/lakebase/get-connection.js";
+import {
+  createLakebaseProject,
+  deleteLakebaseProject,
+} from "../../scripts/lakebase/lakebase-project.js";
+import { getDefaultBranch } from "../../scripts/lakebase/branch-utils.js";
+
+const E2E = process.env.LAKEBASE_TEST_E2E === "1";
+const DATABRICKS_HOST = process.env.DATABRICKS_HOST ?? "";
+
+function hasCmd(cmd: string): boolean {
+  const res = spawnSync(cmd, ["--version"], { stdio: "ignore" });
+  return res.status === 0;
+}
+const FLYWAY_AVAILABLE = E2E ? hasCmd("flyway") : false;
+const JAVA_AVAILABLE = E2E ? hasCmd("java") : false;
+const DATABRICKS_AVAILABLE = E2E ? hasCmd("databricks") : false;
+
+const RUN_SUITE = E2E && DATABRICKS_HOST && DATABRICKS_AVAILABLE && FLYWAY_AVAILABLE && JAVA_AVAILABLE;
+
+describe.skipIf(!RUN_SUITE)(
+  "migrate live (flyway against a freshly-provisioned Lakebase project)",
+  () => {
+    let projectDir: string;
+    let projectId: string;
+    let branchName: string;
+    let tableName: string;
+
+    beforeAll(async () => {
+      projectId = `migrate-7098-${Date.now()}`;
+      projectDir = fs.mkdtempSync(path.join(os.tmpdir(), `migrate-flyway-live-${projectId}-`));
+      tableName = `flyway_e2e_${Date.now()}`;
+      scaffoldFlywayProject(projectDir, tableName);
+
+      console.log(`  [setup] creating Lakebase project ${projectId} on ${DATABRICKS_HOST}`);
+      await createLakebaseProject({ projectId, host: DATABRICKS_HOST });
+
+      const dflt = await getDefaultBranch({ instance: projectId, host: DATABRICKS_HOST });
+      if (!dflt) {
+        throw new Error(
+          `Project ${projectId} has no default branch after creation. Check workspace + permissions.`
+        );
+      }
+      const fullName = dflt.name ?? "";
+      branchName = fullName.split("/branches/").pop() ?? dflt.uid;
+      console.log(`  [setup] default branch: ${branchName}`);
+    }, 180_000);
+
+    afterAll(async () => {
+      if (projectId) {
+        try {
+          const pool = await getConnection({
+            output: "pool",
+            instance: projectId,
+            branch: branchName,
+          });
+          await pool.query(`DROP TABLE IF EXISTS ${tableName}`);
+          await pool.query(`DROP TABLE IF EXISTS flyway_schema_history`);
+          await pool.end();
+        } catch {
+          // Best effort; project delete below removes everything anyway.
+        }
+        for (let attempt = 1; attempt <= 3; attempt++) {
+          try {
+            await deleteLakebaseProject({ projectId, host: DATABRICKS_HOST });
+            console.log(`  [teardown] deleted Lakebase project ${projectId}`);
+            break;
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (/not.?found/i.test(msg)) break;
+            if (attempt === 3) {
+              console.error(`  [teardown] FAILED to delete ${projectId}: ${msg}`);
+              console.error(
+                `  [teardown] clean up manually: databricks postgres delete-project ${projectId}`
+              );
+            } else {
+              await new Promise((r) => setTimeout(r, 5_000 * attempt));
+            }
+          }
+        }
+      }
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }, 240_000);
+
+    it("listMigrations enumerates the scaffolded V1 migration", () => {
+      const files = listMigrations({ projectDir });
+      expect(files).toHaveLength(1);
+      expect(files[0].tool).toBe("flyway");
+      expect(files[0].version).toBe("1");
+      expect(files[0].description.toLowerCase().includes("init")).toBe(true);
+    });
+
+    it("migrationStatus reports current=undefined and one pending before apply", async () => {
+      const status = await migrationStatus({
+        instance: projectId,
+        branch: branchName,
+        projectDir,
+      });
+      expect(status.tool).toBe("flyway");
+      expect(status.current).toBeUndefined();
+      expect(status.pending.some((p) => p.version === "1")).toBe(true);
+    }, 60_000);
+
+    it("applyMigrations applies the pending V1; table exists in DB", async () => {
+      const result = await applyMigrations({
+        instance: projectId,
+        branch: branchName,
+        projectDir,
+      });
+      expect(result.tool).toBe("flyway");
+      expect(result.applied.some((a) => a.version === "1")).toBe(true);
+
+      const pool = await getConnection({
+        output: "pool",
+        instance: projectId,
+        branch: branchName,
+      });
+      try {
+        const { rows } = await pool.query(`SELECT to_regclass($1) AS oid`, [tableName]);
+        expect(rows[0].oid).not.toBeNull();
+      } finally {
+        await pool.end();
+      }
+    }, 180_000);
+
+    it("migrationStatus reports current=1 and no pending after apply", async () => {
+      const status = await migrationStatus({
+        instance: projectId,
+        branch: branchName,
+        projectDir,
+      });
+      expect(status.current).toBe("1");
+      expect(status.pending.some((p) => p.version === "1")).toBe(false);
+    }, 60_000);
+  }
+);
+
+/** Lay down a minimal self-contained Flyway-compatible project: a stub
+ *  pom.xml (so detectLanguage() returns "java") plus one SQL migration
+ *  under the standard Flyway location. */
+function scaffoldFlywayProject(dir: string, tableName: string): void {
+  fs.writeFileSync(path.join(dir, "pom.xml"), "<project/>\n");
+
+  const migrationsDir = path.join(dir, "src", "main", "resources", "db", "migration");
+  fs.mkdirSync(migrationsDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(migrationsDir, `V1__init_${tableName}.sql`),
+    `CREATE TABLE ${tableName} (
+  id SERIAL PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+`
+  );
+}

--- a/tests/bdd/migrate-live.test.ts
+++ b/tests/bdd/migrate-live.test.ts
@@ -80,7 +80,6 @@ describe.skipIf(!RUN_SUITE)("migrate live (alembic against a freshly-provisioned
           output: "pool",
           instance: projectId,
           branch: branchName,
-          host: DATABRICKS_HOST,
         });
         await pool.query(`DROP TABLE IF EXISTS ${tableName}`);
         await pool.end();
@@ -138,7 +137,6 @@ describe.skipIf(!RUN_SUITE)("migrate live (alembic against a freshly-provisioned
       output: "pool",
       instance: projectId,
       branch: branchName,
-      host: DATABRICKS_HOST,
     });
     try {
       const { rows } = await pool.query(`SELECT to_regclass($1) AS oid`, [tableName]);
@@ -172,7 +170,6 @@ describe.skipIf(!RUN_SUITE)("migrate live (alembic against a freshly-provisioned
       output: "pool",
       instance: projectId,
       branch: branchName,
-      host: DATABRICKS_HOST,
     });
     try {
       const { rows } = await pool.query(`SELECT to_regclass($1) AS oid`, [tableName]);

--- a/tests/bdd/migrate.test.ts
+++ b/tests/bdd/migrate.test.ts
@@ -227,22 +227,10 @@ describe("listMigrations: language override", () => {
   });
 });
 
-describe("flyway + knex apply/rollback/status: stub errors", () => {
-  // These primitives are not yet implemented (FEIP-7098 / FEIP-7099).
-  // The stubs must throw clear MigrationError pointers; tests confirm
-  // that a Java/Kotlin or Node consumer gets the right message rather
-  // than a confusing crash.
-
-  it("flyway apply throws MigrationError with FEIP-7098 pointer", async () => {
-    const dir = mkTempDir();
-    fs.writeFileSync(path.join(dir, "pom.xml"), "<project/>");
-    try {
-      const { applyFlyway } = await import("../../scripts/lakebase/migrate-runners/flyway.js");
-      await expect(applyFlyway({ projectDir: dir, dsn: "x" })).rejects.toThrow(/FEIP-7098/);
-    } finally {
-      rm(dir);
-    }
-  });
+describe("flyway rollback + knex apply/rollback/status: error paths", () => {
+  // Flyway: apply + status are implemented (live test covers them).
+  // Rollback intentionally throws because Flyway Community Edition has
+  // no `undo`. Knex primitives are stubs pending FEIP-7099.
 
   it("flyway rollback throws with the Flyway Community caveat", async () => {
     const dir = mkTempDir();
@@ -250,7 +238,7 @@ describe("flyway + knex apply/rollback/status: stub errors", () => {
       const { rollbackFlyway } = await import("../../scripts/lakebase/migrate-runners/flyway.js");
       await expect(
         rollbackFlyway({ projectDir: dir, dsn: "x", target: "-1" })
-      ).rejects.toThrow(/Flyway Community Edition does not support rollback/);
+      ).rejects.toThrow(/Flyway Community Edition does not support/);
     } finally {
       rm(dir);
     }


### PR DESCRIPTION
## Summary
- Replaces the FEIP-7098 stub in \`scripts/lakebase/migrate-runners/flyway.ts\` with a real runner that shells to the standalone Flyway Community CLI in JSON output mode. Credentials pass via env, not CLI flags.
- Calls Flyway with \`-baselineOnMigrate=true -baselineVersion=0\` to handle Lakebase's pre-existing \`public\` schema; without these flags Flyway 9+ refuses with \`NON_EMPTY_SCHEMA_WITHOUT_SCHEMA_HISTORY_TABLE\`.
- Rollback still throws: Flyway Community Edition has no \`undo\`. Hermetic test asserts the clear error message; live test does not exercise rollback.
- New live BDD: \`tests/bdd/migrate-live-flyway.test.ts\` provisions a fresh Lakebase project, scaffolds the Maven Flyway layout, runs list + status + apply + status against the default branch.
- \`scripts/run-live-tests.sh\` learns to auto-provision the Flyway CLI under \`.tools-live-tests/flyway-<version>/\` (or use a pre-installed \`flyway\` on PATH).
- Also fixes 3 pre-existing TS errors in \`migrate-live.test.ts\` (\`host:\` was passed to \`getConnection\` where it isn't on the args type).
- Version bump to \`0.2.1-alpha.0\`.

## Test plan
- [x] Hermetic \`npm test\`: 213 passed, 32 skipped, 0 failed
- [x] Live flyway suite against fevm: 4/4 passed
- [x] Live alembic suite still passes alongside (no regression)
- [ ] CI green on this PR before merge

This pull request and its description were written by Isaac.