### PR TITLE
Fix helper-script discovery in post-merge.sh + pre-push.sh

### DIFF
--- a/templates/project/common/scripts/post-merge.sh
+++ b/templates/project/common/scripts/post-merge.sh
@@ -7,9 +7,14 @@
 # Install: ./scripts/install-hook.sh
 
 set -e
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Resolve the repo root via git, not via BASH_SOURCE/.., so this works both
+# when invoked directly from scripts/ (as during local testing) and when
+# installed at .git/hooks/post-merge by installHooks (as in production).
+# The BASH_SOURCE/.. heuristic resolves to .git/ in the installed case,
+# which made every helper-script lookup below fail silently.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
+HELPERS_DIR="$REPO_ROOT/scripts"
 
 # Only run on main branch
 BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
@@ -32,9 +37,9 @@ if [ -n "$PR_NUM" ] || [ -n "$FEATURE_BRANCH" ]; then
   ARGS=""
   [ -n "$PR_NUM" ] && ARGS="ci-pr-${PR_NUM}"
   [ -n "$FEATURE_BRANCH" ] && ARGS="${ARGS:+$ARGS }${FEATURE_BRANCH}"
-  if [ -n "$ARGS" ] && [ -x "$SCRIPT_DIR/delete-lakebase-branches.sh" ]; then
+  if [ -n "$ARGS" ] && [ -x "$HELPERS_DIR/delete-lakebase-branches.sh" ]; then
     echo "Post-merge: cleaning up Lakebase branches: $ARGS"
-    "$SCRIPT_DIR/delete-lakebase-branches.sh" $ARGS 2>/dev/null || true
+    "$HELPERS_DIR/delete-lakebase-branches.sh" $ARGS 2>/dev/null || true
   fi
 fi
 

--- a/templates/project/common/scripts/pre-push.sh
+++ b/templates/project/common/scripts/pre-push.sh
@@ -7,9 +7,13 @@
 # Install: ./scripts/install-hook.sh
 
 set -e
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Resolve the repo root via git, not via BASH_SOURCE/.., so this works both
+# when invoked directly from scripts/ and when installed at .git/hooks/pre-push
+# by installHooks. The BASH_SOURCE/.. heuristic resolves to .git/ in the
+# installed case, which made set-repo-secrets.sh lookup fail silently.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
+HELPERS_DIR="$REPO_ROOT/scripts"
 
 if [ -f .env ]; then
   set -a
@@ -38,7 +42,7 @@ fi
 
 # Sync secrets to GitHub (DATABRICKS_HOST, DATABRICKS_TOKEN, LAKEBASE_PROJECT_ID)
 if [ -n "${DATABRICKS_HOST:-}" ] && [ -n "${LAKEBASE_PROJECT_ID:-}" ] && [ -n "${DATABRICKS_TOKEN:-}" ]; then
-  if "$SCRIPT_DIR/set-repo-secrets.sh" 2>/dev/null; then
+  if "$HELPERS_DIR/set-repo-secrets.sh" 2>/dev/null; then
     echo "Pre-push: repository secrets synced."
   fi
   # If set-repo-secrets fails (e.g. no gh), push continues anyway


### PR DESCRIPTION
## Summary

`post-merge.sh` and `pre-push.sh` looked for their helpers (`delete-lakebase-branches.sh`, `set-repo-secrets.sh`) at `$(dirname BASH_SOURCE)/../delete-lakebase-branches.sh` etc. That resolves to `<repo>/scripts/...` when invoked from `scripts/` directly, but resolves to `.git/<helper>` when the hook lives at `.git/hooks/<name>` (which is exactly where `installHooks` puts it).

Result: the production install path silently exits without doing the Lakebase cleanup (post-merge) or the secret sync (pre-push). The hooks fire, log entry happens, but the helper invocation `[ -x "$SCRIPT_DIR/helper" ]` test fails and the branch is skipped.

Fix: switch to `git rev-parse --show-toplevel` (same pattern `post-checkout.sh` already uses) and look for helpers in `<repo>/scripts/` where `deployScripts` puts them. No behavior change when invoked from `scripts/`; the installed path now actually finds the helpers.

## Test plan

- [x] Surfaced by FEIP-7102 small-repro postMerge test (`test/integration/hook/postMerge.test.ts` in lakebase-scm-extension). Pre-fix run: hook fires, Lakebase branches not deleted, AssertionError. Post-fix: re-running once this PR + extension substrate-pin land.
- [ ] Re-run the FEIP-7102 postMerge + prePush small repros (both affected) against the fixed substrate.
- [ ] No version bump in this PR per maintainer direction; bundle into the next alpha bump.

This pull request and its description were written by Isaac.