### PR TITLE
Resolve alembic from project's .venv before PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/scripts/lakebase/migrate-runners/alembic.ts
+++ b/scripts/lakebase/migrate-runners/alembic.ts
@@ -15,6 +15,8 @@
 // to logger config drift in the consumer's `alembic.ini`.
 
 import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import {
   MigrationError,
   type ApplyMigrationsResult,
@@ -29,9 +31,33 @@ interface RunnerCtx {
   dsn: string;
 }
 
+/**
+ * Resolve the `alembic` binary path. uv-managed Python projects install
+ * alembic into a per-project `.venv/bin/alembic`, which is NOT on the
+ * runner's PATH. Spawning bare `alembic` fails with ENOENT in CI even
+ * after `uv sync` succeeded. Prefer the project-local venv when it
+ * exists; fall back to bare `alembic` for projects with a pre-activated
+ * shell venv or a system-wide install.
+ */
+export function resolveAlembicBin(projectDir: string): string {
+  const candidates = [
+    path.join(projectDir, ".venv", "bin", "alembic"),
+    path.join(projectDir, "venv", "bin", "alembic"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch {
+      // best-effort; keep checking
+    }
+  }
+  return "alembic";
+}
+
 function runAlembic(ctx: RunnerCtx, args: string[]): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    const child = spawn("alembic", args, {
+    const bin = resolveAlembicBin(ctx.projectDir);
+    const child = spawn(bin, args, {
       cwd: ctx.projectDir,
       env: { ...process.env, DATABASE_URL: ctx.dsn },
       stdio: ["ignore", "pipe", "pipe"],

--- a/tests/bdd/alembic-runner.test.ts
+++ b/tests/bdd/alembic-runner.test.ts
@@ -1,0 +1,70 @@
+// Hermetic test for the alembic runner's binary resolution. The live
+// runAlembic path (which actually invokes alembic against a real DB) is
+// covered by the lakebase-scm-extension's python-devloop integration
+// suite. Here we only lock the project-local-venv detection logic so a
+// future refactor can't regress back to bare `spawn("alembic", ...)`.
+
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveAlembicBin } from "../../scripts/lakebase/migrate-runners/alembic.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  }
+});
+
+function mkTmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lbscm-alembic-bin-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function touch(p: string): void {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, "");
+  fs.chmodSync(p, 0o755);
+}
+
+describe("resolveAlembicBin", () => {
+  it("prefers <projectDir>/.venv/bin/alembic when present", () => {
+    const dir = mkTmp();
+    const venvBin = path.join(dir, ".venv", "bin", "alembic");
+    touch(venvBin);
+    expect(resolveAlembicBin(dir)).toBe(venvBin);
+  });
+
+  it("falls back to <projectDir>/venv/bin/alembic when .venv is absent", () => {
+    const dir = mkTmp();
+    const venvBin = path.join(dir, "venv", "bin", "alembic");
+    touch(venvBin);
+    expect(resolveAlembicBin(dir)).toBe(venvBin);
+  });
+
+  it("prefers .venv over venv when both exist", () => {
+    const dir = mkTmp();
+    const dotVenv = path.join(dir, ".venv", "bin", "alembic");
+    const plainVenv = path.join(dir, "venv", "bin", "alembic");
+    touch(dotVenv);
+    touch(plainVenv);
+    expect(resolveAlembicBin(dir)).toBe(dotVenv);
+  });
+
+  it("returns bare 'alembic' when no project venv exists", () => {
+    const dir = mkTmp();
+    expect(resolveAlembicBin(dir)).toBe("alembic");
+  });
+
+  it("returns bare 'alembic' for a non-existent projectDir", () => {
+    // Resolution must not throw on a missing dir; fall through to PATH.
+    const fake = path.join(os.tmpdir(), `lbscm-alembic-missing-${Date.now()}`);
+    expect(resolveAlembicBin(fake)).toBe("alembic");
+  });
+});


### PR DESCRIPTION
## Summary

The substrate's alembic runner spawned bare \`alembic\` from PATH. uv-managed Python projects install alembic into the per-project \`.venv/bin/\` only; the runner's PATH doesn't include that. Result: \`spawn alembic ENOENT\` on the python-devloop integration suite even after \`uv sync\` succeeded.

Fix: resolve \`alembic\` via project-local venv first, then fall back to PATH.

Resolution order:
1. \`<projectDir>/.venv/bin/alembic\` (uv default)
2. \`<projectDir>/venv/bin/alembic\` (legacy)
3. Bare \`alembic\` (pre-activated venv or system install)

Hermetic test locks the priority order.

This pull request and its description were written by Isaac.