### PR TITLE
[lakebase-app-dev-kit] Update FEIP-7100 placeholders to FEIP-7096

### DIFF
--- a/skills/lakebase-release-workflows/references/branching-and-release-methodology.md
+++ b/skills/lakebase-release-workflows/references/branching-and-release-methodology.md
@@ -161,7 +161,7 @@ Substrate primitives that encode this convention (FEIP-7059 roadmap):
 Companion changes:
 
 - Extension branch picker (VS Code) restricts new-branch creation to the convention's types.
-- Scaffolded project YAMLs (`pr.yml`, `merge.yml`) call substrate primitives instead of inlining `mvn flyway:migrate` / `alembic upgrade head` (FEIP-7100).
+- Scaffolded project YAMLs (`pr.yml`, `merge.yml`) call substrate primitives instead of inlining `mvn flyway:migrate` / `alembic upgrade head` (FEIP-7096).
 - Coding-agent skills reference this document as the source for "how do releases work in a Lakebase-paired project."
 
 ## Open questions

--- a/templates/project/common/.github/workflows/merge.yml
+++ b/templates/project/common/.github/workflows/merge.yml
@@ -201,7 +201,7 @@ jobs:
             # baselineOnMigrate + baselineVersion=0 because Lakebase's
             # `public` schema is always non-empty (system catalogs); Flyway 9+
             # otherwise aborts with NON_EMPTY_SCHEMA_WITHOUT_SCHEMA_HISTORY_TABLE.
-            # Long-term: FEIP-7100 will route this through substrate's
+            # Long-term: FEIP-7096 will route this through substrate's
             # lakebase-migrate CLI so the flag handling lives in ONE place.
             if ! ./mvnw -q flyway:migrate -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="${SPRING_DATASOURCE_PASSWORD:-}" -Dflyway.baselineOnMigrate=true -Dflyway.baselineVersion=0; then
               echo "::error::Flyway migrate failed."

--- a/templates/project/common/.github/workflows/pr.yml
+++ b/templates/project/common/.github/workflows/pr.yml
@@ -320,7 +320,7 @@ jobs:
             # baselineOnMigrate + baselineVersion=0 because Lakebase's
             # `public` schema is always non-empty (system catalogs); Flyway 9+
             # otherwise aborts with NON_EMPTY_SCHEMA_WITHOUT_SCHEMA_HISTORY_TABLE.
-            # Long-term: FEIP-7100 will route this through substrate's
+            # Long-term: FEIP-7096 will route this through substrate's
             # lakebase-migrate CLI so the flag handling lives in ONE place.
             ./mvnw -q flyway:migrate -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="$PASS_TRIMMED" -Dflyway.locations=filesystem:src/main/resources/db/migration -Dflyway.baselineOnMigrate=true -Dflyway.baselineVersion=0
             echo "Flyway info (after migrate):"


### PR DESCRIPTION
Three placeholders pointed at the substrate-route refactor ticket using the predicted number FEIP-7100; JIRA actually assigned [FEIP-7096](https://databricks.atlassian.net/browse/FEIP-7096). Rename for consistency. Docs-only; no version bump.

This pull request and its description were written by Isaac.