### PR TITLE
Detect existing flyway + honor proxy override in pr.yml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/templates/project/common/.github/workflows/pr.yml
+++ b/templates/project/common/.github/workflows/pr.yml
@@ -305,14 +305,32 @@ jobs:
       # migrate runner spawns the standalone `flyway` binary; non-Java
       # projects don't need it. Runtime-gated on pom.xml so the YAML is
       # one shape for every language.
+      #
+      # Resolution order:
+      #   1. `flyway` already on PATH (self-hosted runner with brew /
+      #      apt install): use it, skip download.
+      #   2. $FLYWAY_DOWNLOAD_BASE_URL env override (runners behind a
+      #      Maven-proxy mirror that block repo1.maven.org). Wire via
+      #      repo Variables → vars.FLYWAY_DOWNLOAD_BASE_URL.
+      #   3. Default https://repo1.maven.org/maven2 for GitHub-hosted
+      #      runners with public internet.
       - name: Install Flyway CLI
         if: steps.lakebase-db.outputs.url != '' && hashFiles('pom.xml') != ''
+        env:
+          FLYWAY_DOWNLOAD_BASE_URL: ${{ vars.FLYWAY_DOWNLOAD_BASE_URL }}
         run: |
+          if command -v flyway >/dev/null 2>&1; then
+            echo "Flyway already on PATH ($(command -v flyway)); skipping download."
+            flyway --version 2>&1 | head -1 || true
+            exit 0
+          fi
           FLYWAY_VERSION=10.20.1
+          FLYWAY_BASE="${FLYWAY_DOWNLOAD_BASE_URL:-https://repo1.maven.org/maven2}"
           DEST="$RUNNER_TEMP/flyway"
           mkdir -p "$DEST"
+          echo "Downloading Flyway $FLYWAY_VERSION from $FLYWAY_BASE ..."
           curl --fail --silent --location \
-            "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.zip" \
+            "$FLYWAY_BASE/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.zip" \
             -o "$DEST/flyway.zip"
           unzip -q "$DEST/flyway.zip" -d "$DEST"
           rm -f "$DEST/flyway.zip"

--- a/tests/bdd/scaffold.test.ts
+++ b/tests/bdd/scaffold.test.ts
@@ -167,6 +167,30 @@ describe("deployWorkflows: {{LAKEBASE_KIT_VERSION}} substitution", () => {
     expect(prYml).toMatch(/hashFiles\('pom\.xml'\) != ''/);
   });
 
+  it("scaffolded pr.yml's Install Flyway step short-circuits when flyway is on PATH", async () => {
+    // Prevents a regression where the step unconditionally curl'd from
+    // repo1.maven.org. Internal self-hosted runners often have flyway
+    // already on PATH via brew/apt; the kit must use it before reaching
+    // out to the network.
+    const dir = mkTmp();
+    await deployWorkflows(dir);
+    const prYml = fs.readFileSync(path.join(dir, ".github", "workflows", "pr.yml"), "utf-8");
+    expect(prYml).toMatch(/command -v flyway >\/dev\/null 2>&1/);
+    expect(prYml).toMatch(/skipping download/);
+  });
+
+  it("scaffolded pr.yml honors FLYWAY_DOWNLOAD_BASE_URL via vars.* and env default", async () => {
+    // For runners behind a Maven-proxy mirror (e.g. internal proxies
+    // that block repo1.maven.org). The vars.X reference wires the GH
+    // Actions repo Variable into the step's env; the bash fallback
+    // keeps repo1.maven.org as the default when the var is unset.
+    const dir = mkTmp();
+    await deployWorkflows(dir);
+    const prYml = fs.readFileSync(path.join(dir, ".github", "workflows", "pr.yml"), "utf-8");
+    expect(prYml).toMatch(/FLYWAY_DOWNLOAD_BASE_URL:\s*\$\{\{\s*vars\.FLYWAY_DOWNLOAD_BASE_URL\s*\}\}/);
+    expect(prYml).toMatch(/FLYWAY_BASE="\$\{FLYWAY_DOWNLOAD_BASE_URL:-https:\/\/repo1\.maven\.org\/maven2\}"/);
+  });
+
   it("falls back to 'unknown' when templatesDir points at a tree without a package.json", async () => {
     // Build a minimal fixture: tmpRoot has only `templates/project/common/.github/workflows/`,
     // no package.json at tmpRoot. kitVersion() resolves via path.dirname twice,


### PR DESCRIPTION
## Summary

Scaffolded pr.yml's Install Flyway CLI step unconditionally curled from `https://repo1.maven.org/maven2/...`, which fails on self-hosted runners that block Maven Central even when `flyway` is already on PATH (e.g. brew/apt-installed).

New resolution order in priority:
1. `flyway` on PATH already → use it, skip download.
2. `$FLYWAY_DOWNLOAD_BASE_URL` env override (wired through `vars.FLYWAY_DOWNLOAD_BASE_URL` at the repo level) → curl from that base URL. For Maven-proxy mirrors that fronted internal networks.
3. Default `https://repo1.maven.org/maven2` for GitHub-hosted runners with public internet.

## Why

The v0.3.0-alpha.1 ecom integration suite failed on the self-hosted runner: `curl --fail` exited 7 (network unreachable) on the Maven Central download. The runner's brew-installed Flyway 12.6.2 was sitting unused at `/opt/homebrew/bin/flyway` because the step short-circuited to download.

## Test plan

- [x] `npx vitest run tests/bdd/scaffold.test.ts` (20/20)
- [ ] Bump lakebase-scm-extension to v0.3.0-alpha.2, re-run ecom integration suite (expect Phase B build-and-test to pass now).

This pull request and its description were written by Isaac.