### PR TITLE
Bump version to 0.3.0-alpha.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.16",
+  "version": "0.3.0-alpha.17",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,


### PR DESCRIPTION
Captures PR #25 (FEIP-7121: patchWorkflowsForRunnerType swaps runs-on for github-hosted). Required by FEIP-7104 small repro.