### PR TITLE
[lakebase-app-dev-kit] Drop offline-mode injection from scaffolded mvnw calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.2.1-alpha.1",
+  "version": "0.2.1-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.2.1-alpha.1",
+      "version": "0.2.1-alpha.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.2.1-alpha.1",
+  "version": "0.2.1-alpha.2",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/scripts/lakebase/scaffold.ts
+++ b/scripts/lakebase/scaffold.ts
@@ -228,8 +228,6 @@ export async function patchWorkflowsForRunnerType(targetDir: string, runnerType:
       /- name: Set up JDK\n(?:\s+[\w-]+:.*\n)*\s+uses: actions\/setup-java@v4\n\s+with:\n(?:\s+#[^\n]*\n)*(?:\s+[\w-]+:.*\n)+/g,
       localJdkStep
     );
-    // Add `-o` (offline) to mvnw calls for local Maven cache.
-    content = content.replace(/\.\/mvnw /g, "./mvnw -o ");
     fs.writeFileSync(filePath, content);
   }
 }

--- a/tests/bdd/scaffold.test.ts
+++ b/tests/bdd/scaffold.test.ts
@@ -150,7 +150,7 @@ describe("patchWorkflowsForRunnerType", () => {
     expect(after).toBe(before);
   });
 
-  it("swaps setup-java + adds mvnw -o for self-hosted", async () => {
+  it("swaps setup-java for self-hosted and leaves mvnw calls online", async () => {
     const dir = mkTmp();
     await deployWorkflows(dir);
     await patchWorkflowsForRunnerType(dir, "self-hosted");
@@ -158,12 +158,15 @@ describe("patchWorkflowsForRunnerType", () => {
       const filePath = path.join(dir, ".github", "workflows", file);
       if (!fs.existsSync(filePath)) continue;
       const content = fs.readFileSync(filePath, "utf-8");
-      // After patch, setup-java@v4 should not appear
+      // After patch, setup-java@v4 should not appear (self-hosted runner
+      // brings its own JDK; the scaffold swaps to a local JDK step).
       expect(content).not.toMatch(/uses: actions\/setup-java@v4/);
-      // And any mvnw calls should have -o as the first arg
+      // mvnw calls stay online. Maven resolves through the user's
+      // ~/.m2/settings.xml mirror; forcing -o here would block
+      // plugin-prefix lookups (e.g. `flyway:migrate`) on a cold runner.
       const mvnwHits = content.match(/\.\/mvnw\s+\S+/g) ?? [];
       for (const hit of mvnwHits) {
-        expect(hit).toMatch(/\.\/mvnw -o\b/);
+        expect(hit).not.toMatch(/\.\/mvnw -o\b/);
       }
     }
   });


### PR DESCRIPTION
## Summary
- \`scripts/lakebase/scaffold.ts\` no longer post-injects \`-o\` (offline) into every \`./mvnw\` call when patching scaffolded workflow templates.
- The offline-injection was a workaround from when Maven Central was blocked. Now that \`~/.m2/settings.xml\` mirrors through the Databricks Maven proxy, online resolution works reliably and the workaround does more harm than good — it blocks plugin-prefix lookups (e.g. \`mvn flyway:migrate\`) on a cold runner where the plugin metadata isn't in \`~/.m2/repository\` yet.
- \`tests/bdd/scaffold.test.ts\` inverts its assertion: scaffolded mvnw calls should NOT contain \`-o\`. The setup-java -> local-JDK swap is preserved (independent fix).
- Version bump to \`0.2.1-alpha.2\`.

## Why this unblocks the e-commerce e2e suite
The actual GH Actions failure was:
\`\`\`
[ERROR] No plugin found for prefix 'flyway' in the current project and in the plugin groups [...]
\`\`\`
Tracing it back: scaffold.ts was post-rewriting \`./mvnw flyway:migrate\` to \`./mvnw -o flyway:migrate\`, and offline mode can't resolve a plugin prefix from the proxy on the first invocation. The earlier baseline-flags PR was correct but downstream of this blocker.

## Test plan
- [x] \`npm run typecheck\`: clean (the pre-existing \`js-yaml\` types error is on main, not from this branch)
- [x] \`npm test\`: 213 passing, 32 skipped, 0 failed
- [ ] e-commerce integration test against fevm (rerun after extension bumps substrate to v0.2.1-alpha.2 and updates its own \`-o\` assertion)

This pull request and its description were written by Isaac.