### PR TITLE
[substrate] v0.3.0-alpha.19 – default no_expiry + gitignore overlay after Initializr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.0",
+  "version": "0.3.0-alpha.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.0",
+      "version": "0.3.0-alpha.18",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",
@@ -21,17 +21,21 @@
       },
       "bin": {
         "lakebase-create-project": "dist/scripts/lakebase/create-project.cli.js",
+        "lakebase-cut-backup": "dist/scripts/lakebase/cut-backup.cli.js",
         "lakebase-get-connection": "dist/scripts/lakebase/get-connection.cli.js",
         "lakebase-github-token": "dist/scripts/github/auth.cli.js",
         "lakebase-mcp-server": "dist/apps/mcp-server/index.js",
+        "lakebase-migrate": "dist/scripts/lakebase/migrate.cli.js",
         "lakebase-schema-diff": "dist/scripts/lakebase/schema-diff.cli.js"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@types/adm-zip": "^0.5.7",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.10.0",
         "@types/pg": "^8.20.0",
         "@types/tar": "^6.1.13",
+        "js-yaml": "^4.1.1",
         "tsup": "^8.5.1",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
@@ -4316,6 +4320,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
       "resolved": "https://npm-proxy.dev.databricks.com/@types/memcached/-/memcached-2.2.10.tgz",
@@ -5885,7 +5896,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "resolved": "https://npm-proxy.dev.databricks.com/js-yaml/-/js-yaml-4.1.1.tgz",
+      "resolved": "https://npm-proxy.cloud.databricks.com/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.18",
+  "version": "0.3.0-alpha.19",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,
@@ -103,9 +103,11 @@
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@types/adm-zip": "^0.5.7",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.10.0",
     "@types/pg": "^8.20.0",
     "@types/tar": "^6.1.13",
+    "js-yaml": "^4.1.1",
     "tsup": "^8.5.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",

--- a/scripts/lakebase/branch-create.ts
+++ b/scripts/lakebase/branch-create.ts
@@ -46,13 +46,17 @@ export interface CreateBranchArgs extends BranchLookupOpts {
   /** Poll interval in milliseconds. Default 5_000. */
   pollIntervalMs?: number;
   /**
-   * If true, the spec sets `no_expiry: true` so Lakebase never auto-deletes
-   * the branch. Use for permanent branches: long-running tiers
-   * (`createLongRunningBranch` passes this) and release-time backups
-   * (`cutBackup` passes this). Default is to omit `no_expiry` from the
-   * spec so Lakebase applies its own default expiry – which is the right
-   * safety net for ephemeral feature / ci-pr branches: if the post-merge
-   * cleanup hook misses them, they still age out on their own.
+   * If true (default), the spec sets `no_expiry: true` so Lakebase never
+   * auto-deletes the branch. Lakebase's API requires one of expire_time /
+   * ttl / no_expiry to be set on every create-branch call; omitting all
+   * three is rejected. We default to `no_expiry: true` because that is the
+   * only expiration policy the canonical Lakebase CLI surface (devhub
+   * `databricks-lakebase` skill) currently documents. Callers that want a
+   * different expiry can pass `noExpiry: false` along with an explicit
+   * spec override path (today substrate does not expose ttl or expire_time
+   * directly; raise the limitation in a substrate ticket when needed).
+   * Orphan-cleanup falls to the post-merge hook + cleanup-cli for
+   * ephemeral feature / ci-pr branches.
    */
   noExpiry?: boolean;
 }
@@ -110,8 +114,9 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
     return existing;
   }
 
+  const noExpiry = args.noExpiry ?? true;
   const specObj: { source_branch: string; no_expiry?: boolean } = { source_branch: sourceBranchPath };
-  if (args.noExpiry) {
+  if (noExpiry) {
     specObj.no_expiry = true;
   }
   const spec = JSON.stringify({ spec: specObj });

--- a/scripts/lakebase/scaffold.ts
+++ b/scripts/lakebase/scaffold.ts
@@ -428,5 +428,15 @@ export async function scaffoldAll(args: ScaffoldAllArgs): Promise<ScaffoldStatic
     report,
   });
 
