### PR TITLE
[FEIP-7095] Branch convention helpers + ttl support in createBranch

### DIFF
--- a/scripts/lakebase/branch-create.ts
+++ b/scripts/lakebase/branch-create.ts
@@ -46,19 +46,22 @@ export interface CreateBranchArgs extends BranchLookupOpts {
   /** Poll interval in milliseconds. Default 5_000. */
   pollIntervalMs?: number;
   /**
-   * If true (default), the spec sets `no_expiry: true` so Lakebase never
-   * auto-deletes the branch. Lakebase's API requires one of expire_time /
-   * ttl / no_expiry to be set on every create-branch call; omitting all
-   * three is rejected. We default to `no_expiry: true` because that is the
-   * only expiration policy the canonical Lakebase CLI surface (devhub
-   * `databricks-lakebase` skill) currently documents. Callers that want a
-   * different expiry can pass `noExpiry: false` along with an explicit
-   * spec override path (today substrate does not expose ttl or expire_time
-   * directly; raise the limitation in a substrate ticket when needed).
-   * Orphan-cleanup falls to the post-merge hook + cleanup-cli for
-   * ephemeral feature / ci-pr branches.
+   * If true, the spec sets `no_expiry: true` so Lakebase never auto-deletes
+   * the branch. Lakebase's API requires one of expire_time / ttl /
+   * no_expiry to be set on every create-branch call; omitting all three is
+   * rejected. Default behavior: no_expiry: true if `ttl` is also unset;
+   * if `ttl` is set, that wins and noExpiry must be omitted or false.
+   * Mutually exclusive with `ttl`.
    */
   noExpiry?: boolean;
+  /**
+   * Lakebase-format TTL string ("<seconds>s", e.g. "604800s" = 7 days). When
+   * set, Lakebase auto-deletes the branch after this duration relative to
+   * create_time. Use for finite-lifetime workflow tiers (feature / test /
+   * uat / perf). Mutually exclusive with `noExpiry: true`. Format is the
+   * protobuf Duration JSON encoding — bare seconds with trailing "s".
+   */
+  ttl?: string;
 }
 
 /**
@@ -114,9 +117,20 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
     return existing;
   }
 
-  const noExpiry = args.noExpiry ?? true;
-  const specObj: { source_branch: string; no_expiry?: boolean } = { source_branch: sourceBranchPath };
-  if (noExpiry) {
+  // Expiration policy: ttl wins if set; otherwise default to no_expiry: true.
+  // Refuse the inconsistent combination (ttl + noExpiry: true both set).
+  if (args.ttl && args.noExpiry === true) {
+    throw new LakebaseBranchError(
+      `Cannot set both ttl ("${args.ttl}") and noExpiry: true on the same ` +
+        `branch — they are mutually exclusive. Pass one or the other.`,
+    );
+  }
+  const specObj: { source_branch: string; no_expiry?: boolean; ttl?: string } = {
+    source_branch: sourceBranchPath,
+  };
+  if (args.ttl) {
+    specObj.ttl = args.ttl;
+  } else if (args.noExpiry ?? true) {
     specObj.no_expiry = true;
   }
   const spec = JSON.stringify({ spec: specObj });

--- a/scripts/lakebase/convention-branches.ts
+++ b/scripts/lakebase/convention-branches.ts
@@ -1,0 +1,107 @@
+/**
+ * Branch convention helpers — `createFeatureBranch / createTestBranch /
+ * createUatBranch / createPerfBranch`.
+ *
+ * The PSA branching methodology (see
+ * skills/lakebase-release-workflows/SKILL.md + references/branching-and-
+ * release-methodology.md) defines four short-tier workflow branch types
+ * that fork from `staging`:
+ *
+ *   prod ── staging ── feature   (active feature dev)
+ *                  ├── test      (integration testing)
+ *                  ├── uat       (user acceptance)
+ *                  └── perf      (performance / load)
+ *
+ * Each is finite-lifetime — tied to a specific dev cycle, not a permanent
+ * tier. So unlike `createLongRunningBranch` (which sets `no_expiry: true`
+ * for the prod/staging tiers), these helpers default to a Lakebase TTL.
+ *
+ * Per-tier TTL defaults (override via `args.ttl`):
+ *   feature: 30 days (typical feature dev cycle)
+ *   test:    14 days
+ *   uat:     14 days
+ *   perf:     7 days
+ *
+ * All four fork from `staging` by default. Callers in non-staging-rooted
+ * projects can override via `parentBranch`.
+ */
+
+import { createBranch as createLakebaseBranch } from "./branch-create.js";
+import { LakebaseBranchInfo, BranchLookupOpts } from "./branch-utils.js";
+
+/** Lakebase TTL format is protobuf Duration JSON: "<seconds>s". */
+const DAY_SECONDS = 86_400;
+const ttlDays = (days: number): string => `${days * DAY_SECONDS}s`;
+
+/** Tier defaults. Exported so tests + future tickets can introspect. */
+export const CONVENTION_TIER_DEFAULTS = {
+  feature: { ttl: ttlDays(30), parentBranch: "staging" },
+  test: { ttl: ttlDays(14), parentBranch: "staging" },
+  uat: { ttl: ttlDays(14), parentBranch: "staging" },
+  perf: { ttl: ttlDays(7), parentBranch: "staging" },
+} as const;
+
+export interface CreateConventionBranchArgs extends BranchLookupOpts {
+  /** Target branch name. Will be sanitized to a Lakebase id. */
+  branch: string;
+  /** Override the parent branch. Defaults to "staging" for all four tiers. */
+  parentBranch?: string;
+  /** Override the TTL. Defaults to the tier's value (see CONVENTION_TIER_DEFAULTS). */
+  ttl?: string;
+}
+
+/**
+ * Cut a feature-tier Lakebase branch off `staging` with a 30-day TTL.
+ * Lakebase deletes the branch automatically when the TTL expires — useful
+ * for feature dev cycles where the branch lives only as long as the work.
+ */
+export async function createFeatureBranch(
+  args: CreateConventionBranchArgs,
+): Promise<LakebaseBranchInfo> {
+  return createLakebaseBranch({
+    instance: args.instance,
+    host: args.host,
+    branch: args.branch,
+    parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.feature.parentBranch,
+    ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.feature.ttl,
+  });
+}
+
+/** Cut a test-tier Lakebase branch off `staging` with a 14-day TTL. */
+export async function createTestBranch(
+  args: CreateConventionBranchArgs,
+): Promise<LakebaseBranchInfo> {
+  return createLakebaseBranch({
+    instance: args.instance,
+    host: args.host,
+    branch: args.branch,
+    parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.test.parentBranch,
+    ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.test.ttl,
+  });
+}
+
+/** Cut a uat-tier Lakebase branch off `staging` with a 14-day TTL. */
+export async function createUatBranch(
+  args: CreateConventionBranchArgs,
+): Promise<LakebaseBranchInfo> {
+  return createLakebaseBranch({
+    instance: args.instance,
+    host: args.host,
+    branch: args.branch,
+    parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.uat.parentBranch,
+    ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.uat.ttl,
+  });
+}
+
+/** Cut a perf-tier Lakebase branch off `staging` with a 7-day TTL. */
+export async function createPerfBranch(
+  args: CreateConventionBranchArgs,
+): Promise<LakebaseBranchInfo> {
+  return createLakebaseBranch({
+    instance: args.instance,
+    host: args.host,
+    branch: args.branch,
+    parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.perf.parentBranch,
+    ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.perf.ttl,
+  });
+}

