### PR TITLE
[lakebase-app-dev-kit] Add cutBackup substrate primitive (FEIP-7096 PR1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.2.1-alpha.2",
+  "version": "0.3.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.2.1-alpha.2",
+      "version": "0.3.0-alpha.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.2.1-alpha.2",
+  "version": "0.3.0-alpha.0",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,
@@ -70,6 +70,7 @@
     "lakebase-github-token": "./dist/scripts/github/auth.cli.js",
     "lakebase-create-project": "./dist/scripts/lakebase/create-project.cli.js",
     "lakebase-migrate": "./dist/scripts/lakebase/migrate.cli.js",
+    "lakebase-cut-backup": "./dist/scripts/lakebase/cut-backup.cli.js",
     "lakebase-mcp-server": "./dist/apps/mcp-server/index.js"
   },
   "scripts": {

--- a/scripts/lakebase/cut-backup.cli.ts
+++ b/scripts/lakebase/cut-backup.cli.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// CLI for the cutBackup primitive (FEIP-7096).
+//
+//   lakebase-cut-backup --instance <id> --source <branch> --name <backup>
+//
+// Prints JSON on stdout, progress on stderr.
+
+import { cutBackup } from "./cut-backup.js";
+
+interface ParsedArgs {
+  instance?: string;
+  source?: string;
+  name?: string;
+  host?: string;
+  pretty?: boolean;
+  help?: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--instance":
+        out.instance = argv[++i];
+        break;
+      case "--source":
+        out.source = argv[++i];
+        break;
+      case "--name":
+        out.name = argv[++i];
+        break;
+      case "--host":
+        out.host = argv[++i];
+        break;
+      case "--pretty":
+        out.pretty = true;
+        break;
+      case "--help":
+      case "-h":
+        out.help = true;
+        break;
+      default:
+        break;
+    }
+  }
+  return out;
+}
+
+const HELP = `lakebase-cut-backup (FEIP-7096)
+
+Snapshot a Lakebase branch by forking a new branch off it. Use for
+"cut prod-backup" before a release migrates production.
+
+Flags:
+  --instance <id>      Lakebase project id (required)
+  --source <branch>    Branch to snapshot (required, e.g. production)
+  --name <backup>      Name for the backup branch (required)
+  --host <url>         Databricks workspace URL (default: $DATABRICKS_HOST)
+  --pretty             Pretty-print JSON output
+
+Example:
+  lakebase-cut-backup --instance proj-x --source production --name prod-backup-v1.2.3
+`;
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (!args.instance || !args.source || !args.name) {
+    process.stderr.write("cut-backup: --instance, --source, and --name are required.\n\n" + HELP);
+    return 2;
+  }
+
+  try {
+    const result = await cutBackup({
+      instance: args.instance,
+      sourceBranch: args.source,
+      backupName: args.name,
+      host: args.host,
+    });
+    process.stdout.write(
+      (args.pretty ? JSON.stringify(result, null, 2) : JSON.stringify(result)) + "\n"
+    );
+    return 0;
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+);

--- a/scripts/lakebase/cut-backup.ts
+++ b/scripts/lakebase/cut-backup.ts
@@ -1,0 +1,62 @@
+// Snapshot a Lakebase branch for rollback safety (FEIP-7096).
+//
+// Used in the release-sprint flow's "cut prod-backup" phase before
+// migrating production. Wraps `createBranch` with an opinionated
+// intent signal ("this is a backup snapshot, not new work") and a
+// returned BackupRef that downstream rollback tooling can use to
+// repoint production at the backup branch in a single step.
+
+import { createBranch } from "./branch-create.js";
+import type { LakebaseBranchInfo, BranchLookupOpts } from "./branch-utils.js";
+
+export interface CutBackupArgs extends BranchLookupOpts {
+  /**
+   * Branch to snapshot. For the release flow this is the current prod
+   * branch (e.g. "production"). The snapshot is forked off this branch
+   * at the moment of the call.
+   */
+  sourceBranch: string;
+  /**
+   * Name for the new backup branch. Should encode the release / run
+   * identifier so rollback knows which backup to restore (e.g.
+   * "prod-backup-v1.2.3" or "pre-migrate-pr-42"). The substrate does
+   * not enforce a naming pattern - it is documented in the
+   * lakebase-release-workflows skill.
+   */
+  backupName: string;
+  /** Wait-for-READY budget. Passed through to createBranch. */
+  readyTimeoutMs?: number;
+  /** Poll interval. Passed through to createBranch. */
+  pollIntervalMs?: number;
+}
+
+export interface CutBackupResult {
+  /** The created backup branch. */
+  backup: LakebaseBranchInfo;
+  /** The source branch's full resource name (echoed for caller convenience). */
+  sourceBranchName: string;
+}
+
+/**
+ * Snapshot a Lakebase branch by creating a new branch forked off it.
+ *
+ * Idempotent on retry: if a branch with `backupName` already exists AND
+ * was forked from `sourceBranch`, returns the existing branch. If it
+ * was forked from a different source, throws (delegated to createBranch's
+ * lineage-conflict check) - silently returning a wrongly-rooted backup
+ * would defeat the rollback contract.
+ */
+export async function cutBackup(args: CutBackupArgs): Promise<CutBackupResult> {
+  const backup = await createBranch({
+    instance: args.instance,
+    host: args.host,
+    branch: args.backupName,
+    parentBranch: args.sourceBranch,
+    readyTimeoutMs: args.readyTimeoutMs,
+    pollIntervalMs: args.pollIntervalMs,
+  });
+  return {
+    backup,
+    sourceBranchName: backup.sourceBranchName ?? "",
+  };
+}

