### PR TITLE
Substrate-route scaffolded merge.yml (FEIP-7096 PR3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.4",
+  "version": "0.3.0-alpha.5",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/templates/project/common/.github/workflows/merge.yml
+++ b/templates/project/common/.github/workflows/merge.yml
@@ -147,9 +147,61 @@ jobs:
           fi
           echo "Target branch resolved: $LAKEBASE_BRANCH_NAME (git: $TARGET_GIT_BRANCH)"
 
+      # Install Flyway CLI for Java/Kotlin projects only. The substrate's
+      # migrate runner spawns the standalone `flyway` binary; non-Java
+      # projects don't need it. Runtime-gated on pom.xml so the YAML is
+      # one shape for every language.
+      #
+      # Resolution order (mirrors pr.yml's Install Flyway CLI step):
+      #   1. `flyway` already on PATH (self-hosted runner with brew /
+      #      apt install): use it, skip download.
+      #   2. $FLYWAY_DOWNLOAD_BASE_URL env override (runners behind a
+      #      Maven-proxy mirror that block repo1.maven.org). Wire via
+      #      repo Variables → vars.FLYWAY_DOWNLOAD_BASE_URL.
+      #   3. Default https://repo1.maven.org/maven2 for GitHub-hosted
+      #      runners with public internet.
+      - name: Install Flyway CLI
+        if: hashFiles('pom.xml') != ''
+        env:
+          FLYWAY_DOWNLOAD_BASE_URL: ${{ vars.FLYWAY_DOWNLOAD_BASE_URL }}
+        run: |
+          if command -v flyway >/dev/null 2>&1; then
+            echo "Flyway already on PATH ($(command -v flyway)); skipping download."
+            flyway --version 2>&1 | head -1 || true
+            exit 0
+          fi
+          FLYWAY_VERSION=10.20.1
+          FLYWAY_BASE="${FLYWAY_DOWNLOAD_BASE_URL:-https://repo1.maven.org/maven2}"
+          DEST="$RUNNER_TEMP/flyway"
+          mkdir -p "$DEST"
+          echo "Downloading Flyway $FLYWAY_VERSION from $FLYWAY_BASE ..."
+          curl --fail --silent --location \
+            "$FLYWAY_BASE/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.zip" \
+            -o "$DEST/flyway.zip"
+          unzip -q "$DEST/flyway.zip" -d "$DEST"
+          rm -f "$DEST/flyway.zip"
+          echo "$DEST/flyway-$FLYWAY_VERSION" >> $GITHUB_PATH
+
+      # Snapshot the production branch before migrating. Cut via the
+      # substrate's lakebase-cut-backup CLI so the snapshot name +
+      # lineage rules stay aligned with the release-sprint flow.
+      #
+      # The substrate primitive doesn't currently take a TTL; the cleanup
+      # step below explicitly deletes on success and preserves on failure.
+      # A catastrophic runner crash between cut-backup and cleanup would
+      # leak the snapshot, where the previous inline call's ttl=86400s
+      # was a backstop - tracked as a follow-up on FEIP-7096.
       - name: Create pre-migration snapshot
         id: snapshot
         env:
+          # Pull auth from secrets directly. The substrate's lakebase-cut-backup
+          # CLI shells out to `databricks postgres create-branch`, which on
+          # Databricks CLI v1+ rejects the pre-v1 credential cache and won't
+          # fall back to DATABRICKS_TOKEN unless DATABRICKS_AUTH_TYPE=pat
+          # pins it. Same pattern as pr.yml's "Run migrations (CI branch)".
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          DATABRICKS_AUTH_TYPE: pat
           LAKEBASE_PROJECT_ID: ${{ secrets.LAKEBASE_PROJECT_ID }}
         run: |
           PROJ_PATH="projects/${LAKEBASE_PROJECT_ID}"
@@ -157,71 +209,76 @@ jobs:
           PR_NUM="$(git log -1 --pretty=%s | grep -oE '#[0-9]+' | head -1 | tr -d '#')" || true
           SNAPSHOT_NAME="pre-migrate-pr-${PR_NUM:-$(date +%s)}"
 
-          # Find default branch as source
+          # Find the default branch (snapshot source). The Lakebase API
+          # marks the production branch with status.default=true; we
+          # snapshot that one, not the merge-target git branch.
           LIST_RAW="$(databricks postgres list-branches "$PROJ_PATH" -o json 2>&1)"
           BRANCHES="$(echo "$LIST_RAW" | jq -c 'if type == "array" then . elif type == "object" then (.branches // .items // []) else [] end' 2>/dev/null)" || BRANCHES="[]"
           DEFAULT_NAME="$(echo "$BRANCHES" | jq -r '.[] | select((.status.default == true) or (.is_default == true)) | .name' 2>/dev/null | head -1)"
 
-          if [ -n "$DEFAULT_NAME" ]; then
-            echo "Creating pre-migration snapshot: $SNAPSHOT_NAME"
-            # Capture stdout+stderr and exit status separately so a failure
-            # here doesn't get masked by a downstream "may have already
-            # expired" message in the cleanup step.
-            if CREATE_OUT="$(databricks postgres create-branch "$PROJ_PATH" "$SNAPSHOT_NAME" \
-                              --json "{\"spec\": {\"source_branch\": \"${DEFAULT_NAME}\", \"ttl\": \"86400s\"}}" 2>&1)"; then
-              echo "$CREATE_OUT"
-              echo "SNAPSHOT_NAME=$SNAPSHOT_NAME" >> $GITHUB_ENV
-              echo "SNAPSHOT_PROJ_PATH=$PROJ_PATH" >> $GITHUB_ENV
-            else
-              echo "$CREATE_OUT"
-              echo "::warning::Failed to create pre-migration snapshot. Proceeding without rollback safety."
-              echo "SNAPSHOT_NAME=" >> $GITHUB_ENV
-            fi
-          else
+          if [ -z "$DEFAULT_NAME" ]; then
             echo "::warning::Could not find default branch for snapshot. Proceeding without rollback safety."
+            echo "SNAPSHOT_NAME=" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          echo "Routing snapshot through substrate's lakebase-cut-backup CLI"
+          echo "  kit version: {{LAKEBASE_KIT_VERSION}}"
+          echo "  instance:    $LAKEBASE_PROJECT_ID"
+          echo "  source:      $DEFAULT_NAME"
+          echo "  backup:      $SNAPSHOT_NAME"
+          if CREATE_OUT="$(npx --yes --package=github:databricks-solutions/lakebase-app-dev-kit#v{{LAKEBASE_KIT_VERSION}} \
+                              lakebase-cut-backup \
+                              --instance "$LAKEBASE_PROJECT_ID" \
+                              --source "$DEFAULT_NAME" \
+                              --name "$SNAPSHOT_NAME" \
+                              --pretty 2>&1)"; then
+            echo "$CREATE_OUT"
+            echo "SNAPSHOT_NAME=$SNAPSHOT_NAME" >> $GITHUB_ENV
+            echo "SNAPSHOT_PROJ_PATH=$PROJ_PATH" >> $GITHUB_ENV
+          else
+            echo "$CREATE_OUT"
+            echo "::warning::Failed to create pre-migration snapshot. Proceeding without rollback safety."
             echo "SNAPSHOT_NAME=" >> $GITHUB_ENV
           fi
 
       - name: Run migrations (target)
         env:
-          DATABASE_URL: ${{ env.DATABASE_URL }}
-          DB_USERNAME: ${{ env.DB_USERNAME }}
-          DB_PASSWORD: ${{ env.DB_PASSWORD }}
-          SPRING_DATASOURCE_URL: ${{ env.SPRING_DATASOURCE_URL || secrets.SPRING_DATASOURCE_URL || '' }}
-          SPRING_DATASOURCE_USERNAME: ${{ env.SPRING_DATASOURCE_USERNAME || secrets.SPRING_DATASOURCE_USERNAME || '' }}
-          SPRING_DATASOURCE_PASSWORD: ${{ env.SPRING_DATASOURCE_PASSWORD || secrets.SPRING_DATASOURCE_PASSWORD || '' }}
+          # Substrate's lakebase-migrate CLI handles language detection,
+          # baseline flags, and tool spawning. Auth pulled from secrets
+          # directly (DATABRICKS_AUTH_TYPE=pat required for CLI v1+;
+          # see pr.yml's "Run migrations (CI branch)" for the rationale).
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          DATABRICKS_AUTH_TYPE: pat
+          LAKEBASE_PROJECT_ID: ${{ secrets.LAKEBASE_PROJECT_ID }}
         run: |
-          if [ -z "$DATABASE_URL" ] && [ -z "$SPRING_DATASOURCE_URL" ]; then
-            echo "::error::No database credentials available after auth step. This should not happen."
+          if [ -z "$LAKEBASE_BRANCH_NAME" ]; then
+            echo "::error::LAKEBASE_BRANCH_NAME not set; the resolve-credentials step should have populated it."
             exit 1
           fi
-          LANG="${{ steps.detect-lang.outputs.lang }}"
-          echo "Running migrations on target Lakebase '$LAKEBASE_BRANCH_NAME' (git: $GITHUB_REF_NAME, $LANG)..."
-          if [ "$LANG" = "java" ]; then
-            # baselineOnMigrate + baselineVersion=0 because Lakebase's
-            # `public` schema is always non-empty (system catalogs); Flyway 9+
-            # otherwise aborts with NON_EMPTY_SCHEMA_WITHOUT_SCHEMA_HISTORY_TABLE.
-            # Long-term: FEIP-7096 will route this through substrate's
-            # lakebase-migrate CLI so the flag handling lives in ONE place.
-            if ! ./mvnw -q flyway:migrate -Dflyway.url="$SPRING_DATASOURCE_URL" -Dflyway.user="${SPRING_DATASOURCE_USERNAME:-}" -Dflyway.password="${SPRING_DATASOURCE_PASSWORD:-}" -Dflyway.baselineOnMigrate=true -Dflyway.baselineVersion=0; then
-              echo "::error::Flyway migrate failed."
-              exit 1
-            fi
-          elif [ "$LANG" = "python" ]; then
-            if ! uv run alembic upgrade head; then
-              echo "::error::Alembic upgrade failed."
-              exit 1
-            fi
-          elif [ "$LANG" = "nodejs" ]; then
-            if ! npx knex migrate:latest; then
-              echo "::error::Knex migrate failed."
-              exit 1
-            fi
-          fi
+          echo "Routing migrations through the substrate's lakebase-migrate CLI"
+          echo "  kit version: {{LAKEBASE_KIT_VERSION}}"
+          echo "  instance:    $LAKEBASE_PROJECT_ID"
+          echo "  branch:      $LAKEBASE_BRANCH_NAME"
+          echo "  git ref:     $GITHUB_REF_NAME"
+          npx --yes --package=github:databricks-solutions/lakebase-app-dev-kit#v{{LAKEBASE_KIT_VERSION}} \
+            lakebase-migrate apply \
+            --instance "$LAKEBASE_PROJECT_ID" \
+            --branch "$LAKEBASE_BRANCH_NAME" \
+            --pretty
+          echo "Migrations completed."
 
       - name: Clean up or preserve snapshot
         if: always()
         env:
+          # Same v1 CLI cache trap as the substrate-routed steps: this
+          # step calls `databricks postgres list-branches` + `delete-branch`,
+          # which on CLI v1+ refuse the pre-v1 credential cache without
+          # DATABRICKS_AUTH_TYPE=pat pinning auth to DATABRICKS_TOKEN.
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          DATABRICKS_AUTH_TYPE: pat
           LAKEBASE_PROJECT_ID: ${{ secrets.LAKEBASE_PROJECT_ID }}
         run: |
           if [ -z "${SNAPSHOT_NAME}" ]; then

--- a/tests/bdd/scaffold.test.ts
+++ b/tests/bdd/scaffold.test.ts
@@ -217,6 +217,66 @@ describe("deployWorkflows: {{LAKEBASE_KIT_VERSION}} substitution", () => {
     expect(prYml).toMatch(/FLYWAY_BASE="\$\{FLYWAY_DOWNLOAD_BASE_URL:-https:\/\/repo1\.maven\.org\/maven2\}"/);
   });
 
+  it("scaffolded merge.yml substitutes the kit version and substrate-routes its migrate + snapshot steps", async () => {
+    // FEIP-7096 PR3: same substrate-routing pattern as pr.yml, applied
+    // to merge.yml's migrate-target job. Locks down all four lessons
+    // learned during the ecom + python-devloop integration loop:
+    //   - kit version substitution at scaffold time
+    //   - migrations route through `lakebase-migrate apply`
+    //   - snapshot routes through `lakebase-cut-backup`
+    //   - Flyway-install detects existing binary + supports proxy
+    //   - migrate + snapshot + cleanup pass DATABRICKS_AUTH_TYPE=pat
+    const dir = mkTmp();
+    await deployWorkflows(dir);
+    const mergeYml = fs.readFileSync(path.join(dir, ".github", "workflows", "merge.yml"), "utf-8");
+    const kitPkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf-8"),
+    ) as { version: string };
+
+    // Substitution leaves no placeholder behind.
+    expect(mergeYml).not.toContain("{{LAKEBASE_KIT_VERSION}}");
+    expect(mergeYml).toContain(`#v${kitPkg.version}`);
+
+    // Substrate routing for migrations (replaces the language-branched
+    // mvnw/uv-run/npx-knex block).
+    expect(mergeYml).toMatch(/lakebase-migrate apply/);
+    expect(mergeYml).not.toMatch(/\.\/mvnw -q flyway:migrate/);
+    expect(mergeYml).not.toMatch(/uv run alembic upgrade head/);
+    expect(mergeYml).not.toMatch(/npx knex migrate:latest/);
+
+    // Substrate routing for the pre-migration snapshot (cut-backup CLI).
+    expect(mergeYml).toMatch(/lakebase-cut-backup/);
+    expect(mergeYml).toMatch(/--source "\$DEFAULT_NAME"/);
+    expect(mergeYml).toMatch(/--name "\$SNAPSHOT_NAME"/);
+    // The old inline `databricks postgres create-branch ... --json {...}`
+    // invocation MUST be gone from the snapshot step body. (The string
+    // may still appear inside a comment explaining the substrate's
+    // internals - we narrow this to the actual invocation shape.)
+    expect(mergeYml).not.toMatch(/^\s*databricks postgres create-branch\s/m);
+
+    // Flyway-install step has the PATH-detection + base URL override.
+    expect(mergeYml).toMatch(/command -v flyway >\/dev\/null 2>&1/);
+    expect(mergeYml).toMatch(/FLYWAY_DOWNLOAD_BASE_URL:\s*\$\{\{\s*vars\.FLYWAY_DOWNLOAD_BASE_URL\s*\}\}/);
+
+    // Each substrate-routed step (snapshot, migrate, cleanup) must
+    // pass DATABRICKS_AUTH_TYPE=pat alongside the token, or the v1+
+    // databricks CLI hits the credential-cache rejection.
+    const stepNames = [
+      "Create pre-migration snapshot",
+      "Run migrations \\(target\\)",
+      "Clean up or preserve snapshot",
+    ];
+    for (const stepName of stepNames) {
+      const re = new RegExp(`- name: ${stepName}[\\s\\S]*?(?=\\n\\s*- name:|\\Z)`);
+      const m = mergeYml.match(re);
+      expect(m, `${stepName} step not found in merge.yml`).toBeTruthy();
+      const block = m![0];
+      expect(block).toMatch(/DATABRICKS_HOST:\s*\$\{\{\s*secrets\.DATABRICKS_HOST\s*\}\}/);
+      expect(block).toMatch(/DATABRICKS_TOKEN:\s*\$\{\{\s*secrets\.DATABRICKS_TOKEN\s*\}\}/);
+      expect(block).toMatch(/DATABRICKS_AUTH_TYPE:\s*pat/);
+    }
+  });
+
   it("falls back to 'unknown' when templatesDir points at a tree without a package.json", async () => {
     // Build a minimal fixture: tmpRoot has only `templates/project/common/.github/workflows/`,
     // no package.json at tmpRoot. kitVersion() resolves via path.dirname twice,


### PR DESCRIPTION
## Summary

Final PR of FEIP-7096: apply the substrate-routing pattern that PR2 (#14) introduced for `pr.yml` to `merge.yml`'s promotion-target job.

- **Run migrations (target)** → substrate `lakebase-migrate apply --instance --branch`. Drops the language-branched mvnw/uv-run/npx-knex block.
- **Create pre-migration snapshot** → substrate `lakebase-cut-backup --source --name`. Drops the inline `databricks postgres create-branch ... --json {ttl}` invocation.
- **Install Flyway CLI** → PATH detection + `FLYWAY_DOWNLOAD_BASE_URL` env override (mirrors #15).
- **Snapshot + migrate + cleanup step envs** → `DATABRICKS_TOKEN` + `DATABRICKS_AUTH_TYPE=pat` from secrets directly (mirrors #16; v1+ CLI rejects the pre-v1 credential cache without the auth-type pin).

## Follow-up (not in this PR)

"Clean up or preserve snapshot" still uses `databricks postgres list-branches` + `delete-branch` directly — there's no `lakebase-delete-backup` primitive yet. Behavior is unchanged from pre-PR3. Listed as a follow-up under FEIP-7096.

## Test plan

- [x] `npx vitest run tests/bdd/scaffold.test.ts tests/bdd/alembic-runner.test.ts tests/bdd/cut-backup.test.ts` (29/29 + 1 skipped)
- [ ] After merge + tag v0.3.0-alpha.5, bump extension and run integration suites (ecom merge-flow + python-devloop merge-flow).

This pull request and its description were written by Isaac.