--- a/scripts/lakebase/index.ts
+++ b/scripts/lakebase/index.ts
@@ -7,6 +7,7 @@
 
 export * from "./branch-create.js";
 export * from "./branch-delete.js";
+export * from "./convention-branches.js";
 export * from "./cut-backup.js";
 export * from "./long-running-branch.js";
 export * from "./release.js";

--- a/tests/bdd/convention-branches.test.ts
+++ b/tests/bdd/convention-branches.test.ts
@@ -1,0 +1,96 @@
+// Hermetic coverage for the convention-branches helpers.
+//
+// Verifies that createFeatureBranch / createTestBranch / createUatBranch /
+// createPerfBranch forward the right parent + TTL into substrate's
+// createBranch — without actually hitting Lakebase. Live behavior is
+// exercised in the workspace-bound branch tests; this test is the contract
+// guard.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCreateBranch = vi.fn();
+
+vi.mock("../../scripts/lakebase/branch-create.js", () => ({
+  createBranch: (...args: unknown[]) => mockCreateBranch(...args),
+}));
+
+// Import after the mock is registered.
+const conv = await import("../../scripts/lakebase/convention-branches.js");
+
+beforeEach(() => {
+  mockCreateBranch.mockReset();
+  mockCreateBranch.mockResolvedValue({
+    name: "projects/p/branches/x",
+    uid: "br-x",
+    state: "READY",
+    isDefault: false,
+  });
+});
+
+describe("convention-branches: default tier values", () => {
+  it("createFeatureBranch defaults parentBranch=staging, ttl=30 days", async () => {
+    await conv.createFeatureBranch({ instance: "p", branch: "f1" });
+    expect(mockCreateBranch).toHaveBeenCalledTimes(1);
+    expect(mockCreateBranch.mock.calls[0][0]).toMatchObject({
+      instance: "p",
+      branch: "f1",
+      parentBranch: "staging",
+      ttl: `${30 * 86_400}s`,
+    });
+  });
+
+  it("createTestBranch defaults parentBranch=staging, ttl=14 days", async () => {
+    await conv.createTestBranch({ instance: "p", branch: "t1" });
+    expect(mockCreateBranch.mock.calls[0][0]).toMatchObject({
+      parentBranch: "staging",
+      ttl: `${14 * 86_400}s`,
+    });
+  });
+
+  it("createUatBranch defaults parentBranch=staging, ttl=14 days", async () => {
+    await conv.createUatBranch({ instance: "p", branch: "u1" });
+    expect(mockCreateBranch.mock.calls[0][0]).toMatchObject({
+      parentBranch: "staging",
+      ttl: `${14 * 86_400}s`,
+    });
+  });
+
+  it("createPerfBranch defaults parentBranch=staging, ttl=7 days", async () => {
+    await conv.createPerfBranch({ instance: "p", branch: "perf1" });
+    expect(mockCreateBranch.mock.calls[0][0]).toMatchObject({
+      parentBranch: "staging",
+      ttl: `${7 * 86_400}s`,
+    });
+  });
+});
+
+describe("convention-branches: caller overrides", () => {
+  it("ttl override is forwarded as-is", async () => {
+    await conv.createFeatureBranch({ instance: "p", branch: "f2", ttl: "3600s" });
+    expect(mockCreateBranch.mock.calls[0][0].ttl).toBe("3600s");
+  });
+
+  it("parentBranch override is forwarded", async () => {
+    await conv.createTestBranch({
+      instance: "p",
+      branch: "t2",
+      parentBranch: "dev",
+    });
+    expect(mockCreateBranch.mock.calls[0][0].parentBranch).toBe("dev");
+  });
+
+  it("host is forwarded", async () => {
+    await conv.createUatBranch({ instance: "p", branch: "u2", host: "https://h" });
+    expect(mockCreateBranch.mock.calls[0][0].host).toBe("https://h");
+  });
+});
+
+describe("CONVENTION_TIER_DEFAULTS exposes tier metadata", () => {
+  it("declares all four tiers with parentBranch + ttl", () => {
+    for (const tier of ["feature", "test", "uat", "perf"] as const) {
+      const d = conv.CONVENTION_TIER_DEFAULTS[tier];
+      expect(d.parentBranch).toBe("staging");
+      expect(d.ttl).toMatch(/^\d+s$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the four PSA branching-methodology helpers — `createFeatureBranch`, `createTestBranch`, `createUatBranch`, `createPerfBranch` — plus the missing `ttl` field in substrate's `CreateBranchArgs`.

Each helper is a thin wrapper over `createBranch` that defaults `parentBranch="staging"` and a tier-specific TTL:

| Helper | parent | TTL default |
|---|---|---|
| createFeatureBranch | staging | 30 days |
| createTestBranch | staging | 14 days |
| createUatBranch | staging | 14 days |
| createPerfBranch | staging | 7 days |

Unlike the long-running tiers (prod, staging — `createLongRunningBranch` with `no_expiry: true`), these are FINITE workflow branches. Lakebase auto-deletes them when the TTL expires, so a dropped post-merge hook or abandoned branch doesn't accumulate forever.

## Substrate API addition: ttl

`CreateBranchArgs` gains `ttl?: string` (Lakebase Duration JSON encoding, `<seconds>s`). Mutually exclusive with `noExpiry: true` — substrate throws on the inconsistent combination.

TTL format verified via a real Lakebase create-branch probe against `fevm-serverless-stable-ecparr` — `"720h"` (Go duration) and bare numeric were rejected, `"<N>s"` string was accepted.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 236 passing (was 228; +8 from `tests/bdd/convention-branches.test.ts`)
- [x] TTL format probed live against real Lakebase API
- [ ] Extension UI / release-workflow YAMLs can adopt the helpers in a follow-up (this is the substrate side only)

This pull request and its description were written by Isaac.