--- a/scripts/lakebase/index.ts
+++ b/scripts/lakebase/index.ts
@@ -7,6 +7,7 @@
 
 export * from "./branch-create.js";
 export * from "./branch-delete.js";
+export * from "./cut-backup.js";
 export * from "./branch-endpoint.js";
 export * from "./branch-schema.js";
 export * from "./paired-branch.js";

--- a/tests/bdd/cut-backup.test.ts
+++ b/tests/bdd/cut-backup.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { cutBackup } from "../../scripts/lakebase/cut-backup.js";
+import { deleteBranch } from "../../scripts/lakebase/branch-delete.js";
+
+// cutBackup wraps createBranch with an opinionated intent. Live test
+// gated on LAKEBASE_TEST_INSTANCE + LAKEBASE_TEST_PARENT mirrors the
+// branch-create + delete test pattern: snapshot the parent branch,
+// assert shape, delete.
+
+const cliAvailable = (() => {
+  try {
+    execFileSync("databricks", ["--version"], { stdio: "ignore", timeout: 3_000 });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const TEST_INSTANCE = process.env.LAKEBASE_TEST_INSTANCE;
+const TEST_PARENT = process.env.LAKEBASE_TEST_PARENT;
+const live = cliAvailable && !!TEST_INSTANCE && !!TEST_PARENT;
+
+describe.skipIf(!live)("cutBackup - destructive live test", () => {
+  it("snapshots the parent branch, returns backup with correct lineage, deletes cleanly", async () => {
+    const backupName = `lbscm-cutbackup-${Date.now()}`;
+    const result = await cutBackup({
+      instance: TEST_INSTANCE!,
+      sourceBranch: TEST_PARENT!,
+      backupName,
+      readyTimeoutMs: 180_000,
+    });
+
+    expect(result.backup.state).toBe("READY");
+    expect(result.backup.uid).toBeTruthy();
+    expect(result.backup.name).toMatch(/^projects\/.*\/branches\//);
+    // Backup lineage echoes the requested source.
+    expect(result.sourceBranchName).toContain(`/branches/${TEST_PARENT}`);
+    // And matches the underlying branch's sourceBranchName field.
+    expect(result.sourceBranchName).toBe(result.backup.sourceBranchName ?? "");
+
+    await deleteBranch({ instance: TEST_INSTANCE!, branch: result.backup.uid });
+  }, 240_000);
+});
+
+describe("cutBackup - shape", () => {
+  it("exports a function with the documented signature", () => {
+    expect(typeof cutBackup).toBe("function");
+  });
+});
+
+describe("cutBackup - skip-when-env-missing", () => {
+  it("documents the skip reason when LAKEBASE_TEST_INSTANCE/PARENT or CLI missing", () => {
+    if (live) return;
+    // eslint-disable-next-line no-console
+    console.log(
+      !cliAvailable
+        ? "`databricks` CLI not available - live cutBackup suite skipped."
+        : "LAKEBASE_TEST_INSTANCE/LAKEBASE_TEST_PARENT not set - live destructive suite skipped."
+    );
+    expect(live).toBe(false);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     "scripts/lakebase/schema-diff.cli": "scripts/lakebase/schema-diff.cli.ts",
     "scripts/lakebase/create-project.cli": "scripts/lakebase/create-project.cli.ts",
     "scripts/lakebase/migrate.cli": "scripts/lakebase/migrate.cli.ts",
+    "scripts/lakebase/cut-backup.cli": "scripts/lakebase/cut-backup.cli.ts",
     "apps/mcp-server/index": "apps/mcp-server/index.ts",
     "apps/mcp-server/dump-tools": "apps/mcp-server/dump-tools.ts",
   },


### PR DESCRIPTION
## Summary
- New substrate function \`cutBackup\` and CLI bin \`lakebase-cut-backup\` for snapshotting a Lakebase branch (forking a new branch off it).
- Thin opinionated wrapper around \`createBranch\` with a domain-specific return shape (\`CutBackupResult\` carrying the backup branch + echoed \`sourceBranchName\`).
- Foundation for [FEIP-7096](https://databricks.atlassian.net/browse/FEIP-7096)'s merge.yml rewrite (PR3 in the sequence) which will replace the inlined \"Create pre-migration snapshot\" workflow step with this primitive.
- Bump to \`0.3.0-alpha.0\` (new public API surface).

## PR sequence (per FEIP-7096 design comment)
1. **This PR** - substrate \`cutBackup\` primitive (function + CLI bin + hermetic tests).
2. PR2 - \`scaffold.ts\` adds \`{{LAKEBASE_KIT_VERSION}}\` template substitution + conditional Flyway-install step generation.
3. PR3 - rewrite \`pr.yml\` + \`merge.yml\` to route migrate + snapshot through substrate calls.
4. PR4 - hermetic test updates + live integration test verification.

## Test plan
- [x] \`npm run typecheck\` clean (pre-existing js-yaml types error remains, out of scope)
- [x] \`npm test\`: 215 passing, 33 skipped, 0 failed (2 new shape tests, 1 new live destructive test gated on \`LAKEBASE_TEST_INSTANCE\` + \`LAKEBASE_TEST_PARENT\`)
- [ ] Live cutBackup test against fevm (deferred to PR4)

This pull request and its description were written by Isaac.