### PR TITLE
[lakebase-app-dev-kit] Fix Flyway baseline flags in scaffolded CI YAMLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.2.1-alpha.0",
+  "version": "0.2.1-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.2.1-alpha.0",
+      "version": "0.2.1-alpha.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.2.1-alpha.0",
+  "version": "0.2.1-alpha.1",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/scripts/lakebase/migrate.cli.ts
+++ b/scripts/lakebase/migrate.cli.ts
@@ -102,7 +102,7 @@ Examples:
 
 Language support today:
   python (alembic)  Full: apply, rollback, status, list
-  java, kotlin      list only (apply/rollback/status: FEIP-7098)
+  java, kotlin      Full: apply, status, list (rollback unsupported in Flyway Community Edition)
   nodejs            list only (apply/rollback/status: FEIP-7099)
 `;
 

--- a/templates/project/common/.github/workflows/merge.yml
+++ b/templates/project/common/.github/workflows/merge.yml
@@ -198,7 +198,12 @@ jobs:
           LANG="${{ steps.detect-lang.outputs.lang }}"
           echo "Running migrations on target Lakebase '$LAKEBASE_BRANCH_NAME' (git: $GITHUB_REF_NAME, $LANG)..."
           if [ "$LANG" = "java" ]; then
-            if ! ./mvnw -q flyway:migrate -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="${SPRING_DATASOURCE_PASSWORD:-}"; then
+            # baselineOnMigrate + baselineVersion=0 because Lakebase's
+            # `public` schema is always non-empty (system catalogs); Flyway 9+
+            # otherwise aborts with NON_EMPTY_SCHEMA_WITHOUT_SCHEMA_HISTORY_TABLE.
+            # Long-term: FEIP-7100 will route this through substrate's
+            # lakebase-migrate CLI so the flag handling lives in ONE place.
+            if ! ./mvnw -q flyway:migrate -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="${SPRING_DATASOURCE_PASSWORD:-}" -Dflyway.baselineOnMigrate=true -Dflyway.baselineVersion=0; then
               echo "::error::Flyway migrate failed."
               exit 1
             fi

--- a/templates/project/common/.github/workflows/pr.yml
+++ b/templates/project/common/.github/workflows/pr.yml
@@ -317,7 +317,12 @@ jobs:
             echo "Migration files:"; ls -la src/main/resources/db/migration/ || true
             PASS_TRIMMED="$(printf '%s' "$SPRING_DATASOURCE_PASSWORD" | tr -d '\n')"
             echo "Running Flyway migrate on CI branch..."
-            ./mvnw -q flyway:migrate -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="$PASS_TRIMMED" -Dflyway.locations=filesystem:src/main/resources/db/migration
+            # baselineOnMigrate + baselineVersion=0 because Lakebase's
+            # `public` schema is always non-empty (system catalogs); Flyway 9+
+            # otherwise aborts with NON_EMPTY_SCHEMA_WITHOUT_SCHEMA_HISTORY_TABLE.
+            # Long-term: FEIP-7100 will route this through substrate's
+            # lakebase-migrate CLI so the flag handling lives in ONE place.
+            ./mvnw -q flyway:migrate -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="$PASS_TRIMMED" -Dflyway.locations=filesystem:src/main/resources/db/migration -Dflyway.baselineOnMigrate=true -Dflyway.baselineVersion=0
             echo "Flyway info (after migrate):"
             ./mvnw -q flyway:info -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="$PASS_TRIMMED" -Dflyway.locations=filesystem:src/main/resources/db/migration
           elif [ "$LANG" = "python" ]; then


### PR DESCRIPTION
## Summary
- Adds \`-Dflyway.baselineOnMigrate=true -Dflyway.baselineVersion=0\` to \`./mvnw flyway:migrate\` invocations in scaffolded \`pr.yml\` (line 320) and \`merge.yml\` (line 201). Without these, Flyway 9+ aborts on the first migrate against any Lakebase Postgres branch with \`NON_EMPTY_SCHEMA_WITHOUT_SCHEMA_HISTORY_TABLE\` (the \`public\` schema is always non-empty on Lakebase). Same fix the substrate's Flyway runner already uses internally (FEIP-7098).
- Updates the stale CLI HELP text in \`scripts/lakebase/migrate.cli.ts\`: java/kotlin no longer list as "list only" since FEIP-7098 shipped Flyway apply + status. Rollback stays unsupported (Flyway Community caveat).
- Version bump to \`0.2.1-alpha.1\`.

## Why a quick patch + follow-up FEIP
Phase 1 of routing the CI workflows through \`lakebase-migrate\` (FEIP-7100, to be filed). This PR is the smallest fix that unblocks the e-commerce integration test today; FEIP-7100 will fully route both YAMLs through the substrate CLI so the Lakebase-specific flag handling lives in ONE place instead of duplicated between substrate's runner and the YAML templates.

## Test plan
- [x] Hermetic \`npm test\`: 213 passing, 32 skipped, 0 failed
- [ ] Ecom integration test (will rerun against fevm after extension dep bumps to v0.2.1-alpha.1)

This pull request and its description were written by Isaac.