### PR TITLE
Route scaffolded pr.yml migrations through substrate (FEIP-7096 PR2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.0",
+  "version": "0.3.0-alpha.1",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/scripts/lakebase/scaffold.ts
+++ b/scripts/lakebase/scaffold.ts
@@ -98,11 +98,55 @@ export async function deployScripts(targetDir: string, opts?: ScaffoldOptions): 
 
 /** Deploy GitHub Actions workflows from common/.github/workflows/. */
 export async function deployWorkflows(targetDir: string, opts?: ScaffoldOptions): Promise<string[]> {
-  return copyDir(
+  const written = copyDir(
     path.join(commonDir(opts), ".github", "workflows"),
     path.join(targetDir, ".github", "workflows"),
     false
   );
+  substituteWorkflowPlaceholders(
+    path.join(targetDir, ".github", "workflows"),
+    opts
+  );
+  return written;
+}
+
+/**
+ * Read the kit's `package.json` version. The kit root sits two levels
+ * above `templates/project`; tests can pass `templatesDir` to override
+ * which kit's package.json is consulted. When the package.json is
+ * missing or malformed the version comes through as the literal string
+ * "unknown" rather than throwing, so a scaffold against a test fixture
+ * tree without a package.json still completes (its YAML will pin to
+ * the literal "unknown" tag, which is fine for hermetic tests).
+ */
+function kitVersion(opts?: ScaffoldOptions): string {
+  try {
+    const kitRoot = path.dirname(path.dirname(templatesRoot(opts)));
+    const raw = fs.readFileSync(path.join(kitRoot, "package.json"), "utf-8");
+    const pkg = JSON.parse(raw) as { version?: unknown };
+    return typeof pkg.version === "string" ? pkg.version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Rewrite scaffolded workflow YAML files for per-project values that
+ * can only be known at scaffold time.
+ *
+ * Today: substitute `{{LAKEBASE_KIT_VERSION}}` with the kit version
+ * that ran the scaffold. Future-proofed for additional placeholders.
+ */
+function substituteWorkflowPlaceholders(workflowDir: string, opts?: ScaffoldOptions): void {
+  if (!fs.existsSync(workflowDir)) return;
+  const version = kitVersion(opts);
+  for (const entry of fs.readdirSync(workflowDir)) {
+    if (!entry.endsWith(".yml") && !entry.endsWith(".yaml")) continue;
+    const filePath = path.join(workflowDir, entry);
+    const before = fs.readFileSync(filePath, "utf-8");
+    const after = before.replace(/\{\{LAKEBASE_KIT_VERSION\}\}/g, version);
+    if (after !== before) fs.writeFileSync(filePath, after);
+  }
 }
 
 /**

--- a/templates/project/common/.github/workflows/pr.yml
+++ b/templates/project/common/.github/workflows/pr.yml
@@ -301,40 +301,43 @@ jobs:
           unset PGPASSWORD PGHOST PGPORT PGDATABASE PGUSER PGSSLMODE
           exit 0
 
+      # Install Flyway CLI for Java/Kotlin projects only. The substrate's
+      # migrate runner spawns the standalone `flyway` binary; non-Java
+      # projects don't need it. Runtime-gated on pom.xml so the YAML is
+      # one shape for every language.
+      - name: Install Flyway CLI
+        if: steps.lakebase-db.outputs.url != '' && hashFiles('pom.xml') != ''
+        run: |
+          FLYWAY_VERSION=10.20.1
+          DEST="$RUNNER_TEMP/flyway"
+          mkdir -p "$DEST"
+          curl --fail --silent --location \
+            "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.zip" \
+            -o "$DEST/flyway.zip"
+          unzip -q "$DEST/flyway.zip" -d "$DEST"
+          rm -f "$DEST/flyway.zip"
+          echo "$DEST/flyway-$FLYWAY_VERSION" >> $GITHUB_PATH
+
       - name: Run migrations (CI branch)
         id: migrate-ci
         if: steps.lakebase-db.outputs.url != ''
         env:
-          DATABASE_URL: ${{ env.DATABASE_URL }}
-          DB_USERNAME: ${{ env.DB_USERNAME }}
-          DB_PASSWORD: ${{ env.DB_PASSWORD }}
-          SPRING_DATASOURCE_URL: ${{ env.SPRING_DATASOURCE_URL }}
-          SPRING_DATASOURCE_USERNAME: ${{ env.SPRING_DATASOURCE_USERNAME }}
-          SPRING_DATASOURCE_PASSWORD: ${{ env.SPRING_DATASOURCE_PASSWORD }}
+          DATABRICKS_HOST: ${{ env.DATABRICKS_HOST }}
+          LAKEBASE_PROJECT_ID: ${{ secrets.LAKEBASE_PROJECT_ID }}
         run: |
-          LANG="${{ steps.detect-lang.outputs.lang }}"
-          if [ "$LANG" = "java" ]; then
-            echo "Migration files:"; ls -la src/main/resources/db/migration/ || true
-            PASS_TRIMMED="$(printf '%s' "$SPRING_DATASOURCE_PASSWORD" | tr -d '\n')"
-            echo "Running Flyway migrate on CI branch..."
-            # baselineOnMigrate + baselineVersion=0 because Lakebase's
-            # `public` schema is always non-empty (system catalogs); Flyway 9+
-            # otherwise aborts with NON_EMPTY_SCHEMA_WITHOUT_SCHEMA_HISTORY_TABLE.
-            # Long-term: FEIP-7096 will route this through substrate's
-            # lakebase-migrate CLI so the flag handling lives in ONE place.
-            ./mvnw -q flyway:migrate -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="$PASS_TRIMMED" -Dflyway.locations=filesystem:src/main/resources/db/migration -Dflyway.baselineOnMigrate=true -Dflyway.baselineVersion=0
-            echo "Flyway info (after migrate):"
-            ./mvnw -q flyway:info -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="$PASS_TRIMMED" -Dflyway.locations=filesystem:src/main/resources/db/migration
-          elif [ "$LANG" = "python" ]; then
-            echo "Migration files:"; ls -la alembic/versions/ || true
-            echo "Running Alembic upgrade head on CI branch..."
-            uv run alembic upgrade head
-            echo "Alembic current:"; uv run alembic current || true
-          elif [ "$LANG" = "nodejs" ]; then
-            echo "Migration files:"; ls -la migrations/ || true
-            echo "Running Knex migrate:latest on CI branch..."
-            npx knex migrate:latest
+          if [ -z "$LAKEBASE_BRANCH_NAME" ]; then
+            echo "::error::LAKEBASE_BRANCH_NAME not set; the resolve-credentials step should have populated it."
+            exit 1
           fi
+          echo "Routing migrations through the substrate's lakebase-migrate CLI"
+          echo "  kit version: {{LAKEBASE_KIT_VERSION}}"
+          echo "  instance:    $LAKEBASE_PROJECT_ID"
+          echo "  branch:      $LAKEBASE_BRANCH_NAME"
+          npx --yes --package=github:databricks-solutions/lakebase-app-dev-kit#v{{LAKEBASE_KIT_VERSION}} \
+            lakebase-migrate apply \
+            --instance "$LAKEBASE_PROJECT_ID" \
+            --branch "$LAKEBASE_BRANCH_NAME" \
+            --pretty
           echo "Migrations completed."
 
       - name: Run tests

--- a/tests/bdd/scaffold.test.ts
+++ b/tests/bdd/scaffold.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import {
   deployGitignore,
   deployVscodeSettings,
@@ -117,6 +120,73 @@ describe("deployScripts + deployWorkflows", () => {
     const workflows = await deployWorkflows(dir);
     expect(workflows).toContain("pr.yml");
     expect(workflows).toContain("merge.yml");
+  });
+});
+
+describe("deployWorkflows: {{LAKEBASE_KIT_VERSION}} substitution", () => {
+  // Kit version pinning happens at scaffold-time so the generated YAML
+  // resolves the substrate via a stable `github:.../#vX.Y.Z` ref. After
+  // copy, no scaffolded file should contain the literal placeholder.
+  it("substitutes {{LAKEBASE_KIT_VERSION}} in scaffolded pr.yml with the kit's package.json version", async () => {
+    const dir = mkTmp();
+    await deployWorkflows(dir);
+    const prYml = fs.readFileSync(path.join(dir, ".github", "workflows", "pr.yml"), "utf-8");
+    expect(prYml).not.toContain("{{LAKEBASE_KIT_VERSION}}");
+    // The kit's own package.json version is what gets pinned.
+    const kitPkg = JSON.parse(
+      fs.readFileSync(
+        path.join(__dirname, "..", "..", "package.json"),
+        "utf-8"
+      )
+    ) as { version: string };
+    expect(prYml).toContain(`#v${kitPkg.version}`);
+  });
+
+  it("scaffolded pr.yml routes migrations through the substrate's lakebase-migrate CLI", async () => {
+    const dir = mkTmp();
+    await deployWorkflows(dir);
+    const prYml = fs.readFileSync(path.join(dir, ".github", "workflows", "pr.yml"), "utf-8");
+    // Substrate routing line, not the old language-branched mvnw/uv/npx-knex shape.
+    expect(prYml).toMatch(/lakebase-migrate apply/);
+    expect(prYml).toMatch(/github:databricks-solutions\/lakebase-app-dev-kit/);
+    expect(prYml).toMatch(/--instance "\$LAKEBASE_PROJECT_ID"/);
+    expect(prYml).toMatch(/--branch "\$LAKEBASE_BRANCH_NAME"/);
+    // The old per-language branches MUST be gone — substrate handles
+    // language detection internally.
+    expect(prYml).not.toMatch(/flyway:migrate/);
+    expect(prYml).not.toMatch(/uv run alembic upgrade head/);
+    expect(prYml).not.toMatch(/npx knex migrate:latest/);
+  });
+
+  it("scaffolded pr.yml includes the Flyway CLI install step gated on pom.xml", async () => {
+    const dir = mkTmp();
+    await deployWorkflows(dir);
+    const prYml = fs.readFileSync(path.join(dir, ".github", "workflows", "pr.yml"), "utf-8");
+    expect(prYml).toMatch(/name: Install Flyway CLI/);
+    // Runtime gate: only install on Java/Kotlin projects (pom.xml present).
+    expect(prYml).toMatch(/hashFiles\('pom\.xml'\) != ''/);
+  });
+
+  it("falls back to 'unknown' when templatesDir points at a tree without a package.json", async () => {
+    // Build a minimal fixture: tmpRoot has only `templates/project/common/.github/workflows/`,
+    // no package.json at tmpRoot. kitVersion() resolves via path.dirname twice,
+    // so the lookup target is tmpRoot/package.json — which is absent.
+    const fixture = mkTmp();
+    const templates = path.join(fixture, "templates", "project");
+    const wfDir = path.join(templates, "common", ".github", "workflows");
+    fs.mkdirSync(wfDir, { recursive: true });
+    // Marker file expected by findTemplatesDir (not consulted when
+    // templatesDir is passed explicitly, but cheap to include).
+    fs.writeFileSync(path.join(templates, "common", ".gitignore.base"), "");
+    fs.writeFileSync(
+      path.join(wfDir, "pr.yml"),
+      "kit: {{LAKEBASE_KIT_VERSION}}\n"
+    );
+
+    const target = mkTmp();
+    await deployWorkflows(target, { templatesDir: templates });
+    const out = fs.readFileSync(path.join(target, ".github", "workflows", "pr.yml"), "utf-8");
+    expect(out).toBe("kit: unknown\n");
   });
 });
 


### PR DESCRIPTION
## Summary

- Substitute `{{LAKEBASE_KIT_VERSION}}` in scaffolded workflow YAMLs at scaffold time so the generated pr.yml pins the substrate to the exact kit version that scaffolded it (no floating `main`).
- Replace pr.yml's language-branched Flyway/Alembic/Knex block with a single substrate-routed step that calls `lakebase-migrate apply`. Substrate handles language detection, baseline flags, and tool spawning in one place.
- Add a runtime-gated Flyway CLI install step (only on Java/Kotlin projects with `pom.xml`) so the substrate's Flyway runner can find the standalone binary on PATH.
- Bump kit to `0.3.0-alpha.1` so the scaffolded YAML's `#v0.3.0-alpha.1` ref resolves after the tag is cut.

## Scope

PR2 of FEIP-7096. PR1 added the `cutBackup` primitive. PR3 will substrate-route `merge.yml` (apply migrations + cutBackup pre-snapshot).

## Hermetic test coverage

`tests/bdd/scaffold.test.ts`:
- Substituted pr.yml contains no `{{LAKEBASE_KIT_VERSION}}` literal.
- Substituted pr.yml pins `#v<kit-version>` from package.json.
- Substituted pr.yml has the substrate `lakebase-migrate apply` line with `--instance`/`--branch` from env.
- Old per-language branches (`flyway:migrate`, `uv run alembic upgrade head`, `npx knex migrate:latest`) are gone.
- Flyway-install step exists with the `hashFiles('pom.xml')` gate.
- Substitution falls back to `'unknown'` for trees without a package.json (test fixtures).

Full hermetic suite: 219 passed, 33 skipped (env-gated live tests).

## Test plan

- [x] `npx vitest run tests/bdd/scaffold.test.ts` (18/18 pass)
- [x] `npx vitest run` (219/219 hermetic; 33 env-gated skips)
- [ ] After merge + tag `v0.3.0-alpha.1`, exercise live via lakebase-scm-extension's python-devloop + ecom e2e suites (substrate routing is the same code path the extension's substrate-proxy already calls).

This pull request and its description were written by Isaac.