### PR TITLE
[FEIP-7114] Parameterize no_expiry on CreateBranchArgs

### DIFF
--- a/scripts/lakebase/branch-create.ts
+++ b/scripts/lakebase/branch-create.ts
@@ -45,6 +45,16 @@ export interface CreateBranchArgs extends BranchLookupOpts {
   readyTimeoutMs?: number;
   /** Poll interval in milliseconds. Default 5_000. */
   pollIntervalMs?: number;
+  /**
+   * If true, the spec sets `no_expiry: true` so Lakebase never auto-deletes
+   * the branch. Use for permanent branches: long-running tiers
+   * (`createLongRunningBranch` passes this) and release-time backups
+   * (`cutBackup` passes this). Default is to omit `no_expiry` from the
+   * spec so Lakebase applies its own default expiry – which is the right
+   * safety net for ephemeral feature / ci-pr branches: if the post-merge
+   * cleanup hook misses them, they still age out on their own.
+   */
+  noExpiry?: boolean;
 }
 
 /**
@@ -100,7 +110,11 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
     return existing;
   }
 
-  const spec = JSON.stringify({ spec: { source_branch: sourceBranchPath, no_expiry: true } });
+  const specObj: { source_branch: string; no_expiry?: boolean } = { source_branch: sourceBranchPath };
+  if (args.noExpiry) {
+    specObj.no_expiry = true;
+  }
+  const spec = JSON.stringify({ spec: specObj });
   await dbcli(
     ["postgres", "create-branch", projectPath(args.instance), sanitized, "--json", spec],
     args.host

--- a/scripts/lakebase/cut-backup.ts
+++ b/scripts/lakebase/cut-backup.ts
@@ -54,6 +54,11 @@ export async function cutBackup(args: CutBackupArgs): Promise<CutBackupResult> {
     parentBranch: args.sourceBranch,
     readyTimeoutMs: args.readyTimeoutMs,
     pollIntervalMs: args.pollIntervalMs,
+    // Backups must outlive any ephemeral-branch expiration so the
+    // rollback contract holds: if Lakebase auto-expired a backup
+    // before the operator decided to roll back, the release flow
+    // would have nothing to restore to.
+    noExpiry: true,
   });
   return {
     backup,

--- a/scripts/lakebase/long-running-branch.ts
+++ b/scripts/lakebase/long-running-branch.ts
@@ -69,6 +69,10 @@ export async function createLongRunningBranch(
   const created = await createLakebaseBranch({
     instance: args.projectId,
     branch: args.name,
+    // Long-running tiers (staging, uat, perf, ...) are permanent by
+    // definition; without this they'd inherit Lakebase's default
+    // expiry and silently disappear.
+    noExpiry: true,
   });
 
   // Git side: build the new tier off `forkFromBranch` on the remote.


### PR DESCRIPTION
Adds noExpiry?: boolean to CreateBranchArgs (default omitted). cutBackup + createLongRunningBranch opt in. Paired feature/ci-pr branches now inherit Lakebase default expiry as auto-cleanup safety net. See commit message for the rationale + audit.

This pull request and its description were written by Isaac.