### PR TITLE
Pass DATABRICKS_TOKEN + AUTH_TYPE=pat to substrate migrate step

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/templates/project/common/.github/workflows/pr.yml
+++ b/templates/project/common/.github/workflows/pr.yml
@@ -340,7 +340,15 @@ jobs:
         id: migrate-ci
         if: steps.lakebase-db.outputs.url != ''
         env:
-          DATABRICKS_HOST: ${{ env.DATABRICKS_HOST }}
+          # Pull auth from secrets directly. The substrate's lakebase-migrate
+          # CLI spawns `databricks postgres list-endpoints` under the hood,
+          # which on Databricks CLI v1+ refuses to read the pre-v1 ~/.databricks/
+          # credential cache and won't fall back to DATABRICKS_TOKEN unless
+          # DATABRICKS_AUTH_TYPE=pat pins it. Same pattern as the other auth-
+          # requiring steps in this workflow ("Run E2E tests", "Schema diff").
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          DATABRICKS_AUTH_TYPE: pat
           LAKEBASE_PROJECT_ID: ${{ secrets.LAKEBASE_PROJECT_ID }}
         run: |
           if [ -z "$LAKEBASE_BRANCH_NAME" ]; then

--- a/tests/bdd/scaffold.test.ts
+++ b/tests/bdd/scaffold.test.ts
@@ -158,6 +158,32 @@ describe("deployWorkflows: {{LAKEBASE_KIT_VERSION}} substitution", () => {
     expect(prYml).not.toMatch(/npx knex migrate:latest/);
   });
 
+  it("scaffolded pr.yml's migrate step passes auth from secrets with DATABRICKS_AUTH_TYPE=pat", async () => {
+    // Regression guard: the substrate's lakebase-migrate CLI spawns
+    // `databricks postgres list-endpoints` under the hood. On Databricks
+    // CLI v1+ that call fails with "stored credentials from older CLI
+    // versions are no longer used" unless DATABRICKS_AUTH_TYPE=pat is
+    // set in the step env. Pulling DATABRICKS_HOST from `env.X` (which
+    // is empty unless a prior step echoed into $GITHUB_ENV) is the trap
+    // we want to prevent regressing into.
+    const dir = mkTmp();
+    await deployWorkflows(dir);
+    const prYml = fs.readFileSync(path.join(dir, ".github", "workflows", "pr.yml"), "utf-8");
+    // Extract the Run migrations (CI branch) step's env block via a
+    // narrow regex - other steps have their own env blocks we don't
+    // want to false-match against.
+    const migrateBlock = prYml.match(
+      /- name: Run migrations \(CI branch\)[\s\S]*?(?=\n\s*- name:|\Z)/,
+    );
+    expect(migrateBlock, "Run migrations (CI branch) step not found").toBeTruthy();
+    const block = migrateBlock![0];
+    expect(block).toMatch(/DATABRICKS_HOST:\s*\$\{\{\s*secrets\.DATABRICKS_HOST\s*\}\}/);
+    expect(block).toMatch(/DATABRICKS_TOKEN:\s*\$\{\{\s*secrets\.DATABRICKS_TOKEN\s*\}\}/);
+    expect(block).toMatch(/DATABRICKS_AUTH_TYPE:\s*pat/);
+    // The trap: env.DATABRICKS_HOST (empty unless someone echoed it).
+    expect(block).not.toMatch(/DATABRICKS_HOST:\s*\$\{\{\s*env\.DATABRICKS_HOST\s*\}\}/);
+  });
+
   it("scaffolded pr.yml includes the Flyway CLI install step gated on pom.xml", async () => {
     const dir = mkTmp();
     await deployWorkflows(dir);


### PR DESCRIPTION
## Summary

The substrate-routed migrate step in scaffolded `pr.yml` was missing `DATABRICKS_TOKEN` + `DATABRICKS_AUTH_TYPE=pat` and pulled `DATABRICKS_HOST` from `env.X` (empty unless a prior step echoed it via `$GITHUB_ENV` — no step does). Result: `databricks postgres list-endpoints` failed with the v1+ credential cache rejection. Same trap that bit merge.yml's Authenticate Databricks step.

## Fix

Pull all three from `secrets.*` directly, matching the pattern of the other auth-requiring steps in this workflow ("Run E2E tests", "Schema diff").

## Hermetic test

Asserts the new env shape AND guards regression back to `env.DATABRICKS_HOST`.

## Why this didn't surface in PR2

PR2 + PR15 hermetic tests checked YAML *shape* (the substrate URL, the `--instance`/`--branch` flags) but not the env-block correctness. The auth bug only surfaces when an actual CI run spawns `databricks postgres` against Lakebase v1+ CLI.

This pull request and its description were written by Isaac.