### PR TITLE
Bump version to 0.3.0-alpha.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.15",
+  "version": "0.3.0-alpha.16",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,


### PR DESCRIPTION
Bumps version to capture PR #22 (helper-discovery) + PR #23 / FEIP-7116 (gh-based FEATURE_BRANCH). Consumed by lakebase-scm-extension FEIP-7102 small repros.