### PR TITLE
Bump version to 0.3.0-alpha.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.17",
+  "version": "0.3.0-alpha.18",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,


### PR DESCRIPTION
Captures PR #27 (FEIP-7114 no_expiry parameterization) + PR #28 (FEIP-7113 vendor devhub skills + multi-skill installer).