### PR TITLE
[FEIP-7096 PR3] Route detect-language through substrate CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "lakebase-create-project": "./dist/scripts/lakebase/create-project.cli.js",
     "lakebase-migrate": "./dist/scripts/lakebase/migrate.cli.js",
     "lakebase-cut-backup": "./dist/scripts/lakebase/cut-backup.cli.js",
+    "lakebase-detect-language": "./dist/scripts/lakebase/detect-language.cli.js",
     "lakebase-mcp-server": "./dist/apps/mcp-server/index.js"
   },
   "scripts": {

--- a/scripts/lakebase/detect-language.cli.ts
+++ b/scripts/lakebase/detect-language.cli.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// CLI for substrate's project-language detector. Used by the scaffolded
+// pr.yml + merge.yml to populate `steps.detect-lang.outputs.lang` without
+// duplicating the detection bash inline.
+//
+// Output: prints "java" | "python" | "nodejs" to stdout. Exits non-zero
+// if no recognised marker file is present.
+//
+// Optional flag: --project-dir <path> (defaults to cwd).
+//
+// GitHub Actions usage (matches the migrate + cut-backup CLIs pinned at
+// scaffold time via {{LAKEBASE_KIT_VERSION}}):
+//
+//   - name: Detect project language
+//     id: detect-lang
+//     run: |
+//       LANG="$(npx --yes \
+//         --package=github:databricks-solutions/lakebase-app-dev-kit#v<pin> \
+//         lakebase-detect-language)"
+//       echo "lang=$LANG" >> $GITHUB_OUTPUT
+
+import { detectLanguage } from "./migrate.js";
+
+function parseProjectDir(argv: string[]): string {
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--project-dir" && i + 1 < argv.length) {
+      return argv[i + 1];
+    }
+    if (argv[i] === "-h" || argv[i] === "--help") {
+      printHelpAndExit();
+    }
+  }
+  return process.cwd();
+}
+
+function printHelpAndExit(): never {
+  process.stdout.write(
+    `lakebase-detect-language — print the project's language\n\n` +
+      `Usage:\n` +
+      `  lakebase-detect-language [--project-dir <path>]\n\n` +
+      `Output (stdout): one of "java", "python", "nodejs"\n` +
+      `Exits 1 with an error message on stderr if no marker found.\n`,
+  );
+  process.exit(0);
+}
+
+const projectDir = parseProjectDir(process.argv.slice(2));
+
+try {
+  const lang = detectLanguage(projectDir);
+  process.stdout.write(`${lang}\n`);
+  process.exit(0);
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`lakebase-detect-language: ${msg}\n`);
+  process.exit(1);
+}

--- a/templates/project/common/.github/workflows/merge.yml
+++ b/templates/project/common/.github/workflows/merge.yml
@@ -54,19 +54,18 @@ jobs:
 
       - name: Detect project language
         id: detect-lang
+        # Routes through the substrate's lakebase-detect-language CLI so
+        # the kit's marker-file detection (mirrors lakebase-migrate's auto-
+        # detect) is the single source of truth across pr.yml + merge.yml +
+        # the substrate's migrate runners. {{LAKEBASE_KIT_VERSION}} is
+        # substituted at scaffold time to the kit version that produced
+        # this project.
         run: |
-          # Use git ls-files to check tracked marker files (avoids stale files on self-hosted runners)
-          if git ls-files --error-unmatch pom.xml >/dev/null 2>&1; then
-            echo "lang=java" >> $GITHUB_OUTPUT
-          elif git ls-files --error-unmatch pyproject.toml >/dev/null 2>&1 || git ls-files --error-unmatch requirements.txt >/dev/null 2>&1; then
-            echo "lang=python" >> $GITHUB_OUTPUT
-          elif git ls-files --error-unmatch package.json >/dev/null 2>&1; then
-            echo "lang=nodejs" >> $GITHUB_OUTPUT
-          else
-            echo "::error::Cannot detect project language."
-            exit 1
-          fi
-          echo "Detected language: $(cat $GITHUB_OUTPUT | grep lang | cut -d= -f2)"
+          LANG="$(npx --yes \
+            --package=github:databricks-solutions/lakebase-app-dev-kit#v{{LAKEBASE_KIT_VERSION}} \
+            lakebase-detect-language)"
+          echo "lang=$LANG" >> $GITHUB_OUTPUT
+          echo "Detected language: $LANG"
 
       - name: Set up JDK
         if: steps.detect-lang.outputs.lang == 'java'

--- a/templates/project/common/.github/workflows/pr.yml
+++ b/templates/project/common/.github/workflows/pr.yml
@@ -26,19 +26,18 @@ jobs:
 
       - name: Detect project language
         id: detect-lang
+        # Routes through the substrate's lakebase-detect-language CLI so
+        # the kit's marker-file detection (mirrors lakebase-migrate's auto-
+        # detect) is the single source of truth across pr.yml + merge.yml +
+        # the substrate's migrate runners. {{LAKEBASE_KIT_VERSION}} is
+        # substituted at scaffold time to the kit version that produced
+        # this project.
         run: |
