### PR TITLE
[FEIP-7145] Branch identifier normalizer + parent-branch adapter fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.20",
+  "version": "0.3.0-alpha.21",
   "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,

--- a/scripts/lakebase/branch-endpoint.ts
+++ b/scripts/lakebase/branch-endpoint.ts
@@ -6,7 +6,7 @@
 // sanitized name, or full resource path.
 
 import { execFileSync } from "node:child_process";
-import { resolveBranchPath } from "./branch-utils.js";
+import { resolveBranchId, resolveBranchPath } from "./branch-utils.js";
 import { mintCredential } from "./get-connection.js";
 
 export interface EndpointInfo {
@@ -63,6 +63,13 @@ export async function getEndpoint(args: GetEndpointArgs): Promise<EndpointInfo |
  * Build the canonical endpoint resource path that mintCredential expects.
  * Convenience helper – most callers go through getConnection() which builds
  * this internally.
+ *
+ * **NOTE:** synchronous; does NOT normalize uid → branch_id. Caller is
+ * responsible for passing `branch_id` (the friendly leaf, e.g.
+ * "demo-feature" / "staging" / "production"). If you might be holding a
+ * uid, await {@link resolveBranchId} from `./branch-utils.js` first.
+ * The async helpers in this file (getEndpoint, ensureEndpoint, getCredential)
+ * normalize for you.
  */
 export function endpointPath(instance: string, branch: string, endpointName = "primary"): string {
   return `projects/${instance}/branches/${branch}/endpoints/${endpointName}`;
@@ -92,12 +99,15 @@ export interface EnsureEndpointArgs {
  */
 export async function ensureEndpoint(args: EnsureEndpointArgs): Promise<EndpointInfo> {
   const endpointName = args.endpointName ?? "primary";
-  const existing = await getEndpoint({ instance: args.instance, branch: args.branch, endpointName });
+  // Normalize once. Below, branchId flows into both the create-endpoint CLI
+  // path and the retry/poll getEndpoint calls.
+  const branchId = await resolveBranchId({ instance: args.instance, branch: args.branch });
+  const existing = await getEndpoint({ instance: args.instance, branch: branchId, endpointName });
   if (existing?.host) {
     return existing;
   }
 
-  const branchPath = `projects/${args.instance}/branches/${args.branch}`;
+  const branchPath = `projects/${args.instance}/branches/${branchId}`;
   const spec = {
     spec: {
       endpoint_type: args.endpointType ?? "ENDPOINT_TYPE_READ_WRITE",
@@ -116,7 +126,7 @@ export async function ensureEndpoint(args: EnsureEndpointArgs): Promise<Endpoint
   } catch (err) {
     // Race: the endpoint may have been created between our getEndpoint check
     // and the create call. Re-check before failing.
-    const racy = await getEndpoint({ instance: args.instance, branch: args.branch, endpointName });
+    const racy = await getEndpoint({ instance: args.instance, branch: branchId, endpointName });
     if (racy?.host) return racy;
     throw err;
   }
@@ -125,7 +135,7 @@ export async function ensureEndpoint(args: EnsureEndpointArgs): Promise<Endpoint
   const timeoutMs = args.timeoutMs ?? 120_000;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const ep = await getEndpoint({ instance: args.instance, branch: args.branch, endpointName });
+    const ep = await getEndpoint({ instance: args.instance, branch: branchId, endpointName });
     if (ep?.host) return ep;
     await new Promise((r) => setTimeout(r, 5_000));
   }

--- a/scripts/lakebase/branch-schema.ts
+++ b/scripts/lakebase/branch-schema.ts
@@ -11,6 +11,7 @@
 
 import { Client } from "pg";
 import { getEndpoint, endpointPath as buildEndpointPath } from "./branch-endpoint.js";
+import { resolveBranchId } from "./branch-utils.js";
 import { mintCredential } from "./get-connection.js";
 
 export interface TableSchema {
@@ -20,6 +21,12 @@ export interface TableSchema {
 
 export interface QueryBranchSchemaArgs {
   instance: string;
+  /**
+   * Branch identifier. Accepts branch_id (e.g. "demo-feature"; tier names
+   * "production" / "staging" / "uat" / "perf" are branch_ids), branch_uid
+   * (e.g. "br-broad-sky-d2k5gewt"), or full resource path. Normalized
+   * internally before any CLI URL is built.
+   */
   branch: string;
   /** Default: $PGDATABASE then "databricks_postgres" */
   database?: string;
@@ -43,11 +50,16 @@ const SCHEMA_QUERY =
  * configuration problem the caller should surface.
  */
 export async function queryBranchSchema(args: QueryBranchSchemaArgs): Promise<TableSchema[]> {
-  const ep = await getEndpoint({ instance: args.instance, branch: args.branch });
+  // Normalize once. buildEndpointPath is sync + uses raw interpolation, so
+  // every CLI path downstream needs branch_id (not uid). getEndpoint already
+  // accepts either form via resolveBranchPath, but we normalize here so the
+  // single shared `branchId` flows through both call sites consistently.
+  const branchId = await resolveBranchId({ instance: args.instance, branch: args.branch });
+  const ep = await getEndpoint({ instance: args.instance, branch: branchId });
   if (!ep?.host) {
     return [];
   }
-  const { token, email } = await mintCredential(buildEndpointPath(args.instance, args.branch));
+  const { token, email } = await mintCredential(buildEndpointPath(args.instance, branchId));
   const database = args.database ?? process.env.PGDATABASE ?? "databricks_postgres";
   const skipFlyway = args.skipFlyway !== false;
 

--- a/scripts/lakebase/branch-utils.ts
+++ b/scripts/lakebase/branch-utils.ts
@@ -14,16 +14,37 @@ export class LakebaseBranchError extends Error {
 }
 
 export interface LakebaseBranchInfo {
-  /** Lakebase-side branch id (often equals the sanitized git branch). */
+  /**
+   * Lakebase-side opaque uid, e.g. "br-broad-sky-d2k5gewt". Returned by
+   * `get-branch` / `list-branches` as the `uid` field. NOT accepted as the
+   * `{branch}` path segment in CLI subresource URLs — use {@link branchId} or
+   * the friendly leaf of {@link name} for those.
+   */
   uid: string;
   /** Full resource name, e.g. "projects/proj-abc/branches/feature-x". */
   name: string;
   /** "READY", "PROVISIONING", etc. */
   state: string;
-  /** Parent branch full name (from spec.source_branch). */
+  /**
+   * Parent branch full resource name (e.g. "projects/x/branches/staging"),
+   * sourced from `status.source_branch` in the Lakebase API response.
+   *
+   * Use {@link sourceBranchId} for just the leaf segment.
+   */
   sourceBranchName?: string;
+  /** Parent branch leaf id (e.g. "staging"). Derived from sourceBranchName. */
+  sourceBranchId?: string;
   /** True if this is the project's default branch. */
   isDefault?: boolean;
+  /**
+   * RFC3339 expiration, e.g. "2026-06-25T05:00:00Z". Present for branches
+   * created with a TTL (workflow tiers feature / test / uat / perf). Absent
+   * for long-running tiers (production / staging) and for legacy branches
+   * created with `no_expiry: true`.
+   */
+  expireTime?: string;
+  /** True if the branch is protected from deletion. */
+  isProtected?: boolean;
 }
 
 export interface BranchLookupOpts {
@@ -93,13 +114,74 @@ export async function resolveBranchPath(
   return branch?.name;
 }
 
+/**
+ * Normalize a branch reference to the friendly `branch_id` (leaf segment,
+ * e.g. "demo-feature", "staging", "production"). This is the form accepted
+ * by CLI subresource URLs like `branches/{x}/endpoints/primary`.
+ *
+ * Accepts any of:
+ *   - branch_id ("demo-feature", or any PSA tier name: "production",
+ *     "staging", "uat", "perf")
+ *   - branch_uid ("br-broad-sky-d2k5gewt")
+ *   - full resource path ("projects/x/branches/demo-feature")
+ *
+ * Throws when the branch can't be resolved (e.g. uid points at nothing).
+ * Fast-path: returns input unchanged for values that don't look like a uid
+ * (no `br-` prefix) and don't include a path prefix — avoids a round-trip
+ * for the common branch_id case.
+ */
+export async function resolveBranchId(
+  args: BranchLookupOpts & { branch: string }
+): Promise<string> {
+  const { branch, ...opts } = args;
+
+  // Full resource path → take the leaf.
+  if (branch.startsWith("projects/") && branch.includes("/branches/")) {
+    const leaf = branch.split("/branches/").pop();
+    if (leaf) return leaf;
+  }
+
+  // Fast path: looks like a branch_id already (no uid prefix). Trust it.
+  if (!branch.startsWith("br-")) {
+    return branch;
+  }
+
+  // Slow path: uid → list + filter to get the friendly id.
+  const info = await getBranchByName(branch, opts);
+  if (!info) {
+    throw new LakebaseBranchError(
+      `Could not resolve branch "${branch}" in project "${opts.instance}". ` +
+        `Pass either the branch_id (e.g. "demo-feature") or the branch uid.`
+    );
+  }
+  const leaf = info.name.split("/branches/").pop();
+  if (!leaf) {
+    throw new LakebaseBranchError(
+      `Branch info for "${branch}" missing a name segment (got "${info.name}").`
+    );
+  }
+  return leaf;
+}
+
 // ── Internal ────────────────────────────────────────────────────
 
 interface RawBranch {
   uid?: string;
   name?: string;
   state?: string;
-  status?: { current_state?: string; default?: boolean };
+  status?: {
+    current_state?: string;
+    default?: boolean;
+    /**
+     * Lakebase returns the parent branch's full resource name here on
+     * `get-branch` responses. Older speculation was `spec.source_branch`
+     * (kept as a fallback for backward compatibility / list-branches shapes
+     * we haven't seen yet).
+     */
+    source_branch?: string;
+    expire_time?: string;
+    is_protected?: boolean;
+  };
   is_default?: boolean;
   spec?: { source_branch?: string };
 }
@@ -110,12 +192,17 @@ function parseBranch(raw: unknown): LakebaseBranchInfo | undefined {
   const name = r.name ?? "";
   if (!name) return undefined;
   const uid = r.uid ?? name.split("/branches/").pop() ?? "";
+  const sourceBranchName = r.status?.source_branch ?? r.spec?.source_branch;
+  const sourceBranchId = sourceBranchName?.split("/branches/").pop() || undefined;
   return {
     uid,
     name,
     state: r.status?.current_state ?? r.state ?? "UNKNOWN",
-    sourceBranchName: r.spec?.source_branch,
+    sourceBranchName,
+    sourceBranchId,
     isDefault: r.status?.default === true || r.is_default === true,
+    expireTime: r.status?.expire_time,
+    isProtected: r.status?.is_protected,
   };
 }
 

--- a/scripts/lakebase/get-connection.ts
+++ b/scripts/lakebase/get-connection.ts
@@ -16,6 +16,7 @@
 import { execFileSync } from "node:child_process";
 import { createLakebasePool } from "@databricks/lakebase";
 import type { Pool } from "pg";
+import { resolveBranchId } from "./branch-utils.js";
 // AppKit / @databricks/lakebase re-exports a WorkspaceClient type that
 // matches what createLakebasePool expects. We accept `unknown` at the API
 // boundary so this module doesn't have to take a hard SDK dep just to type
@@ -28,8 +29,13 @@ export interface GetConnectionArgs {
    */
   instance: string;
   /**
-   * Branch id within the project (e.g. "br-feature-xyz"). Maps to
-   * `projects/<instance>/branches/<branch>`.
+   * Branch identifier within the project. Accepts:
+   *   - branch_id (e.g. "demo-feature"; also any PSA tier name:
+   *     "production", "staging", "uat", "perf")
+   *   - branch_uid (e.g. "br-broad-sky-d2k5gewt")
+   *   - full resource path ("projects/x/branches/demo-feature")
+   *
+   * Normalized to branch_id internally before any CLI path is built.
    */
   branch: string;
   /**
@@ -74,17 +80,20 @@ export function getConnection(args: PoolArgs): Promise<Pool>;
 export async function getConnection(args: ConnectionArgs): Promise<DsnResult | Pool> {
   const endpointName = args.endpointName ?? "primary";
   const database = args.database ?? process.env.PGDATABASE ?? "databricks_postgres";
-  const endpointPath = `projects/${args.instance}/branches/${args.branch}/endpoints/${endpointName}`;
+  // Normalize once at the entry point. Every downstream CLI path uses
+  // branchId; callers can hand us uid / branch_id / full path.
+  const branchId = await resolveBranchId({ instance: args.instance, branch: args.branch });
+  const endpointPath = `projects/${args.instance}/branches/${branchId}/endpoints/${endpointName}`;
 
   if (args.output === "dsn") {
-    const host = await resolveEndpointHost(args.instance, args.branch);
+    const host = await resolveEndpointHost(args.instance, branchId);
     const { token, email } = await mintCredential(endpointPath);
     const url = buildPostgresUrl({ host, port: 5432, database, user: email, password: token });
     return { url, host, port: 5432, database, user: email, endpointPath };
   }
 
   // output === "pool"
-  const host = await resolveEndpointHost(args.instance, args.branch);
+  const host = await resolveEndpointHost(args.instance, branchId);
   const email = await resolveCurrentUser();
   return createLakebasePool({
     endpoint: endpointPath,
@@ -99,8 +108,15 @@ export async function getConnection(args: ConnectionArgs): Promise<DsnResult | P
   });
 }
 
+/**
+ * Resolve the primary endpoint host for a branch.
+ *
+ * @param branch  branch_id, branch_uid, or full resource path. Normalized
+ *                internally before the CLI subresource URL is built.
+ */
 export async function resolveEndpointHost(instance: string, branch: string): Promise<string> {
-  const branchPath = `projects/${instance}/branches/${branch}`;
+  const branchId = await resolveBranchId({ instance, branch });
+  const branchPath = `projects/${instance}/branches/${branchId}`;
   const raw = dbcli(["postgres", "list-endpoints", branchPath, "-o", "json"]);
   const endpoints = JSON.parse(raw) as Array<{ status?: { hosts?: { host?: string } } }>;
   if (!Array.isArray(endpoints) || endpoints.length === 0) {

--- a/scripts/lakebase/schema-diff.ts
+++ b/scripts/lakebase/schema-diff.ts
@@ -223,50 +223,39 @@ const colKey = (c: SchemaColumn): string => `${c.name}:${c.dataType}`;
 
 /**
  * Resolve the comparison branch via Lakebase metadata:
- *   1. target branch's `sourceBranchId` (its parent), if set
+ *   1. target branch's `status.source_branch` (its parent), if set – this is
+ *      a full resource path like `projects/x/branches/staging`; we trim to
+ *      the leaf id since downstream CLI subresource URLs need branch_id.
  *   2. project's default branch, otherwise
  *   3. undefined if neither is resolvable
+ *
+ * Historical note: earlier code looked for `source_branch_id` at the top
+ * level of `get-branch` responses. The Lakebase API actually nests it under
+ * `status.source_branch` as the full path. Using the full path leaf means
+ * we never need a uid→name lookup hop.
  */
 function resolveComparisonBranch(instance: string, branch: string): string | undefined {
   const branchInfo = describeBranch(instance, branch);
-  const sourceBranchId = branchInfo?.source_branch_id ?? branchInfo?.sourceBranchId;
-  if (sourceBranchId && typeof sourceBranchId === "string") {
-    // source_branch_id is a UID (br-foo-bar). list-endpoints (and most other
-    // postgres API endpoints) accept the branch NAME, not the UID – passing
-    // the UID returns "branch id not found". Resolve it to a name here.
-    const resolved = resolveBranchNameByUid(instance, sourceBranchId);
-    if (resolved) return resolved;
+  const sourceBranch = branchInfo?.status?.source_branch ?? branchInfo?.spec?.source_branch;
+  if (sourceBranch && typeof sourceBranch === "string") {
+    const leaf = sourceBranch.split("/branches/").pop();
+    if (leaf) return leaf;
   }
   const def = findDefaultBranch(instance);
   if (def) return def;
   return undefined;
 }
 
-/**
- * Translate a Lakebase branch UID (`br-foo-bar`) into its branch NAME
- * (`production`, `staging`, etc.). Returns undefined when no matching
- * branch exists. Required because `postgres list-endpoints` accepts the
- * name segment but get-branch reports source_branch_id as the UID.
- */
-function resolveBranchNameByUid(instance: string, uid: string): string | undefined {
-  try {
-    const raw = dbcli(["postgres", "list-branches", `projects/${instance}`, "-o", "json"]);
-    const parsed = JSON.parse(raw) as BranchMetadata[] | { branches?: BranchMetadata[]; items?: BranchMetadata[] };
-    const items = Array.isArray(parsed) ? parsed : parsed.branches ?? parsed.items ?? [];
-    const match = items.find((b) => b.uid === uid);
-    if (!match) return undefined;
-    return match.name?.split("/branches/").pop();
-  } catch {
-    return undefined;
-  }
-}
-
 interface BranchMetadata {
   uid?: string;
   name?: string;
-  source_branch_id?: string;
-  sourceBranchId?: string;
-  status?: { default?: boolean };
+  status?: {
+    default?: boolean;
+    /** Parent branch's full resource name when the branch was forked. */
+    source_branch?: string;
+  };
+  /** Kept as a fallback for list-branches responses that haven't surfaced status.source_branch. */
+  spec?: { source_branch?: string };
   is_default?: boolean;
 }
 

--- a/tests/bdd/branch-identifier.test.ts
+++ b/tests/bdd/branch-identifier.test.ts
@@ -1,0 +1,153 @@
+// FEIP-7145: branch identifier normalization + parent-branch adapter.
+//
+// Two layers of coverage:
+//
+//   1. Pure unit tests for resolveBranchId's input-shape detection
+//      (fast path / full-path strip / uid prefix). No CLI required.
+//   2. Live BDD pair-coverage: any public substrate helper that takes a
+//      `branch` parameter and ultimately builds a CLI subresource URL must
+//      return identical results when called with branch_id, branch_uid, or
+//      full resource path. Gated on LAKEBASE_TEST_INSTANCE + a branch.
+//
+// The parent-branch adapter fix is verified live via getBranchByName:
+// `status.source_branch` must surface as `sourceBranchName` /
+// `sourceBranchId` on the adapter output for any non-default branch.
+
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  getBranchByName,
+  listBranches,
+  resolveBranchId,
+  LakebaseBranchError,
+} from "../../scripts/lakebase/branch-utils.js";
+import { getEndpoint, endpointPath } from "../../scripts/lakebase/branch-endpoint.js";
+import { queryBranchSchema } from "../../scripts/lakebase/branch-schema.js";
+import { resolveEndpointHost } from "../../scripts/lakebase/get-connection.js";
+
+const cliAvailable = (() => {
+  try {
+    execFileSync("databricks", ["--version"], { stdio: "ignore", timeout: 3_000 });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const TEST_INSTANCE = process.env.LAKEBASE_TEST_INSTANCE;
+const TEST_BRANCH = process.env.LAKEBASE_TEST_BRANCH;
+const live = cliAvailable && !!TEST_INSTANCE && !!TEST_BRANCH;
+
+describe("resolveBranchId – input-shape fast paths (no CLI)", () => {
+  it("returns the input unchanged when it is already a branch_id", async () => {
+    // No CLI hit because there's no `br-` prefix and no `projects/...` path.
+    const out = await resolveBranchId({ instance: "fake", branch: "demo-feature" });
+    expect(out).toBe("demo-feature");
+  });
+
+  it("returns the tier name unchanged (tier === branch_id)", async () => {
+    for (const tier of ["production", "staging", "uat", "perf"]) {
+      const out = await resolveBranchId({ instance: "fake", branch: tier });
+      expect(out).toBe(tier);
+    }
+  });
+
+  it("strips the full resource path to the leaf id", async () => {
+    const out = await resolveBranchId({
+      instance: "fake",
+      branch: "projects/some-app/branches/feature-x",
+    });
+    expect(out).toBe("feature-x");
+  });
+
+  it("strips the path even when the embedded project differs from args.instance", async () => {
+    // The function trusts the path leaf; mismatched project is the caller's
+    // problem (and the CLI will surface it downstream).
+    const out = await resolveBranchId({
+      instance: "different",
+      branch: "projects/embedded-project/branches/whatever",
+    });
+    expect(out).toBe("whatever");
+  });
+
+  it("throws LakebaseBranchError when a uid resolves to nothing (slow path)", async () => {
+    // Skipping when no CLI – the slow path requires a list-branches call.
+    if (!live) return;
+    await expect(
+      resolveBranchId({ instance: TEST_INSTANCE!, branch: "br-does-not-exist-xyz" })
+    ).rejects.toBeInstanceOf(LakebaseBranchError);
+  });
+});
+
+describe("parseBranch – parent-branch adapter (live)", () => {
+  it.skipIf(!live)(
+    "sourceBranchName + sourceBranchId are populated from status.source_branch",
+    async () => {
+      // The test branch is expected to be a forked branch (not the default),
+      // so its Lakebase metadata MUST expose a parent under status.source_branch.
+      // If your LAKEBASE_TEST_BRANCH is the default branch, this is expected
+      // to expose neither field; allow either shape.
+      const info = await getBranchByName(TEST_BRANCH!, { instance: TEST_INSTANCE! });
+      expect(info).toBeTruthy();
+      if (info!.isDefault) {
+        expect(info!.sourceBranchName).toBeUndefined();
+        expect(info!.sourceBranchId).toBeUndefined();
+        return;
+      }
+      expect(info!.sourceBranchName).toMatch(/^projects\/.+\/branches\/.+$/);
+      expect(info!.sourceBranchId).toBeTruthy();
+      expect(info!.sourceBranchId).toBe(info!.sourceBranchName!.split("/branches/").pop());
+    }
+  );
+});
+
+describe("branch identifier pair-coverage – live", () => {
+  it.skipIf(!live)("getEndpoint(uid) === getEndpoint(branchId)", async () => {
+    const info = await getBranchByName(TEST_BRANCH!, { instance: TEST_INSTANCE! });
+    expect(info).toBeTruthy();
+    const epByName = await getEndpoint({ instance: TEST_INSTANCE!, branch: TEST_BRANCH! });
+    const epByUid = await getEndpoint({ instance: TEST_INSTANCE!, branch: info!.uid });
+    expect(epByUid).toEqual(epByName);
+  });
+
+  it.skipIf(!live)("resolveEndpointHost(uid) === resolveEndpointHost(branchId)", async () => {
+    const info = await getBranchByName(TEST_BRANCH!, { instance: TEST_INSTANCE! });
+    expect(info).toBeTruthy();
+    const hostByName = await resolveEndpointHost(TEST_INSTANCE!, TEST_BRANCH!);
+    const hostByUid = await resolveEndpointHost(TEST_INSTANCE!, info!.uid);
+    expect(hostByUid).toBe(hostByName);
+  });
+
+  it.skipIf(!live)("queryBranchSchema(uid) === queryBranchSchema(branchId)", async () => {
+    const info = await getBranchByName(TEST_BRANCH!, { instance: TEST_INSTANCE! });
+    expect(info).toBeTruthy();
+    const byName = await queryBranchSchema({ instance: TEST_INSTANCE!, branch: TEST_BRANCH! });
+    const byUid = await queryBranchSchema({ instance: TEST_INSTANCE!, branch: info!.uid });
+    expect(byUid).toEqual(byName);
+  });
+
+  it.skipIf(!live)("endpointPath stays sync and does NOT accept a uid", async () => {
+    // Sanity check: endpointPath is documented as sync + branch_id-only. We
+    // don't want anyone "fixing" it to silently accept a uid via an async
+    // resolution. If you intentionally change that, update both the JSDoc
+    // and this test together.
+    const info = await getBranchByName(TEST_BRANCH!, { instance: TEST_INSTANCE! });
+    expect(info).toBeTruthy();
+    const path = endpointPath(TEST_INSTANCE!, info!.uid);
+    expect(path).toBe(`projects/${TEST_INSTANCE}/branches/${info!.uid}/endpoints/primary`);
+    expect(path).toContain(info!.uid); // Verbatim. No normalization.
+  });
+
+  it.skipIf(!live)("listBranches surfaces sourceBranchName for non-default branches", async () => {
+    const branches = await listBranches({ instance: TEST_INSTANCE! });
+    const nonDefault = branches.filter((b) => !b.isDefault);
+    // At least one non-default branch should have a parent recorded —
+    // otherwise the adapter has nothing to assert against.
+    const withParent = nonDefault.filter((b) => b.sourceBranchName);
+    expect(withParent.length).toBeGreaterThan(0);
+    for (const b of withParent) {
+      expect(b.sourceBranchName).toMatch(/^projects\/.+\/branches\/.+$/);
+      expect(b.sourceBranchId).toBe(b.sourceBranchName!.split("/branches/").pop());
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adapter fix: `parseBranch` now reads `status.source_branch` (the actual Lakebase API location), so `LakebaseBranchInfo.sourceBranchName` / `sourceBranchId` finally populate. Substrate's `getSchemaDiff` resolveComparisonBranch now reads from `status.source_branch` too and trims to the leaf id (no more uid->name round-trip). Fixes the long-standing "Branch Diff Summary always compares against the default branch" bug for feature/test/uat/perf branches forked from staging.
- New `resolveBranchId({instance, branch})` normalizer in `branch-utils.ts`. Accepts branch_id, branch_uid, or full resource path; returns branch_id. Applied at every public boundary that builds CLI subresource URLs: `getConnection`, `resolveEndpointHost`, `ensureEndpoint`, `queryBranchSchema`. `endpointPath` stays sync + branch_id-only with a JSDoc warning.
- `LakebaseBranchInfo` gains `sourceBranchId`, `expireTime`, `isProtected`.
- Cuts `v0.3.0-alpha.21`.

## Test plan
- [x] 296 substrate unit/equivalence tests pass
- [x] 11 new BDD tests in `tests/bdd/branch-identifier.test.ts` (5 fast-path + 6 live)
- [x] All 11 live tests verified against `partner-asset-tracker / demo-feature` — confirms `sourceBranchName` populates from `status.source_branch`, and `getEndpoint(uid)` / `resolveEndpointHost(uid)` / `queryBranchSchema(uid)` return identical results to their branch_id counterparts
- [x] husky pre-push gate green

JIRA: FEIP-7145
Consumer: lakebase-scm-extension already pins `#v0.3.0-alpha.21` and tests green.

This pull request and its description were written by Isaac.