### PR TITLE
post-checkout: auto-derive trunk from origin/HEAD; drop LAKEBASE_TRUNK_BRANCH env (alpha.15 / FEIP-7105)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.14",
+  "version": "0.3.0-alpha.15",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/templates/project/common/.env.example
+++ b/templates/project/common/.env.example
@@ -4,12 +4,6 @@
 DATABRICKS_HOST=
 LAKEBASE_PROJECT_ID=
 
-# Optional: git branch that should behave like main/master for this project
-# (when not on a default-named branch). Set if your repo uses a prefixed
-# trunk branch — common in shared-monorepo conventions where each project's
-# production branch is e.g. `team-alpha/project-foo`.
-# LAKEBASE_TRUNK_BRANCH=
-
 # Long-running tiers (staging, uat, perf, ...) are auto-discovered from the
 # Lakebase branch list: a git checkout to a branch whose name matches an
 # existing Lakebase branch is treated as a tier checkout. The architect

--- a/templates/project/common/scripts/post-checkout.sh
+++ b/templates/project/common/scripts/post-checkout.sh
@@ -39,7 +39,7 @@ fi
 # on what's in the project .env. Otherwise a user who sourced an activation
 # script earlier in the shell would leak LAKEBASE_PROJECT_ID into every
 # git checkout in unrelated repos and create spurious branches.
-unset LAKEBASE_PROJECT_ID LAKEBASE_TRUNK_BRANCH \
+unset LAKEBASE_PROJECT_ID \
       LAKEBASE_BASE_BRANCH LAKEBASE_HOST LAKEBASE_BRANCH_ID \
       DATABRICKS_CONFIG_PROFILE DATABRICKS_HOST DATABASE_URL \
       DB_USERNAME DB_PASSWORD
@@ -63,13 +63,16 @@ if [ -z "$PROJ_ID" ]; then
   exit 0
 fi
 
-# Optional: treat a non-standard git branch like main/master – common in
-# shared-monorepo conventions where the trunk is e.g. `team-alpha/project-foo`
-# rather than `main`. This only covers the special case where the Lakebase
-# DEFAULT branch's name (e.g. `production`) differs from the git trunk name.
-# Other long-running tiers (staging, uat, perf, ...) are auto-discovered
-# below from the Lakebase branch list – no per-tier env var needed.
-TRUNK_ALIAS="${LAKEBASE_TRUNK_BRANCH:-}"
+# Auto-discover the git trunk branch from `origin/HEAD` so a non-`main`
+# trunk (e.g. `release/v3` in some shared-monorepo conventions) doesn't
+# need a per-project env var. `git clone` sets refs/remotes/origin/HEAD
+# to the remote's default branch; that's the authoritative answer for
+# "what's this repo's trunk." If origin/HEAD isn't set (rare; some
+# self-hosted CI clones strip it), TRUNK_ALIAS stays empty and the
+# fallback below treats `main`/`master` as trunk. Other long-running
+# tiers (staging, uat, perf, ...) are auto-discovered later from the
+# Lakebase branch list - no per-tier env var needed.
+TRUNK_ALIAS="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')"
 
 if ! command -v databricks >/dev/null 2>&1; then
   echo "Lakebase: databricks CLI not found. Install and run 'databricks auth login'."
@@ -219,8 +222,10 @@ TIER_BRANCH_NAMES="$(echo "$BRANCH_LIST_JSON" \
 
 # --- Trunk path: git trunk → Lakebase default ---
 # Special-cased because the Lakebase default branch's name (e.g. `production`)
-# may differ from the git trunk name (`main`). LAKEBASE_TRUNK_BRANCH lets the
-# architect declare a non-`main` git trunk (e.g. `release/v3`).
+# may differ from the git trunk name (`main`). TRUNK_ALIAS is auto-derived
+# from `origin/HEAD` above and naturally handles non-`main` trunks like
+# `release/v3`. The `[ -z "$TRUNK_ALIAS" ]` arm is the fallback for clones
+# where origin/HEAD wasn't set.
 if { [ -n "$TRUNK_ALIAS" ] && [ "$BRANCH" = "$TRUNK_ALIAS" ]; } \
    || { [ -z "$TRUNK_ALIAS" ] && { [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; }; }; then
   echo "Lakebase: on $BRANCH, connecting to default Lakebase branch ($DEFAULT_BRANCH_UID)..."


### PR DESCRIPTION
Closes FEIP-7105. Completes the tier-autodiscovery story.

## Change

Replaces env-sourced trunk alias with:
```bash
TRUNK_ALIAS="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')"
```

`git clone` sets `refs/remotes/origin/HEAD` to the remote's default branch — authoritative answer for "what's this repo's git trunk?" without any per-project configuration. Non-`main` trunks (e.g. `release/v3`) are picked up naturally.

Removes `LAKEBASE_TRUNK_BRANCH` from `.env.example` + the hook's unset list. Fallback chain in the trunk-path conditional stays the same: `TRUNK_ALIAS` (auto) → `main` → `master`.

## Out of scope

Substrate `paired-branch.ts` and extension UI's `trunkAlias` references aren't touched here — they're FEIP-7098's scope (the broader post-alpha.9 auto-discovery migration for the UI side).

## Test plan

- [x] YAML/shell syntax valid (`bash -n` passes)
- [x] Substrate `npm run build` clean
- [ ] Next ecom integration run: confirm trunk-path detection works on a fresh project (origin/HEAD is set to `main` by `gh repo create`'s clone, hook's trunk path fires on `git checkout main`)

This pull request and its description were written by Isaac.