-          # Use git ls-files to check tracked marker files (avoids stale files on self-hosted runners)
-          if git ls-files --error-unmatch pom.xml >/dev/null 2>&1; then
-            echo "lang=java" >> $GITHUB_OUTPUT
-          elif git ls-files --error-unmatch pyproject.toml >/dev/null 2>&1 || git ls-files --error-unmatch requirements.txt >/dev/null 2>&1; then
-            echo "lang=python" >> $GITHUB_OUTPUT
-          elif git ls-files --error-unmatch package.json >/dev/null 2>&1; then
-            echo "lang=nodejs" >> $GITHUB_OUTPUT
-          else
-            echo "::error::Cannot detect project language. Expected pom.xml, pyproject.toml, or package.json in repo root."
-            exit 1
-          fi
-          echo "Detected language: $(cat $GITHUB_OUTPUT | grep lang | cut -d= -f2)"
+          LANG="$(npx --yes \
+            --package=github:databricks-solutions/lakebase-app-dev-kit#v{{LAKEBASE_KIT_VERSION}} \
+            lakebase-detect-language)"
+          echo "lang=$LANG" >> $GITHUB_OUTPUT
+          echo "Detected language: $LANG"
 
       - name: Set up JDK
         if: steps.detect-lang.outputs.lang == 'java'

--- a/tests/bdd/detect-language.test.ts
+++ b/tests/bdd/detect-language.test.ts
@@ -1,0 +1,99 @@
+// Hermetic coverage for the lakebase-detect-language CLI (FEIP-7096).
+//
+// The CLI is a thin wrapper over migrate.ts's detectLanguage(projectDir),
+// added so scaffolded pr.yml + merge.yml can route detection through
+// substrate (single source of truth) rather than inlining the marker-file
+// shell each time. These tests exercise the CLI surface itself: argv
+// parsing, stdout output shape, exit codes.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(__dirname, "..", "..", "scripts", "lakebase", "detect-language.cli.ts");
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+function mkTmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lb-detect-lang-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function runCli(projectDir: string): { stdout: string; stderr: string; status: number } {
+  try {
+    const stdout = execFileSync(
+      "npx",
+      ["--yes", "tsx", CLI, "--project-dir", projectDir],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return { stdout, stderr: "", status: 0 };
+  } catch (err: unknown) {
+    const e = err as { status?: number; stdout?: Buffer; stderr?: Buffer };
+    return {
+      stdout: e.stdout?.toString() ?? "",
+      stderr: e.stderr?.toString() ?? "",
+      status: e.status ?? 1,
+    };
+  }
+}
+
+describe("lakebase-detect-language CLI", () => {
+  it("prints 'java' when pom.xml is present", () => {
+    const dir = mkTmp();
+    fs.writeFileSync(path.join(dir, "pom.xml"), "<project/>");
+    const r = runCli(dir);
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("java");
+  });
+
+  it("prints 'python' when pyproject.toml is present", () => {
+    const dir = mkTmp();
+    fs.writeFileSync(path.join(dir, "pyproject.toml"), "");
+    const r = runCli(dir);
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("python");
+  });
+
+  it("prints 'python' when requirements.txt is present", () => {
+    const dir = mkTmp();
+    fs.writeFileSync(path.join(dir, "requirements.txt"), "");
+    const r = runCli(dir);
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("python");
+  });
+
+  it("prints 'nodejs' when only package.json is present", () => {
+    const dir = mkTmp();
+    fs.writeFileSync(path.join(dir, "package.json"), "{}");
+    const r = runCli(dir);
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("nodejs");
+  });
+
+  it("prioritises pom.xml over package.json (Java + Node mixed)", () => {
+    const dir = mkTmp();
+    fs.writeFileSync(path.join(dir, "pom.xml"), "<project/>");
+    fs.writeFileSync(path.join(dir, "package.json"), "{}");
+    const r = runCli(dir);
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("java");
+  });
+
+  it("exits non-zero with a stderr message when no marker is present", () => {
+    const dir = mkTmp();
+    const r = runCli(dir);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/lakebase-detect-language/);
+  });
+});


### PR DESCRIPTION
## Summary

Final piece of FEIP-7096 PR3: removes the inline marker-file shell from scaffolded `pr.yml` + `merge.yml` and replaces it with a substrate-pinned `lakebase-detect-language` CLI call. Substrate's `detectLanguage()` (in `migrate.ts`) is now the single source of truth for project-language resolution across the workflow YAMLs AND the substrate's migrate runners.

Migrate + snapshot were already routed through substrate (`lakebase-migrate`, `lakebase-cut-backup`); detect-lang was the remaining duplication.

## Substrate adds

- `scripts/lakebase/detect-language.cli.ts` — thin CLI wrapper over the existing `detectLanguage(projectDir)` in `migrate.ts`
- `lakebase-detect-language` bin entry in `package.json`
- 6 hermetic tests in `tests/bdd/detect-language.test.ts`

## YAML changes

Both `pr.yml` + `merge.yml` detect-lang step body collapses from a 15-line marker-file shell to a 3-line npx invocation pinned at scaffold time via `{{LAKEBASE_KIT_VERSION}}` (same template substitution used by the migrate + snapshot steps).

Step id `detect-lang` and output `lang` preserved — 5 downstream steps that consume `steps.detect-lang.outputs.lang == 'java'` etc. continue to work unchanged.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` 242 passing (was 236; +6 from detect-language tests)
- [ ] Live integration verification deferred to FEIP-7096 PR4 (separate ticket)

This pull request and its description were written by Isaac.