### PR TITLE
[FEIP-7131] Husky pre-push gate (typecheck + npm test)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# OSS-friendly pre-push gate: runs typecheck + hermetic test before allowing
+# push. Travels with every fork (committed to repo). GitHub Actions is
+# disabled at the databricks-solutions org level (see FEIP-7137), so this
+# hook is the only automated gate today; once Actions is enabled, the
+# existing ci.yml provides the server-side equivalent.
+#
+# Escape hatch: HUSKY=0 git push   (skips this hook entirely)
+# Use only when the gate is broken / not when the gate is correctly red.
+
+set -e
+
+echo "→ husky/pre-push: typecheck"
+npm run typecheck
+
+echo "→ husky/pre-push: test (hermetic)"
+npm test
+
+echo "✓ husky/pre-push: pass"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.18",
+  "version": "0.3.0-alpha.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.18",
+      "version": "0.3.0-alpha.19",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",
@@ -35,6 +35,7 @@
         "@types/node": "^22.10.0",
         "@types/pg": "^8.20.0",
         "@types/tar": "^6.1.13",
+        "husky": "^9.1.7",
         "js-yaml": "^4.1.1",
         "tsup": "^8.5.1",
         "tsx": "^4.19.0",
@@ -5780,6 +5781,22 @@
       "resolved": "https://npm-proxy.dev.databricks.com/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://npm-proxy.cloud.databricks.com/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "prepare": "npm run build",
+    "prepare": "npm run build && husky",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -107,6 +107,7 @@
     "@types/node": "^22.10.0",
     "@types/pg": "^8.20.0",
     "@types/tar": "^6.1.13",
+    "husky": "^9.1.7",
     "js-yaml": "^4.1.1",
     "tsup": "^8.5.1",
     "tsx": "^4.19.0",


### PR DESCRIPTION
## Summary

OSS-friendly portable replacement for the never-executed ci.yml: Husky pre-push hook committed to the repo, auto-installs via `prepare` on `npm install`, runs `npm run typecheck && npm test` (228 hermetic tests in ~9s) before allowing push.

## Why not ci.yml?

GitHub Actions is disabled at the databricks-solutions org level (FEIP-7137). Substrate's existing `.github/workflows/ci.yml` has never executed — `gh run list` returns empty for this repo. Until org policy flips, Husky is the only gate that actually runs.

## Properties

- **Portable**: hook config is in the repo, travels with every fork
- **No infra dependency**: works in any clone
- **Belt + suspenders**: when FEIP-7137 lands, the existing ci.yml runs server-side too
- **Escape hatch**: `HUSKY=0 git push` for emergencies (document separately)

## Test plan

- [x] `sh .husky/pre-push` smoke (228 passing in ~9s)
- [ ] Smoke-test after merge: clone fresh, `npm install`, verify `.husky/_/` activates
- [ ] Sister PR on lakebase-scm-extension (in FEIP-7112 PR #19) adds the same pattern

This pull request and its description were written by Isaac.