### PR TITLE
[substrate] Wire detect-language.cli into tsup build entries

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     "scripts/lakebase/create-project.cli": "scripts/lakebase/create-project.cli.ts",
     "scripts/lakebase/migrate.cli": "scripts/lakebase/migrate.cli.ts",
     "scripts/lakebase/cut-backup.cli": "scripts/lakebase/cut-backup.cli.ts",
+    "scripts/lakebase/detect-language.cli": "scripts/lakebase/detect-language.cli.ts",
     "apps/mcp-server/index": "apps/mcp-server/index.ts",
     "apps/mcp-server/dump-tools": "apps/mcp-server/dump-tools.ts",
   },


### PR DESCRIPTION
## Summary
- PR #34 (FEIP-7096 PR3) added the `lakebase-detect-language` bin to package.json and the source file at `scripts/lakebase/detect-language.cli.ts`, but did not register the entry in `tsup.config.ts`. Build never emitted `dist/scripts/lakebase/detect-language.cli.js`, so `npx --package=github:databricks-solutions/lakebase-app-dev-kit#v0.3.0-alpha.20 lakebase-detect-language` returns "command not found".
- Hermetic vitest at `tests/bdd/detect-language.test.ts` ran tsx against source, so the gap did not surface in PR #34's checks.

## Fix
- Add `"scripts/lakebase/detect-language.cli": "scripts/lakebase/detect-language.cli.ts"` alongside the other `*.cli.ts` entries in tsup.config.ts.

## Test plan
- [x] husky pre-push: typecheck + 242 tests pass
- [x] `npm run build` emits `dist/scripts/lakebase/detect-language.cli.{js,cjs,d.ts,d.cts}`
- [x] `node dist/scripts/lakebase/detect-language.cli.js` against a temp dir with pyproject.toml prints "python"
- [ ] After merge, re-cut `v0.3.0-alpha.20` tag on the new merge commit (alpha.20 was tagged before this fix, force-tag is intentional since nothing has consumed it yet)
- [ ] Re-run npx smoke against the re-tagged ref

## Follow-up
- A separate ticket will be filed for a build-then-`stat dist/bin` regression check so any future bin/tsup-entry drift fails CI fast (would have caught PR #34's gap).

This pull request and its description were written by Isaac.