### PR TITLE
merge.yml: skip migrate-target on initial branch-creation push (alpha.14 / FEIP-7100)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.13",
+  "version": "0.3.0-alpha.14",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/templates/project/common/.github/workflows/merge.yml
+++ b/templates/project/common/.github/workflows/merge.yml
@@ -34,7 +34,19 @@ permissions:
 jobs:
   migrate-target:
     runs-on: self-hosted
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
+    # Skip the initial branch-creation push. github.event.before is the
+    # all-zeros SHA when a ref is being created for the first time (the
+    # scaffold's initial commit being pushed to main; the first cut of
+    # staging via createLongRunningBranch; etc.). On those pushes, the
+    # project tree has only the V1 placeholder migration which is
+    # already present on the Lakebase default branch, so migrate-target
+    # has nothing to apply - and trying to run it (a) wastes a runner
+    # slot for 1-2 minutes per migrate-target invocation that's a no-op,
+    # and (b) the orphaned in-progress run on a fresh project can block
+    # the runner queue for subsequent real promotion merges. Any
+    # real merge to main/staging (PR-merge or direct push) has
+    # before != 0000... and runs normally.
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') && github.event.before != '0000000000000000000000000000000000000000'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Closes FEIP-7100. Adds `github.event.before != '0000000000000000000000000000000000000000'` to merge.yml's migrate-target job-level `if:`. GitHub puts the all-zeros sentinel in `before` when a ref is being created for the first time — the scaffold's initial commit being pushed to main, the first cut of staging via `createLongRunningBranch`, etc. On those pushes the project tree only carries the V1 placeholder migration which is already present on the Lakebase default branch, so migrate-target has nothing to apply.

## Why it matters

Observed in the ecom integration test: every fresh project burned a runner slot 1-2 minutes for a no-op migrate-target invocation on the initial main push. Worse, when that no-op invocation hung (observed at "Set up JDK (local)" — root cause separate), the orphaned in-progress run blocked subsequent merge.yml dispatches on main, masking real promotion merges. After this fix, no-op no-runs.

## Discriminator is precise

| Scenario | `before` | `if:` evaluates |
|---|---|---|
| Initial scaffold push to main | `0000...` | **skipped** ✓ |
| First cut of staging | `0000...` | **skipped** ✓ |
| Step E1 merge (staging → main) | prior main HEAD | runs ✓ |
| Feature merge to staging | prior staging HEAD | runs ✓ |
| Direct push to main/staging | prior HEAD | runs ✓ |
| Force-push to main | prior HEAD | runs ✓ |

## Test plan

- [x] YAML validates (`python3 -c 'import yaml; yaml.safe_load(open(...))'`)
- [ ] Next ecom integration run: confirm the initial scaffold push to main produces zero merge.yml runs, the initial cut of staging produces zero merge.yml runs, and Step E1/E2 still trigger migrate-target normally

This pull request and its description were written by Isaac.