+  // Spring Initializr's starter zip ships its own .gitignore (generic JVM
+  // entries: target/, *.class, .idea/). Extracting that zip into the
+  // scaffold target overwrites the substrate-curated .gitignore that
+  // scaffoldStaticAll just wrote (which includes .env, .tmp/, etc.).
+  // Without re-applying substrate's .gitignore here, the next `git add`
+  // tracks .env, leaking credentials into history. Re-apply is idempotent;
+  // substrate's java/.gitignore.extra already covers the JVM entries
+  // Initializr would have contributed.
+  await deployGitignore(args.targetDir, language, { templatesDir: args.templatesDir });
+
   return staticResult;
 }

--- a/tests/bdd/scaffold.test.ts
+++ b/tests/bdd/scaffold.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+
+// installHooks calls `git config --local`, which requires an actual git
+// repo (not just a bare `.git/` directory). Tests that exercise installHooks
+// or scaffoldStaticAll (which calls it) must initialise a real repo first.
+function gitInit(dir: string): void {
+  execSync("git init -q", { cwd: dir, stdio: "pipe" });
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import {
@@ -309,7 +317,7 @@ describe("installHooks", () => {
 
   it("installs hook files into .git/hooks/ when scripts present", async () => {
     const dir = mkTmp();
-    fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+    gitInit(dir);
     await deployScripts(dir);
     const summary = await installHooks(dir);
     expect(summary).toMatch(/Installed hooks/);
@@ -321,13 +329,18 @@ describe("installHooks", () => {
 });
 
 describe("patchWorkflowsForRunnerType", () => {
-  it("is a no-op for github-hosted", async () => {
+  // Templates ship with `runs-on: self-hosted` (per FEIP-7121). The patch
+  // function rewrites `runs-on: self-hosted` -> `runs-on: ubuntu-latest`
+  // for github-hosted, and swaps the setup-java block for self-hosted.
+  it("swaps runs-on to ubuntu-latest for github-hosted", async () => {
     const dir = mkTmp();
     await deployWorkflows(dir);
     const before = fs.readFileSync(path.join(dir, ".github", "workflows", "pr.yml"), "utf-8");
+    expect(before).toMatch(/runs-on: self-hosted/);
     await patchWorkflowsForRunnerType(dir, "github-hosted");
     const after = fs.readFileSync(path.join(dir, ".github", "workflows", "pr.yml"), "utf-8");
-    expect(after).toBe(before);
+    expect(after).not.toMatch(/runs-on: self-hosted/);
+    expect(after).toMatch(/runs-on: ubuntu-latest/);
   });
 
   it("swaps setup-java for self-hosted and leaves mvnw calls online", async () => {
@@ -355,7 +368,7 @@ describe("patchWorkflowsForRunnerType", () => {
 describe("scaffoldStaticAll orchestrator", () => {
   it("populates a fresh dir end-to-end (with .git/)", async () => {
     const dir = mkTmp();
-    fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+    gitInit(dir);
     const reports: string[] = [];
     const result = await scaffoldStaticAll({
       targetDir: dir,


### PR DESCRIPTION
## Summary

- **branch-create**: default `no_expiry: true` when caller omits the arg. Lakebase API now rejects create-branch calls that don't set one of expire_time/ttl/no_expiry; the prior "rely on Lakebase default expiry" contract is gone. Matches devhub `databricks-lakebase` skill's documented pattern.
- **scaffold**: re-apply `deployGitignore` in `scaffoldAll` AFTER the language project deploy. Spring Initializr's starter zip overwrites substrate's curated `.gitignore` (which lists `.env`), causing scaffolded Java/Kotlin projects to commit `.env` on first push.

Two production fixes surfaced by lakebase-scm-extension's phase-2 integration suite — FEIP-7112's silent-host-fallback cleanup made these visible by routing tests at contributor-chosen workspaces instead of the maintainer's.

## Pre-existing fixes bundled

- `installHooks` tests faked `.git/` with `mkdirSync`; substrate's `git config --local` needs a real repo. Switched fixtures to `git init`.
- `patchWorkflowsForRunnerType` "no-op for github-hosted" assumed pre-FEIP-7121 template default (`ubuntu-latest`); templates now ship `self-hosted`, so github-hosted IS the patch path. Test rewritten.
- `@types/js-yaml` + `js-yaml` declared as devDeps for `workflow-databricks-auth.test`.

## Test plan

- [x] `npm test` — 228 passing, 33 skipped, 0 failing
- [x] `npm run typecheck` — clean
- [ ] Extension `lakebase-scm-extension` pinned to alpha.19 tag after merge
- [ ] Phase-2 integration suite re-runs against alpha.19 (post-merge) at `fevm-serverless-stable-ecparr`

This pull request and its description were written by Isaac.