### PR TITLE
[substrate] v0.3.0-alpha.20 release cut

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.19",
+  "version": "0.3.0-alpha.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.19",
+      "version": "0.3.0-alpha.20",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.19",
+  "version": "0.3.0-alpha.20",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary
- Bumps `package.json` + `package-lock.json` to `0.3.0-alpha.20`
- Cuts a tag so scaffolded `pr.yml` + `merge.yml` can resolve `npx --package=github:databricks-solutions/lakebase-app-dev-kit#v0.3.0-alpha.20 lakebase-detect-language` against a real ref. Without this cut, FEIP-7138 (PR4 live verification) can't actually exercise PR3 in CI.

## Unreleased since alpha.19
- #31 Husky pre-push gate
- #32 HOOKS.md template doc
- #33 Branch convention helpers + ttl support in `createBranch`
- #34 detect-language substrate CLI primitive

## Test plan
- [x] husky pre-push: typecheck + 242 tests pass (45 files, 33 skipped, 18.3s)
- [ ] After merge, tag `v0.3.0-alpha.20` on the merge commit and push
- [ ] Smoke: `npx --package=github:databricks-solutions/lakebase-app-dev-kit#v0.3.0-alpha.20 lakebase-detect-language --help` resolves the bin

This pull request and its description were written by Isaac.