### PR TITLE
docs: split skills into README.md (human) + SKILL.md (agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Lakebase-backed application development kit. The shared foundation that the [`lakebase-scm-extension`](https://github.com/databricks-solutions/lakebase-scm-extension) (VS Code/Cursor) and coding agents – Claude Code (terminal), Claude Desktop, OpenAI Foundry, Cursor, and Databricks Genie Code – all consume. One canonical implementation; multiple presentation layers and workflow-domain skills.
 
 **Workflow domains** (kit-authored, one skill each, hosted under `skills/`):
-- **[`lakebase-scm-workflows`](skills/lakebase-scm-workflows/SKILL.md)** – paired-branch source control, schema diff, PR flow, runner setup.
+- **[`lakebase-scm-workflows`](skills/lakebase-scm-workflows/README.md)** – paired-branch source control, schema diff, PR flow, runner setup.
 - **[`lakebase-release-workflows`](skills/lakebase-release-workflows/SKILL.md)** – branching + release methodology for Lakebase-paired projects.
-- **[`lakebase-tdd-workflows`](skills/lakebase-tdd-workflows/SKILL.md)** – test-driven development against paired branches: portable spec format, experiment / spike primitives, design-spec gate, single-experiment cycle wrapper, synthesis + bad-smell detection, Scrum-Master orchestrator with HITL gates at every phase boundary.
+- **[`lakebase-tdd-workflows`](skills/lakebase-tdd-workflows/README.md)** – test-driven development against paired branches: portable spec format, experiment / spike primitives, design-spec gate, single-experiment cycle wrapper, synthesis + bad-smell detection, Scrum-Master orchestrator with HITL gates at every phase boundary.
 - Future domains include deploying to Databricks Apps and beyond.
 
 **Shared canon** (kit-authored, unprefixed because not Lakebase-specific):

--- a/skills/lakebase-scm-workflows/README.md
+++ b/skills/lakebase-scm-workflows/README.md
@@ -1,0 +1,148 @@
+# lakebase-scm-workflows
+
+Opinionated git-to-Lakebase branch-pairing workflows. The agent surface for the same Node.js scripts that the [`databricks-solutions/lakebase-scm-extension`](https://github.com/databricks-solutions/lakebase-scm-extension) calls from its VS Code/Cursor commands — one canonical executable surface, two presentation layers.
+
+This README is the human-facing overview. The agent's operating contract — when `.env` matters, how the git hooks behave, the credential single-seam, concrete code patterns — lives in [`SKILL.md`](SKILL.md).
+
+> Composes on top of the dev-hub skill [`databricks-lakebase`](https://github.com/databricks/databricks-agent-skills) (Lakebase Postgres CLI basics). It does not shadow it.
+
+## Prerequisites
+
+The control plane and data plane are owned by other Databricks artifacts. Install/configure them once before using this skill:
+
+- `databricks postgres ...` CLI — documented by the dev-hub skill [`databricks-lakebase`](https://github.com/databricks/databricks-agent-skills). Install via `databricks aitools install databricks-lakebase`.
+- `@databricks/lakebase` npm package — drop-in `pg.Pool` with OAuth refresh.
+- `@databricks/appkit` npm package — Lakebase plugin and OBO (`asUser(req)`).
+
+## Installing the substrate
+
+For a JS/TS host (extension, Node service) that imports substrate functions, depend on this repo via a git URL until the npm-publish path settles:
+
+```jsonc
+// host package.json
+"dependencies": {
+  "@databricks-solutions/lakebase-app-dev-kit":
+    "github:databricks-solutions/lakebase-app-dev-kit#<commit-sha-or-tag>"
+}
+```
+
+Pin to a sha. `prepare` builds `dist/` on install so consumers can import from the package name.
+
+For agent use (running `node scripts/lakebase/<verb>.js` directly), clone this repo and run `npm install`. Same `prepare` build runs.
+
+## Operations
+
+Each operation is a CLI bin invocation that returns JSON on stdout. JS callers can import the same functions from the package.
+
+- `create-project` — bootstrap a fresh Lakebase-paired project
+- `schema-diff` — parent-aware diff between two Lakebase branches
+- `branch-create` / `branch-delete` — Lakebase branch lifecycle
+- `create-paired-branch` / `delete-paired-branch` / `checkout-paired` / `sync-env-to-current-branch` — paired ops that keep git + Lakebase + `.env` in lockstep
+- `get-endpoint` / `ensure-endpoint` / `get-credential` — branch endpoint + raw token/email
+- `query-branch-schema` / `query-branch-tables` — live pg introspection
+- `get-project-info` — project metadata (uid, display name, state)
+- `create-pull-request` / `get-pull-request` / `merge-pull-request` / `merge-paired-pull-request` — PR flow
+- `get-pull-request-reviews` / `get-pull-request-files` / `get-pull-request-comments` / `list-issue-comments` / `list-workflow-runs` — PR introspection
+
+## Under the covers
+
+What the substrate does on your behalf, in user-journey order. You don't invoke these primitives directly — the agent does, in response to the prompts in [How to use](#how-to-use). The exception is `create-project`, which is a one-shot bootstrap you can also run yourself via the `lakebase-create-project` bin (see the CLI cheat sheet).
+
+### 1. Create-project
+
+End-to-end project bootstrap — the first thing you'll touch. This is the one operation you may also run yourself via the `lakebase-create-project` bin; the agent prompt in [How to use](#how-to-use) flow 1 is the conversational equivalent.
+
+When create-project finishes you get a scaffolded layout shaped like:
+
+```
+~/code/proj-checkout/                      ← local clone (parent dir is your choice)
+  src/                                     ← language-specific scaffold (Java/Kotlin/Python/Node)
+  db/migrations/                           ← Flyway / Alembic migrations land here
+  .env.example                             ← committed; .env never is
+  .githooks/                               ← post-checkout (refresh DSN), prepare-commit-msg (embed schema diff)
+  .github/workflows/
+    pr.yml                                 ← schema diff + tests on every PR
+    merge.yml                              ← migrate parent on merge
+  .tdd/                                    ← lakebase-tdd-workflows scaffold (opt-out via --enable-tdd false)
+  README.md, .gitignore, package.json/pom.xml/pyproject.toml, ...
+```
+
+Eleven steps run in order: GitHub repo creation, repo-visibility wait, clone or git-init, Lakebase project creation, default-branch resolution, language scaffold (Spring Initializr for Java/Kotlin, static templates for Python/Node), CI secrets sync, self-hosted runner setup (or GitHub-hosted), initial commit + push, and a health check. The non-fatal steps (secrets sync, runner setup, hook verification) collect into a warnings list rather than aborting. Hard-fatal errors (GitHub repo creation, Lakebase project creation, git push) abort and roll nothing back — manual cleanup is on you.
+
+### 2. Branch lifecycle
+
+Once the project exists, every piece of feature work starts by cutting a paired branch. Git-side operations (`git branch`, `git checkout`) stay with you and your IDE; this is the matching Lakebase-side that gives the branch its own database.
+
+**Parent resolution.** When the agent creates a branch, it picks the parent in this order: an explicit override you specified ("branch from prod for this hotfix"), then a "branch I'm currently on" hint (git-like fork semantics), then the project's default branch (usually `production`). The "current branch" hint is ignored if it equals the target.
+
+**Names.** Whatever you call the branch in conversation gets sanitized to a Lakebase id — lowercase, alphanumeric + hyphens, 3–63 chars. The substrate accepts a uid, the sanitized name, or the full resource path interchangeably when looking the branch up later.
+
+**Idempotency.** Asking to create a branch that already exists returns the existing one unchanged. Deletion is not idempotent — asking to delete a branch that doesn't exist surfaces an error to you rather than silently succeeding.
+
+### 3. Endpoint + credential
+
+With a branch in hand, the next step is to connect to its database. The agent mints a Lakebase credential for that branch on demand — short-lived OAuth token, scoped to that branch only.
+
+When it needs a DSN string (for `psql`, Flyway, Alembic, etc.) it gets one shaped like `postgresql://...`. When it needs a connection pool from JS/TS code, it gets a `pg.Pool` with auto-refresh built in. When it needs raw endpoint metadata (host + provisioning state), it gets that without touching credentials.
+
+All of this funnels through one substrate helper — the single credential-minting seam — so a CI grep guard can detect any second code path trying to bypass it. You don't need to think about this; it just means there's exactly one place to look when credential issues arise.
+
+### 4. Schema introspection
+
+Once you're connected, you may want to see the current shape of the branch. The agent queries `information_schema` over the branch's DSN and returns the live tables and columns.
+
+Skips `flyway_schema_history` by default — that table is migration metadata, not schema content. Returns an empty list when the branch is still provisioning (the endpoint has no host yet); the agent polls until it's ready.
+
+### 5. Schema-diff
+
+When you're ready to share work, the agent compares your branch against its parent — the branch's `sourceBranchId` in Lakebase metadata — so a feature branch forked from `staging` diffs against `staging`, not against `production`. When the source can't be resolved, falls back to the project's default branch.
+
+The diff comes back as a structured summary: tables added / removed / modified, columns added / removed / type-changed, and an `inSync` boolean for the whole branch. You'd ask: "show me the diff" or "what changed since I forked." The `prepare-commit-msg` hook calls this automatically on a feature branch's first commit so the diff lands in the PR body for review.
+
+## How to use
+
+Four flows — shown as what you'd prompt your agent to do, using a running cart-checkout example (a project called `proj-checkout`, branch `feature-add-orders`). The bins listed in the CLI cheat sheet are also valid direct entry points; the prompts here are how you'd ask without remembering flags.
+
+### 1. Bootstrap a new Lakebase-paired project
+
+> "Create a new Lakebase-paired project called `proj-checkout` for the checkout flow. Use Java, a self-hosted runner, my GitHub org `my-org`, and the Databricks workspace at `https://<workspace>.cloud.databricks.com`."
+
+The agent runs `lakebase-create-project` under the hood. When it returns you have a GitHub repo at `my-org/proj-checkout`, a Lakebase project with `production` as the default branch, a local clone with the language scaffold, `.github/workflows/{pr,merge}.yml`, `.githooks/` (post-checkout + prepare-commit-msg), `.env.example`, and `.tdd/` (the TDD workflow scaffold). Initial commit pushed, CI auth secrets synced, runner registered.
+
+Add "skip the .tdd scaffold" to the prompt to opt out for projects that won't use `lakebase-tdd-workflows`.
+
+### 2. Cut a feature branch and inspect schema-diff against the parent
+
+> "Cut a Lakebase feature branch off `staging` called `feature-add-orders`, switch git to it, apply the new migration at `db/migrations/V003__add_orders.sql`, and show me the schema diff against staging."
+
+The agent cuts the paired Lakebase branch, runs `git checkout -b feature-add-orders` (the post-checkout hook refreshes `.env`), pipes the migration through `lakebase-get-connection --output dsn`, and prints the diff from `lakebase-schema-diff`. The diff is JSON: tables added/removed/modified, columns added/removed/changed, an `inSync` boolean.
+
+### 3. Open a PR with the schema-diff embedded in the body
+
+> "Open a PR from `feature-add-orders` to `staging` for `my-org/proj-checkout` titled 'Add orders table'. Include the schema diff in the body."
+
+In most cases you don't even need to ask — the `prepare-commit-msg` hook (installed by `create-project`) already writes the schema diff into the first commit on a feature branch, so `gh pr create` or the GitHub UI picks it up automatically. The prompt above is for when you want the agent to do it programmatically (catching drift between PR-open and PR-merge by re-running the diff is the job of CI's `pr.yml`).
+
+### 4. Recover when a checkout left the DSN pointing at the wrong branch
+
+Happens when the post-checkout hook is missing, disabled, or you switched branches outside git (e.g. via an IDE that skipped hooks). The DSN in `.env` still points at the previous branch.
+
+> "My `.env` DSN looks stale — refresh it to point at the Lakebase branch matching the git branch I'm currently on."
+
+The agent reads the current git branch, calls `lakebase-get-connection --output dsn --write-env` for that branch, and confirms the new `DATABASE_URL`. If you hit this often, ask: "Reinstall the git hooks" — that runs `bash .githooks/install.sh`.
+
+## CLI cheat sheet
+
+| Bin | Purpose |
+|---|---|
+| `lakebase-create-project` | End-to-end Lakebase + GitHub project bootstrap (see flow 1). |
+| `lakebase-get-connection` | Mint a DSN string (`--output dsn`) or pg.Pool (`--output pool`) against any branch. Add `--write-env` to refresh `.env`. |
+| `lakebase-schema-diff` | Parent-aware schema diff between any branch and its parent (or a comparison override). |
+| `lakebase-github-token` | Resolve the GitHub token via the same auth chain CI uses. Useful for debugging permission issues. |
+| `lakebase-migrate` | Apply / rollback / status / list schema migrations against a branch. |
+| `lakebase-mcp-server` | Stdio MCP server exposing every script as an MCP tool — for Claude Desktop / OpenAI Codex consumers. |
+
+## Composition
+
+- **TDD on Lakebase-paired projects**: paired with [`lakebase-tdd-workflows`](../lakebase-tdd-workflows/README.md). This skill owns branch + schema + PR plumbing; TDD-workflows layers experiment / cycle / synthesis on top.
+- **Inside VS Code/Cursor**: the [`lakebase-scm-extension`](https://github.com/databricks-solutions/lakebase-scm-extension) consumes the same substrate via npm dep — same operations, different presentation layer.

--- a/skills/lakebase-scm-workflows/SKILL.md
+++ b/skills/lakebase-scm-workflows/SKILL.md
@@ -7,45 +7,21 @@ metadata:
 parent: databricks-lakebase
 ---
 
-# Lakebase SCM Workflows
+# lakebase-scm-workflows — agent contract
 
-Opinionated git-to-Lakebase branch-pairing workflow operations. Agent surface for the same Node.js scripts that the [`databricks-solutions/lakebase-scm-extension`](https://github.com/databricks-solutions/lakebase-scm-extension) calls from its VS Code/Cursor commands. One canonical executable surface, two presentation layers.
+Agent-facing contract: operating rules (`.env`, git hooks, credential single-seam), concrete code patterns for each substrate primitive, and reference pointers.
 
-**FIRST**: Use the parent `databricks-lakebase` skill for Lakebase Postgres CLI basics (project creation, branch concepts, connectivity). This skill composes on top of it – it does not shadow the dev-hub Lakebase skill.
+For the human-facing overview (prerequisites, installation, prompts, journey, CLI cheat sheet) see [`README.md`](README.md).
 
-## Prerequisites
+**FIRST**: load the parent `databricks-lakebase` skill for Lakebase Postgres CLI basics (project / branch / endpoint shapes, name formats, "never delete the production branch" rule). This skill composes on top of it.
 
-The control plane and data plane are owned by other Databricks artifacts. Install/configure them once before using this skill:
+## Project state — when `.env` matters
 
-- `databricks postgres ...` CLI – documented by the dev-hub skill [`databricks-lakebase`](https://github.com/databricks/databricks-agent-skills). Install via `databricks aitools install databricks-lakebase`.
-- `@databricks/lakebase` npm package – drop-in `pg.Pool` with OAuth refresh.
-- `@databricks/appkit` npm package – Lakebase plugin and OBO (`asUser(req)`).
-
-## Installing the substrate
-
-For agent use (running `node scripts/lakebase/<verb>.js` directly), clone this repo and run `npm install`. The `prepare` script builds `dist/` on install.
-
-For a JS/TS host (extension, Node service) that imports substrate functions, depend on this repo via a git URL until the npm-publish path settles:
-
-```jsonc
-// host package.json
-"dependencies": {
-  "@databricks-solutions/lakebase-app-dev-kit":
-    "github:databricks-solutions/lakebase-app-dev-kit#<commit-sha-or-tag>"
-}
-```
-
-Pin to a sha. `prepare` builds `dist/` on install so consumers can import from the package name.
-
-## Project state – when `.env` matters
-
-The substrate API takes explicit args (`instance`, `branch`, etc.) on every public function – agents can drive every operation without a project `.env` at all. **But** when an agent is acting AS the developer in a checked-out paired project, the project's `.env` is the source of truth for "which Lakebase branch is this workspace currently paired with."
-
-**Two modes:**
+The substrate API takes explicit args (`instance`, `branch`, etc.) on every public function — agents can drive every operation without a project `.env` at all. **But** when an agent is acting AS the developer in a checked-out paired project, the project's `.env` is the source of truth for "which Lakebase branch is this workspace currently paired with."
 
 | Agent context | `.env` contract |
 |---|---|
-| In a checked-out paired project (Claude Code / Cursor / Genie Code on a developer's machine) | **Respect it.** Read `LAKEBASE_PROJECT_ID` to derive `instance`. After `git checkout`, call `syncEnvToCurrentBranch({ cwd })` so `.env` matches the new branch – otherwise the bundled CI scripts (`refresh-token.sh`, `flyway-migrate.sh`) and the git hooks operate on stale credentials. |
+| In a checked-out paired project (Claude Code / Cursor / Genie Code on a developer's machine) | **Respect it.** Read `LAKEBASE_PROJECT_ID` to derive `instance`. After `git checkout`, call `syncEnvToCurrentBranch({ cwd })` so `.env` matches the new branch — otherwise the bundled CI scripts (`refresh-token.sh`, `flyway-migrate.sh`) and the git hooks operate on stale credentials. |
 | Sandbox / no workspace (Claude Desktop, OpenAI Agent Builder, exploratory) | **Ignore it.** Pass `instance` and `branch` explicitly per call. Substrate never requires `.env`. |
 | Bootstrapping a new project | **N/A.** `createProject` creates the `.env` for you as step 7. No `.env` exists before that. |
 
@@ -69,7 +45,7 @@ LAKEBASE_PROJECT_ID=my-app
 
 If you're an agent dropping into a project mid-session, read these first to know what `instance` to pass to every subsequent operation.
 
-## Sync without an IDE – the git hooks
+## Sync without an IDE — the git hooks
 
 The construct that keeps a Lakebase branch and a git branch in sync in a plain terminal session (no extension, no explicit substrate call) is the **bundled git hooks** that `scaffoldAll` / `installHooks` drops into `.git/hooks/` during project bootstrap. They are the default-on automatic sync mechanism. Agents driving raw `git` commands inherit them for free.
 
@@ -77,37 +53,35 @@ The construct that keeps a Lakebase branch and a git branch in sync in a plain t
 |---|---|---|
 | `post-checkout` | `git checkout <branch>` | Reads new current branch → finds matching Lakebase branch → mints fresh credential → rewrites `.env` connection block. **The primary sync mechanism.** |
 | `post-merge` | `git merge` | Runs Flyway migrations against the now-current Lakebase branch so schema catches up. |
-| `pre-push` | `git push` | Schema-diff guard – surfaces unmigrated changes before remote sees them. |
+| `pre-push` | `git push` | Schema-diff guard — surfaces unmigrated changes before remote sees them. |
 | `prepare-commit-msg` | `git commit` | Embeds Lakebase branch context in commit messages so the schema-diff CI workflow can find them. |
 
 **Practical implications for an agent:**
 
-1. **Don't fight the hooks.** If you run `git checkout feature-x` in a paired project, `.env` auto-updates. Don't also call `syncEnvToCurrentBranch` defensively – let the hook own that side of the workflow.
+1. **Don't fight the hooks.** If you run `git checkout feature-x` in a paired project, `.env` auto-updates. Don't also call `syncEnvToCurrentBranch` defensively — let the hook own that side of the workflow.
+2. **Hooks don't create branches.** They sync state after-the-fact. To CREATE a Lakebase branch (which has no git equivalent), use the substrate's `createPairedBranch` — it creates the Lakebase side first, then `git checkout -b` triggers the hook to populate credentials.
+3. **If hooks aren't installed, re-arm them.** Some workflows clone a paired project without scaffolding (e.g. cloning someone else's checkout). The substrate's `installHooks(projectDir)` is the recovery — copies `scripts/post-checkout.sh` and siblings into `.git/hooks/` with the right permissions.
+4. **For pure-API sessions (no checkout) the hooks are irrelevant.** A Claude Desktop sandbox or OpenAI Agent Builder session that just calls `getConnection({ instance, branch })` doesn't have a `.git/` to install hooks into — and doesn't need them. The hooks only matter when an agent (or human) is driving a working tree with `git` commands.
 
-2. **Hooks don't create branches.** They sync state after-the-fact. To CREATE a Lakebase branch (which has no git equivalent), use the substrate's `createPairedBranch` – it creates the Lakebase side first, then `git checkout -b` triggers the hook to populate credentials.
+The bundled hook scripts live in `templates/project/common/scripts/`.
 
-3. **If hooks aren't installed, re-arm them.** Some workflows clone a paired project without scaffolding (e.g. cloning someone else's checkout). The substrate's `installHooks(projectDir)` is the recovery – copies `scripts/post-checkout.sh` and siblings into `.git/hooks/` with the right permissions.
+## Credential handoff — two helpers, one pattern
 
-4. **For pure-API sessions (no checkout) the hooks are irrelevant.** A Claude Desktop sandbox or OpenAI Agent Builder session that just calls `getConnection({ instance, branch })` doesn't have a `.git/` to install hooks into – and doesn't need them. The hooks only matter when an agent (or human) is driving a working tree with `git` commands.
-
-The bundled hook scripts live in `templates/project/common/scripts/` if you want to inspect or extend them.
-
-## Credential handoff – two helpers, one pattern
-
-Two narrow auth seams – one for Lakebase, one for GitHub. Both follow the same shape: single module, dynamic-runtime fallback chain, CI grep guard preventing any other file from resolving credentials directly.
+Two narrow auth seams — one for Lakebase, one for GitHub. Both follow the same shape: single module, dynamic-runtime fallback chain, CI grep guard preventing any other file from resolving credentials directly.
 
 ### GitHub
 
 ```bash
 lakebase-github-token                 # print token to stdout
 lakebase-github-token --diagnose      # which sources are configured
+```
 
-# JS callers:
-const { resolveGitHubToken } = require('@databricks-solutions/lakebase-app-dev-kit');
+```ts
+import { resolveGitHubToken } from "@databricks-solutions/lakebase-app-dev-kit";
 const token = await resolveGitHubToken();
 ```
 
-Fallback: `GITHUB_TOKEN` env → VS Code `getSession` (extension host only, via dynamic `import('vscode')`) → `gh auth token` → clear error. Scopes: `['repo', 'workflow', 'delete_repo']`. Full docs: [references/github-auth.md](references/github-auth.md).
+Fallback: `GITHUB_TOKEN` env → VS Code `getSession` (extension host only, via dynamic `import('vscode')`) → `gh auth token` → clear error. Scopes: `['repo', 'workflow', 'delete_repo']`. Full docs: [`references/github-auth.md`](references/github-auth.md).
 
 ### Lakebase
 
@@ -116,132 +90,212 @@ Every workflow op that touches Lakebase resolves credentials through a single se
 ```bash
 lakebase-get-connection --output dsn --instance <id> --branch <name>
 # -> libpq URL string (use for Flyway, Alembic, psql)
-
-# from JS:
-const { getConnection } = require('@databricks-solutions/lakebase-app-dev-kit');
-const pool = await getConnection({ output: 'pool', instance, branch });
-# -> @databricks/lakebase pg.Pool with refresh-on-connect
 ```
 
-DSN and Pool resolve to the same database via the same OAuth substrate. Never call `databricks postgres generate-database-credential` from anywhere else in your code – there is a CI grep guard that fails the build if you do. Full docs: [references/get-connection.md](references/get-connection.md).
+```ts
+import { getConnection } from "@databricks-solutions/lakebase-app-dev-kit";
+const pool = await getConnection({ output: "pool", instance, branch });
+// -> @databricks/lakebase pg.Pool with refresh-on-connect
+```
+
+DSN and Pool resolve to the same database via the same OAuth substrate. Never call `databricks postgres generate-database-credential` from anywhere else in your code — a CI grep guard fails the build if you do. Full docs: [`references/get-connection.md`](references/get-connection.md).
 
 ## Operations
 
-Each operation is a CLI bin invocation that returns JSON on stdout. JS callers can import the same functions from the package.
-
-
-- `create-project` – bootstrap a fresh Lakebase-paired project
-- `schema-diff` – parent-aware diff between two Lakebase branches
-- `branch-create` / `branch-delete` – Lakebase branch lifecycle
-- `create-paired-branch` / `delete-paired-branch` / `checkout-paired` / `sync-env-to-current-branch` – paired ops that keep git + Lakebase + .env in lockstep
-- `get-endpoint` / `ensure-endpoint` / `get-credential` – branch endpoint + raw token/email
-- `query-branch-schema` / `query-branch-tables` – live pg introspection
-- `get-project-info` – project metadata (uid, display name, state)
-- `create-pull-request` / `get-pull-request` / `merge-pull-request` / `merge-paired-pull-request` – PR flow
-- `get-pull-request-reviews` / `get-pull-request-files` / `get-pull-request-comments` / `list-issue-comments` / `list-workflow-runs` – PR introspection
-
-## Under the covers
-
-These sections describe what the substrate does on your behalf. You don't invoke these primitives directly — the agent does, in response to the prompts in [How to use](#how-to-use). The exception is `create-project`, which is a one-shot bootstrap you can also run yourself via the `lakebase-create-project` bin (see the CLI cheat sheet).
+Concrete invocations per primitive, in user-journey order. The agent reads these to know what to call; humans see the conversational equivalent in [`README.md`'s "How to use"](README.md#how-to-use).
 
 ### 1. Create-project
 
-End-to-end project bootstrap — the first thing you'll touch. This is the one operation you may also run yourself via the `lakebase-create-project` bin; the agent prompt in [How to use](#how-to-use) flow 1 is the conversational equivalent.
+End-to-end project bootstrap.
 
-When create-project finishes you get a scaffolded layout shaped like:
+```bash
+lakebase-create-project \
+  --project-name proj-checkout \
+  --parent-dir ~/code \
+  --databricks-host https://workspace.cloud.databricks.com \
+  --github-owner my-org \
+  --language java \
+  --runner self-hosted
+# -> JSON on stdout: { projectDir, githubRepoUrl, lakebaseProjectId, lakebaseDefaultBranch, warnings }
 
+# Local-only (no GitHub side effects):
+lakebase-create-project --project-name proj-checkout --parent-dir ~/code \
+  --databricks-host https://workspace.cloud.databricks.com --no-github
 ```
-~/code/proj-checkout/                      ← local clone (parent dir is your choice)
-  src/                                     ← language-specific scaffold (Java/Kotlin/Python/Node)
-  db/migrations/                           ← Flyway / Alembic migrations land here
-  .env.example                             ← committed; .env never is
-  .githooks/                               ← post-checkout (refresh DSN), prepare-commit-msg (embed schema diff)
-  .github/workflows/
-    pr.yml                                 ← schema diff + tests on every PR
-    merge.yml                              ← migrate parent on merge
-  .tdd/                                    ← lakebase-tdd-workflows scaffold (opt-out via --enable-tdd false)
-  README.md, .gitignore, package.json/pom.xml/pyproject.toml, ...
+
+```ts
+import { createProject } from "@databricks-solutions/lakebase-app-dev-kit";
+const result = await createProject({
+  projectName: "proj-checkout",
+  parentDir: process.env.HOME + "/code",
+  databricksHost: "https://workspace.cloud.databricks.com",
+  githubOwner: "my-org",
+  language: "java",
+  runnerType: "self-hosted",
+  enableTdd: true,                // default: true — lays down .tdd/ scaffold
+});
 ```
 
-Eleven steps run in order: GitHub repo creation, repo-visibility wait, clone or git-init, Lakebase project creation, default-branch resolution, language scaffold (Spring Initializr for Java/Kotlin, static templates for Python/Node), CI secrets sync, self-hosted runner setup (or GitHub-hosted), initial commit + push, and a health check. The non-fatal steps (secrets sync, runner setup, hook verification) collect into a warnings list rather than aborting. Hard-fatal errors (GitHub repo creation, Lakebase project creation, git push) abort and roll nothing back — manual cleanup is on you.
+Eleven-step orchestration. Non-fatal failures (CI secrets sync, runner setup, hook/workflow verification) land in `result.warnings[]`. Hard-fatal errors (input validation, GitHub repo creation, Lakebase project creation, git operations, push rejection on workflow scope) throw.
 
 ### 2. Branch lifecycle
 
-Once the project exists, every piece of feature work starts by cutting a paired branch. Git-side operations (`git branch`, `git checkout`) stay with you and your IDE; this is the matching Lakebase-side that gives the branch its own database.
+Lakebase branch CRUD. Git-side operations stay with the caller; these scripts handle the paired Lakebase side.
 
-**Parent resolution.** When the agent creates a branch, it picks the parent in this order: an explicit override you specified ("branch from prod for this hotfix"), then a "branch I'm currently on" hint (git-like fork semantics), then the project's default branch (usually `production`). The "current branch" hint is ignored if it equals the target.
+```bash
+# Create a paired Lakebase branch — parent resolves from explicit override,
+# then "branch I'm currently on" hint, then project default.
+node scripts/lakebase/branch-create.js \
+  --instance proj-checkout --branch feature-add-orders \
+  [--parent staging] [--current main]
+# -> { uid, name, state: "READY", sourceBranchName, isDefault }
 
-**Names.** Whatever you call the branch in conversation gets sanitized to a Lakebase id — lowercase, alphanumeric + hyphens, 3–63 chars. The substrate accepts a uid, the sanitized name, or the full resource path interchangeably when looking the branch up later.
+node scripts/lakebase/branch-delete.js --instance proj-checkout --branch feature-add-orders
+```
 
-**Idempotency.** Asking to create a branch that already exists returns the existing one unchanged. Deletion is not idempotent — asking to delete a branch that doesn't exist surfaces an error to you rather than silently succeeding.
+```ts
+import { createBranch, waitForBranchReady, deleteBranch }
+  from "@databricks-solutions/lakebase-app-dev-kit";
+
+const branch = await createBranch({
+  instance: "proj-checkout",
+  branch: "feature-add-orders",     // sanitized to Lakebase id (lowercase, alphanumeric+hyphen, 3-63 chars)
+  parentBranch: "staging",            // optional — overrides "current" hint and default
+  currentBranch: "main",              // optional — git-like "fork from current" semantics
+  timeoutMs: 120_000,                 // default: 2min poll budget
+});
+
+await deleteBranch({ instance: "proj-checkout", branch: branch.uid });
+```
+
+**Parent resolution precedence:**
+1. `parentBranch` arg (explicit override — "branch from prod" / "branch from staging" hotfix)
+2. `currentBranch` arg (git-like "fork from the branch you're on") — skipped if it equals the target
+3. Project default branch (usually `production`)
+
+**Idempotency.** `createBranch` returns the existing branch unchanged if one with the same sanitized name already exists. Delete is NOT idempotent — throws when the branch isn't found.
 
 ### 3. Endpoint + credential
 
-With a branch in hand, the next step is to connect to its database. The agent mints a Lakebase credential for that branch on demand — short-lived OAuth token, scoped to that branch only.
+```bash
+lakebase-get-connection --output dsn --instance proj-checkout --branch feature-add-orders
+# -> postgresql://... DSN
 
-When it needs a DSN string (for `psql`, Flyway, Alembic, etc.) it gets one shaped like `postgresql://...`. When it needs a connection pool from JS/TS code, it gets a `pg.Pool` with auto-refresh built in. When it needs raw endpoint metadata (host + provisioning state), it gets that without touching credentials.
+lakebase-get-connection --output dsn --instance proj-checkout --branch feature-add-orders --write-env
+# -> Same DSN, but also rewrites .env DATABASE_URL block (recovery from broken post-checkout hook)
+```
 
-All of this funnels through one substrate helper — the single credential-minting seam — so a CI grep guard can detect any second code path trying to bypass it. You don't need to think about this; it just means there's exactly one place to look when credential issues arise.
+```ts
+import { getConnection, getEndpoint, getCredential }
+  from "@databricks-solutions/lakebase-app-dev-kit";
+
+// DSN string (for Flyway, Alembic, psql):
+const { dsn } = await getConnection({ output: "dsn", instance, branch });
+
+// Connection pool with OAuth refresh:
+const pool = await getConnection({ output: "pool", instance, branch });
+
+// Just the endpoint metadata (host + state):
+const endpoint = await getEndpoint({ instance, branch });
+// -> { host: "instance-...", state: "ACTIVE" } | undefined
+
+// Just the raw token + email (resolves branch path, then mints via the single seam):
+const { token, email } = await getCredential({ instance, branch });
+```
 
 ### 4. Schema introspection
 
-Once you're connected, you may want to see the current shape of the branch. The agent queries `information_schema` over the branch's DSN and returns the live tables and columns.
+```bash
+node -e "import('@databricks-solutions/lakebase-app-dev-kit').then(m => m.queryBranchSchema({instance:'proj-checkout', branch:'feature-add-orders'}).then(r => console.log(JSON.stringify(r, null, 2))))"
+# -> [{ name: 'users', columns: [{ name: 'id', dataType: 'uuid' }, ...] }, ...]
+```
 
-Skips `flyway_schema_history` by default — that table is migration metadata, not schema content. Returns an empty list when the branch is still provisioning (the endpoint has no host yet); the agent polls until it's ready.
+```ts
+import { queryBranchSchema, queryBranchTables }
+  from "@databricks-solutions/lakebase-app-dev-kit";
+
+const schema = await queryBranchSchema({ instance, branch });
+const tables = await queryBranchTables({ instance, branch });
+```
+
+Skips `flyway_schema_history` by default. Returns `[]` when the endpoint has no host yet (branch still provisioning) — caller can poll.
 
 ### 5. Schema-diff
 
-When you're ready to share work, the agent compares your branch against its parent — the branch's `sourceBranchId` in Lakebase metadata — so a feature branch forked from `staging` diffs against `staging`, not against `production`. When the source can't be resolved, falls back to the project's default branch.
+Parent-aware schema diff between two Lakebase branches. Compares the target branch against its parent (the branch's `sourceBranchId` in Lakebase metadata) — for a feature forked from `staging`, that means diff vs `staging`, not vs `production`. Falls back to the project's default branch when the source can't be resolved.
 
-The diff comes back as a structured summary: tables added / removed / modified, columns added / removed / type-changed, and an `inSync` boolean for the whole branch. You'd ask: "show me the diff" or "what changed since I forked." The `prepare-commit-msg` hook calls this automatically on a feature branch's first commit so the diff lands in the PR body for review.
+```bash
+lakebase-schema-diff --instance proj-checkout --branch feature-add-orders
+# -> SchemaDiffResult JSON
 
-## How to use
+lakebase-schema-diff --instance proj-checkout --branch feature-add-orders --against staging --pretty
+```
 
-Four flows — shown as what you'd prompt your agent to do, using a running cart-checkout example (a project called `proj-checkout`, branch `feature-add-orders`). The bins listed in the CLI cheat sheet are also valid direct entry points; the prompts here are how you'd ask without remembering flags.
+```ts
+import { getSchemaDiff } from "@databricks-solutions/lakebase-app-dev-kit";
 
-### 1. Bootstrap a new Lakebase-paired project
+const diff = await getSchemaDiff({
+  instance: "proj-checkout",
+  branch: "feature-add-orders",
+  // against: "staging",   // optional pin; otherwise auto-resolves from sourceBranchId
+});
+```
 
-> "Create a new Lakebase-paired project called `proj-checkout` for the checkout flow. Use Java, a self-hosted runner, my GitHub org `my-org`, and the Databricks workspace at `https://<workspace>.cloud.databricks.com`."
+**Output shape** (matches the extension's modal data contract):
 
-The agent runs `lakebase-create-project` under the hood. When it returns you have a GitHub repo at `my-org/proj-checkout`, a Lakebase project with `production` as the default branch, a local clone with the language scaffold, `.github/workflows/{pr,merge}.yml`, `.githooks/` (post-checkout + prepare-commit-msg), `.env.example`, and `.tdd/` (the TDD workflow scaffold). Initial commit pushed, CI auth secrets synced, runner registered.
+```json
+{
+  "branchName": "feature-add-orders",
+  "comparisonBranchName": "staging",
+  "timestamp": "2026-05-22T...",
+  "migrations": [],
+  "created":  [{ "type": "TABLE", "name": "...", "columns": [...] }],
+  "modified": [
+    { "type": "TABLE", "name": "...",
+      "columns": [...], "addedColumns": [...], "removedColumns": [...],
+      "prodColumns": [...] }
+  ],
+  "removed": [...],
+  "branchTables": [...],
+  "inSync": false
+}
+```
 
-Add "skip the .tdd scaffold" to the prompt to opt out for projects that won't use `lakebase-tdd-workflows`.
+`migrations` is always empty in the script output — that's a workspace-file concern, not a Lakebase-side one. The extension layer fills it in locally when rendering. `prodColumns` is named for legacy modal compatibility; it carries the parent (comparison) columns regardless of whether the comparison target is production.
 
-### 2. Cut a feature branch and inspect schema-diff against the parent
+### PR flow
 
-> "Cut a Lakebase feature branch off `staging` called `feature-add-orders`, switch git to it, apply the new migration at `db/migrations/V003__add_orders.sql`, and show me the schema diff against staging."
+```ts
+import {
+  createPullRequest, getPullRequest, mergePullRequest, mergePairedPullRequest,
+  getPullRequestReviews, getPullRequestFiles, getPullRequestComments,
+} from "@databricks-solutions/lakebase-app-dev-kit";
 
-The agent cuts the paired Lakebase branch, runs `git checkout -b feature-add-orders` (the post-checkout hook refreshes `.env`), pipes the migration through `lakebase-get-connection --output dsn`, and prints the diff from `lakebase-schema-diff`. The diff is JSON: tables added/removed/modified, columns added/removed/changed, an `inSync` boolean.
+// Open a PR with the current branch's schema diff embedded in the body.
+const diff = await getSchemaDiff({ instance: "proj-checkout", branch: "feature-add-orders" });
+await createPullRequest({
+  owner: "my-org",
+  repo: "proj-checkout",
+  base: "staging",
+  head: "feature-add-orders",
+  title: "Add orders table",
+  body: [
+    "## Summary",
+    "Introduces the `orders` table to support the checkout flow.",
+    "",
+    "## Schema diff (vs staging)",
+    "```json",
+    JSON.stringify(diff, null, 2),
+    "```",
+  ].join("\n"),
+});
+```
 
-### 3. Open a PR with the schema-diff embedded in the body
+`mergePairedPullRequest` merges the git PR AND tears down the Lakebase feature branch in lockstep. Use it for clean post-merge state on paired projects.
 
-> "Open a PR from `feature-add-orders` to `staging` for `my-org/proj-checkout` titled 'Add orders table'. Include the schema diff in the body."
+## References
 
-In most cases you don't even need to ask — the `prepare-commit-msg` hook (installed by `create-project`) already writes the schema diff into the first commit on a feature branch, so `gh pr create` or the GitHub UI picks it up automatically. The prompt above is for when you want the agent to do it programmatically (catching drift between PR-open and PR-merge by re-running the diff is the job of CI's `pr.yml`).
-
-### 4. Recover when a checkout left the DSN pointing at the wrong branch
-
-Happens when the post-checkout hook is missing, disabled, or you switched branches outside git (e.g. via an IDE that skipped hooks). The DSN in `.env` still points at the previous branch.
-
-> "My `.env` DSN looks stale — refresh it to point at the Lakebase branch matching the git branch I'm currently on."
-
-The agent reads the current git branch, calls `lakebase-get-connection --output dsn --write-env` for that branch, and confirms the new `DATABASE_URL`. If you hit this often, ask: "Reinstall the git hooks" — that runs `bash .githooks/install.sh`.
-
-### CLI cheat sheet
-
-| Bin | Purpose |
-|---|---|
-| `lakebase-create-project` | End-to-end Lakebase + GitHub project bootstrap (see flow 1). |
-| `lakebase-get-connection` | Mint a DSN string (`--output dsn`) or pg.Pool (`--output pool`) against any branch. Add `--write-env` to refresh `.env`. |
-| `lakebase-schema-diff` | Parent-aware schema diff between any branch and its parent (or a comparison override). |
-| `lakebase-github-token` | Resolve the GitHub token via the same auth chain CI uses. Useful for debugging permission issues. |
-| `lakebase-migrate` | Apply / rollback / status / list schema migrations against a branch. |
-| `lakebase-mcp-server` | Stdio MCP server exposing every script as an MCP tool — for Claude Desktop / OpenAI Codex consumers. |
-
-## Composition
-
-- **TDD on Lakebase-paired projects**: paired with [`lakebase-tdd-workflows`](../lakebase-tdd-workflows/SKILL.md). This skill owns branch + schema + PR plumbing; TDD-workflows layers experiment / cycle / synthesis on top.
-- **Inside VS Code/Cursor**: the [`lakebase-scm-extension`](https://github.com/databricks-solutions/lakebase-scm-extension) consumes the same substrate via npm dep – same operations, different presentation layer.
-
-## See also
-
+- [`references/get-connection.md`](references/get-connection.md) — Lakebase credential seam (DSN + Pool, OAuth refresh, fallback chain).
+- [`references/github-auth.md`](references/github-auth.md) — GitHub token seam (env → VS Code session → `gh auth token`).
+- Parent skill: [`databricks-lakebase`](https://github.com/databricks/databricks-agent-skills) — Postgres CLI surface this skill composes on.
+- Sibling skill: [`../lakebase-tdd-workflows/SKILL.md`](../lakebase-tdd-workflows/SKILL.md) — TDD workflow on paired branches; consumes `createBranch`, `getSchemaDiff`, `getConnection` from this skill.

--- a/skills/lakebase-tdd-workflows/README.md
+++ b/skills/lakebase-tdd-workflows/README.md
@@ -1,0 +1,182 @@
+# lakebase-tdd-workflows
+
+Substrate for test-driven development on paired Lakebase branches. Canonical Beck-style RED → GREEN → REFACTOR composed with paired-branch primitives (cheap experiments, parent-aware schema diff, real per-branch databases) and HITL gates at every phase boundary.
+
+This README is the human-facing overview. The agent's operating contract — hard rules, function names, code patterns — lives in [`SKILL.md`](SKILL.md).
+
+## When to use
+
+- A new feature needs a spec authored, architected, and test-listed.
+- A feature needs cutting, running, and tearing down on a paired branch.
+- A TDD cycle (RED → GREEN → REFACTOR) needs running against a per-branch Lakebase DB.
+- Multiple parallel experiments need comparing and a winner promoted or synthesized.
+- Bad smells (test list drift, cycle stall, fragility) need detecting and surfacing to a Product Owner.
+
+## Lexicon
+
+| Term | Definition |
+|---|---|
+| **Feature** | A user-facing capability. Has stories with ACs. Lives on one feature branch. The default and most common mode of work. |
+| **AC** | Acceptance Criterion. One observable behavior. Tagged `[API]` / `[E2E]` / `[Infra]`. |
+| **Test list** | Beck's planning artifact. Ordered list of behavioral scenarios that define done. Lives at feature level. |
+| **Cycle** | One RED → GREEN → REFACTOR pass for a single test list item. |
+| **Spike** | Throwaway exploration on a Lakebase branch. No test list, no rigor. Goal: learn. Code is never promoted as-is. |
+| **Experiment** | A rigorous TDD branch — has a test list, runs cycles, ends with working code + tests. When N=1, the experiment IS the feature. The substrate uses "experiment" as the internal noun so the same primitives generalize to N≥2. |
+| **N=1 (the default — just a feature)** | One branch, iterative refinement. The branch IS the feature. No promote/synthesize ceremony, no compare report. This is what most work looks like. |
+| **N≥2 (parallel experiments)** | Deliberate race between competing strategies. Used when the design-spec gate finds opinion gaps the team genuinely wants to resolve by trying them. HITL chooses promote vs synthesize at the end. |
+| **Promote** | (N≥2 only) Take one experiment as-is into the feature PR. The losers are archived. |
+| **Synthesize** | (N≥2 only) PO menu-picks capabilities across experiments; spec is renegotiated; a fresh TDD cycle on a new branch produces the final code. |
+| **Bad smell** | A pattern the orchestrator detects that signals the workflow is sliding. Surfaces a proposed remediation to the HITL. |
+| **Adapter** | Pluggable component that syncs the spec format to/from an external tracker (JIRA, Linear, GitHub Issues, plain markdown). |
+
+The substrate API keeps "experiment" as the noun so the same primitives serve both N=1 and N≥2. When you're racing strategies you have experiments. Otherwise you have a feature.
+
+## Roles
+
+| Role | Responsibility | Agent prompt |
+|---|---|---|
+| **Spec Author** | Composes the initial draft spec — features, stories, ACs. | (Project skill, e.g. `/design`.) |
+| **Architect Reviewer** | Applies layering lens; populates `layer` and `architectural_notes` per AC; imports `software-design-principles`. | [`agents/architect-reviewer.md`](agents/architect-reviewer.md) |
+| **Test Strategist** | Converts annotated ACs into a Beck-style ordered test list; emits per-AC views. | [`agents/test-strategist.md`](agents/test-strategist.md) |
+| **Orchestrator (Scrum-Master)** | Runs design-spec gate; spawns experiments to budget; runs cycles; watches smells; presents outcomes to HITL. | [`agents/scrum-master.md`](agents/scrum-master.md) |
+| **Navigator** | PLAN, RED (writes failing tests), REVIEW. Never weakens an assertion. | [`agents/navigator.md`](agents/navigator.md) |
+| **Driver** | GREEN (minimal honest code), REFACTOR. Never deletes or weakens a test. | [`agents/driver.md`](agents/driver.md) |
+| **Product Owner / HITL** | Owns spec, ACs, test list ordering. Decides promote vs synthesize. Owns every gate. | The human. |
+
+## Phases and gates
+
+| Phase | Output | HITL gate |
+|---|---|---|
+| 0 Discovery | Draft `feature.{md,json}` + `story.{md,json}` + `ac.{md,json}` per AC | **Gate 1 — Draft spec** |
+| 1 Architectural review | Layer + architectural_notes populated; `architecture.md` summary | **Gate 2 — Architectural lens** |
+| 2 Test-list construction | Ordered `test-list.{md,json}` at feature level | **Gate 3 — Test list ordering** |
+| 3 Design-spec gate | Experiment plan in `selection-log.md` (N, strategies, budget) | **Gate 4 — Experiment plan** |
+| 4 Implementation | Per-experiment cycles producing tests + code | Continuous: smells; final: promote / synthesize choice |
+
+Each phase has a defined predecessor + artifact contract. The orchestrator refuses to transition if prior artifacts are missing or invalid.
+
+## Operations
+
+What the substrate does on your behalf, in user-journey order. You don't invoke these directly — the agent does, in response to the prompts in [How to use](#how-to-use).
+
+### 1. Design-spec gate
+
+Once the test list is approved (Gate 3), the agent runs the design-spec gate analyzer — phase 3. It scans the list for opinion-gap signals (keywords like "either", "consider", "alternatively", "decide", "TBD") and proposes either N=1 (iterative refinement) or N≥2 (parallel race), with strategies and a resource budget (concurrent branches, wall-clock minutes, agent-pair count).
+
+The proposal is conservative by design: the analyzer's job is to surface the choice to the PO, not to decide. The PO signs off at Gate 4. The plan and the decision are persisted here:
+
+```
+.tdd/
+  features/
+    F1-checkout/
+      plan.json                  ← { feature_id, N, mode, strategies[], budget, rationale }
+  selection-log.md               ← append-only HITL decision record (every gate)
+```
+
+### 2. Experiment
+
+With the plan approved, the agent cuts branches per the plan — one for N=1, multiple for N≥2 — and runs cycles against them in phase 4 (Implementation). Each experiment gets its own subdirectory:
+
+```
+.tdd/
+  experiments/
+    F1-checkout/
+      checkout/                  ← single experiment (N=1) — slug matches the feature
+        branch.txt               ← Lakebase branch id
+        notes.md                 ← strategy + learning notes
+        outcomes.json            ← { status, tests_passed, tests_failed, schema_diff_summary, ... }
+        timeline.json            ← per-cycle + smell history
+      exp-postgres-arrays/       ← parallel experiment (N≥2)
+        ...
+      exp-json-blob/
+        ...
+      _archive/                  ← losers from a promote decision land here
+        exp-json-blob/
+```
+
+Teardown is HITL-gated: the experiment record is preserved on disk by default even when the Lakebase branch is removed, so the learning survives. The orchestrator proposes deletions to the Product Owner; it never tears down unilaterally.
+
+### 3. Spike
+
+Side-mode for exploration that sits outside the main flow. No test list, no gates, no rigor. The agent runs this when you ask to "spike X" or "explore whether Y is possible" — typically before authoring a spec, to de-risk a choice you'll later put into the design-spec gate.
+
+```
+.tdd/
+  spikes/
+    explore-cart-storage/
+      branch.txt                 ← Lakebase branch id (often deleted shortly after)
+      notes.md                   ← learning that carries forward; survives branch teardown
+```
+
+The branch is deleted by default after notes are captured. **Spike code is never promoted into a TDD branch** — only the learning carries over.
+
+Before cutting any new experiment, the orchestrator checks the budget — at the concurrent-branch or wall-clock limit, it asks the PO to extend or stop, rather than cutting anyway.
+
+## How to use
+
+Three flows — shown as what you'd prompt your agent to do, using a cart-checkout example throughout. The agent reads [`SKILL.md`](SKILL.md) (plus the Scrum-Master / Navigator / Driver agent prompts) and runs the underlying substrate primitives on your behalf.
+
+The project-level slash commands `/design` and `/build` are the canonical entry points. They're thin wrappers that project skills install on top of this substrate — they handle project-specific concerns (JIRA hierarchy, IDE branch suggestions, manual review gates) and delegate the workflow facilitation here. If a slash command isn't installed in your project, just describe what you want to your agent directly; the prompts below work either way.
+
+### 1. Author a feature spec
+
+Just describe what you want to build. The design agent walks Spec Author → Architect Reviewer → Test Strategist and asks you to sign off at each HITL gate; you don't need to tell it about schemas, file layout, IDs, or which questions to ask — that's its job.
+
+> `/design`
+
+…or describe it freeform:
+
+> "I want to build a checkout flow. A shopper should be able to submit their cart and get back an order id with a 201. Empty carts should be rejected with a 400. There'll be more behaviors later (inventory checks, payment) but start with just place-order. Walk me through drafting the spec."
+
+When you're done, your `.tdd/features/F1-checkout/` tree has the feature, stories, ACs, architecture notes, and an ordered test list. If you'd rather author by hand, copy `templates/tdd-bootstrap/.tdd/` into your project and edit the files using [`references/spec-format.md`](references/spec-format.md) as the layout reference.
+
+### 2. Build a feature end-to-end (the N=1 default)
+
+The most common flow. One feature, one branch, iterative refinement. The branch IS the feature.
+
+> `/build F1-checkout`
+
+…or:
+
+> "Build the checkout feature."
+
+Scrum-Master picks up the approved spec, runs the design-spec gate (which proposes N=1 for work without opinion gaps), waits for your sign-off, cuts the feature branch off staging, and alternates Navigator + Driver per test list item. After every cycle it runs the smell detectors and pauses to surface any remediation to you. When the list is exhausted, the feature branch goes straight to PR — no promote/synthesize step.
+
+### 3. Race parallel experiments and either promote or synthesize (N≥2)
+
+When the team has a real opinion gap and wants to resolve it by trying competing strategies. You name the strategies; the agent runs them in parallel.
+
+> "Build the checkout feature, but I want to compare two ways of storing the cart — one as a Postgres array column on orders, one as a JSON blob on a separate carts table. Race them and let me pick a winner."
+
+Scrum-Master cuts a branch per strategy, runs the same test list through each, and at convergence presents the comparison report. It asks you to choose:
+
+- **Promote** — one experiment is the clear winner; take it as-is into the feature PR.
+- **Synthesize** — pick capabilities across the experiments (storage schema from one, API surface from the other), renegotiate the spec, and run a fresh cycle on a synthesized branch.
+- **Continue** — let cycles finish.
+- **Abandon all** — stalled population; re-run the design-spec gate.
+
+The `hitlApproved` flag on the promote and synthesize primitives is enforced at the function boundary, so the agent cannot skip this gate.
+
+### CLI cheat sheet
+
+For when you want to run something directly without the agent. Most TDD work goes through `/design` and `/build`; these are useful for debugging or one-off introspection.
+
+| Command | Purpose |
+|---|---|
+| `node scripts/tdd/spec-sync.js <tddDir>` | Walk the `.tdd/` tree and print drift reports. Exit 0 even when reports exist — warn-only by design. |
+| `node scripts/tdd/test-list.js <tddDir> <featureId>` | Regenerate per-AC views from the feature-level master test list. |
+| `bash tests/run_all.sh` (per scaffolded project) | Run every `validate_*.sh` in the project's `tests/` directory — the project's full validation suite. |
+
+## Project-level entry points
+
+- **`/design`** — wraps Spec Author + Architect Reviewer + Test Strategist phases. Project-specific JIRA hierarchy creation lives here.
+- **`/build`** — wraps Orchestrator. Project-specific PR/merge ceremony lives here.
+- **`/ship`** — lives in `lakebase-release-workflows`. Not part of this skill.
+
+Substrate ships no slash commands. It ships skills + agents + scripts + CLI bins. The MCP server (`apps/mcp-server/`) exposes the tool surface for MCP-capable consumers.
+
+## Integration with sibling skills
+
+- **[`lakebase-scm-workflows`](../lakebase-scm-workflows/README.md)** — `createFeatureBranch`, `deleteBranch`, `getSchemaDiff`, `getConnection`. Experiments and spikes are paired branches.
+- **`lakebase-release-workflows`** — Tier model (feature → staging → production), TTL, "never delete production." TDD defers to release-workflows for everything past PR merge.
+- **[`software-design-principles`](../software-design-principles/SKILL.md)** — Imported as canon by Architect Reviewer (layering + cross-cutting concerns) and Navigator (refactor heuristics).

--- a/skills/lakebase-tdd-workflows/SKILL.md
+++ b/skills/lakebase-tdd-workflows/SKILL.md
@@ -4,190 +4,11 @@ description: "Test-driven development against paired Lakebase branches. Canonica
 user-invocable: true
 ---
 
-# lakebase-tdd-workflows
+# lakebase-tdd-workflows — agent contract
 
-Substrate skill for test-driven development on paired Lakebase branches. The "workflows" suffix is load-bearing: this skill ships orchestration (handoff between roles, gated phase transitions, bad-smell monitoring), not just primitives.
+Agent-facing contract: hard rules, phase flow, agent prompt index, and concrete code patterns for the substrate primitives.
 
-## When to use
-
-- A new feature needs a spec authored, architected, and test-listed.
-- An experiment branch needs cutting, running, and tearing down.
-- A TDD cycle (RED → GREEN → REFACTOR) needs running against a per-branch Lakebase DB.
-- Multiple parallel experiments need comparing and a winner promoted or synthesized.
-- Bad smells (test list drift, cycle stall, fragility) need detecting and surfacing to a Product Owner.
-
-## What this skill ships
-
-- **Spec format**: portable MD + JSON layout under `.tdd/` (validated by JSON Schemas in `scripts/tdd/schemas/`).
-- **Primitives**: scripts under `scripts/tdd/` for spec sync, test-list transformation, experiment + spike branches, design-spec gate analysis, single-experiment cycle wrapper, multi-experiment comparison + synthesis, and a bad-smell catalog + detectors.
-- **Adapters**: `SpecAdapter` interface with `markdown.ts` (no-op default) + `jira.ts` (stub). Project skills wire in the adapter they want.
-- **Agent contracts**: per-role prompts under `agents/` for Architect Reviewer, Test Strategist, Navigator, Driver, Scrum-Master.
-- **References**: spec format, role contracts, hard rules under `references/`.
-
-## Lexicon
-
-| Term | Definition |
-|---|---|
-| **Feature** | A user-facing capability. Has stories with ACs. Lives on one feature branch. The default and most common mode of work. |
-| **AC** | Acceptance Criterion. One observable behavior. Tagged `[API]` / `[E2E]` / `[Infra]`. |
-| **Test list** | Beck's planning artifact. Ordered list of behavioral scenarios that define done. Lives at feature level. |
-| **Cycle** | One RED → GREEN → REFACTOR pass for a single test list item. |
-| **Spike** | Throwaway exploration on a Lakebase branch. No test list, no rigor. Goal: learn. Code is never promoted as-is. |
-| **Experiment** | A rigorous TDD branch — has a test list, runs cycles, ends with working code + tests. When N=1, the experiment IS the feature. The substrate uses "experiment" as the internal noun so the same primitives generalize to N≥2. |
-| **N=1 (the default — just a feature)** | One branch, iterative refinement. The branch IS the feature. No promote/synthesize ceremony, no compare report. This is what most work looks like. |
-| **N≥2 (parallel experiments)** | Deliberate race between competing strategies. Used when the design-spec gate finds opinion gaps the team genuinely wants to resolve by trying them. HITL chooses promote vs synthesize at the end. |
-| **Promote** | (N≥2 only) Take one experiment as-is into the feature PR. The losers are archived. |
-| **Synthesize** | (N≥2 only) PO menu-picks capabilities across experiments; spec is renegotiated; a fresh TDD cycle on a new branch produces the final code. |
-| **Bad smell** | A pattern the orchestrator detects that signals the workflow is sliding. Surfaces a proposed remediation to the HITL. |
-| **Adapter** | Pluggable component that syncs the spec format to/from an external tracker (JIRA, Linear, GitHub Issues, plain markdown). |
-
-The `cutExperiment` / `experimentSlug` substrate API keeps "experiment" as the noun so the same primitives serve both N=1 and N≥2. When you're racing strategies you have experiments. Otherwise you have a feature.
-
-## Roles (and their substrate-shipped contracts)
-
-| Role | Responsibility | Lives at |
-|---|---|---|
-| **Spec Author** | Composes the initial draft spec — features, stories, ACs. | (Project skill, e.g. `/design`.) |
-| **Architect Reviewer** | Applies layering lens; populates `layer` and `architectural_notes` per AC; imports `software-design-principles`. | `agents/architect-reviewer.md` |
-| **Test Strategist** | Converts annotated ACs into a Beck-style ordered test list; emits per-AC views. | `agents/test-strategist.md` |
-| **Orchestrator (Scrum-Master)** | Runs design-spec gate; spawns experiments to budget; runs cycles; watches smells; presents outcomes to HITL. | `agents/scrum-master.md` (M5) |
-| **Navigator** | PLAN, RED (writes failing tests), REVIEW. Never weakens an assertion. | `agents/navigator.md` (M3) |
-| **Driver** | GREEN (minimal honest code), REFACTOR. Never deletes or weakens a test. | `agents/driver.md` (M3) |
-| **Product Owner / HITL** | Owns spec, ACs, test list ordering. Decides promote vs synthesize. Owns every gate. | The human. |
-
-## Spec storage format
-
-See [references/spec-format.md](references/spec-format.md) for the full `.tdd/` directory layout and the markdown ↔ JSON contract. Schemas live in `scripts/tdd/schemas/`. Drift is detected (warn-only) by `scripts/tdd/spec-sync.ts`.
-
-## Phases and gates
-
-| Phase | Output | HITL gate |
-|---|---|---|
-| 0 Discovery | Draft `feature.{md,json}` + `story.{md,json}` + `ac.{md,json}` per AC | **Gate 1 — Draft spec** |
-| 1 Architectural review | Layer + architectural_notes populated; `architecture.md` summary | **Gate 2 — Architectural lens** |
-| 2 Test-list construction | Ordered `test-list.{md,json}` at feature level | **Gate 3 — Test list ordering** |
-| 3 Design-spec gate | Experiment plan in `selection-log.md` (N, strategies, budget) | **Gate 4 — Experiment plan** |
-| 4 Implementation | Per-experiment cycles producing tests + code | Continuous: smells; final: promote / synthesize choice |
-
-Each phase has a defined predecessor + artifact contract. The orchestrator refuses to transition if prior artifacts are missing or invalid.
-
-## Integration points
-
-- **`lakebase-scm-workflows`** — `createFeatureBranch`, `deleteBranch`, `getSchemaDiff`, `getConnection`. Experiments and spikes are paired branches.
-- **`lakebase-release-workflows`** — Tier model (feature → staging → production), TTL, "never delete production." TDD defers to release-workflows for everything past PR merge.
-- **`software-design-principles`** — Imported as canon by Architect Reviewer (layering + cross-cutting concerns) and Navigator (refactor heuristics).
-
-## Operations
-
-These sections describe what the substrate does on your behalf. You don't invoke them directly — the agent does, in response to the prompts in [How to use](#how-to-use).
-
-### 1. Design-spec gate
-
-Once the test list is approved (Gate 3), the agent runs the design-spec gate analyzer — phase 3. It scans the list for opinion-gap signals (keywords like "either", "consider", "alternatively", "decide", "TBD") and proposes either N=1 (iterative refinement) or N≥2 (parallel race), with strategies and a resource budget (concurrent branches, wall-clock minutes, agent-pair count).
-
-The proposal is conservative by design: the analyzer's job is to surface the choice to the PO, not to decide. The PO signs off at Gate 4. The plan and the decision are persisted here:
-
-```
-.tdd/
-  features/
-    F1-checkout/
-      plan.json                  ← { feature_id, N, mode, strategies[], budget, rationale }
-  selection-log.md               ← append-only HITL decision record (every gate)
-```
-
-### 2. Experiment
-
-With the plan approved, the agent cuts branches per the plan — one for N=1, multiple for N≥2 — and runs cycles against them in phase 4 (Implementation). Each experiment gets its own subdirectory:
-
-```
-.tdd/
-  experiments/
-    F1-checkout/
-      checkout/                  ← single experiment (N=1) — slug matches the feature
-        branch.txt               ← Lakebase branch id
-        notes.md                 ← strategy + learning notes
-        outcomes.json            ← { status, tests_passed, tests_failed, schema_diff_summary, ... }
-        timeline.json            ← per-cycle + smell history
-      exp-postgres-arrays/       ← parallel experiment (N≥2)
-        ...
-      exp-json-blob/
-        ...
-      _archive/                  ← losers from a promote decision land here
-        exp-json-blob/
-```
-
-Teardown is HITL-gated: the experiment record is preserved on disk by default even when the Lakebase branch is removed, so the learning survives. The orchestrator proposes deletions to the Product Owner; it never tears down unilaterally.
-
-### 3. Spike
-
-Side-mode for exploration that sits outside the main flow. No test list, no gates, no rigor. The agent runs this when you ask to "spike X" or "explore whether Y is possible" — typically before authoring a spec, to de-risk a choice you'll later put into the design-spec gate.
-
-```
-.tdd/
-  spikes/
-    explore-cart-storage/
-      branch.txt                 ← Lakebase branch id (often deleted shortly after)
-      notes.md                   ← learning that carries forward; survives branch teardown
-```
-
-The branch is deleted by default after notes are captured. **Spike code is never promoted into a TDD branch** — only the learning carries over.
-
-Before cutting any new experiment, the orchestrator checks the budget — at the concurrent-branch or wall-clock limit, it asks the PO to extend or stop, rather than cutting anyway.
-
-## How to use
-
-Three flows — shown as what you'd prompt your agent to do, using a cart-checkout example throughout. The agent reads this skill (plus the Scrum-Master / Navigator / Driver agent prompts) and runs the underlying substrate primitives on your behalf.
-
-The project-level slash commands `/design` and `/build` are the canonical entry points. They're thin wrappers that project skills install on top of this substrate — they handle project-specific concerns (JIRA hierarchy, Cursor branch suggestions, manual review gates) and delegate the workflow facilitation here. If a slash command isn't installed in your project, just describe what you want to your agent directly; the prompts below work either way.
-
-### 1. Author a feature spec
-
-Just describe what you want to build. The design agent walks Spec Author → Architect Reviewer → Test Strategist and asks you to sign off at each HITL gate; you don't need to tell it about schemas, file layout, IDs, or which questions to ask — that's its job.
-
-> `/design`
-
-…or describe it freeform:
-
-> "I want to build a checkout flow. A shopper should be able to submit their cart and get back an order id with a 201. Empty carts should be rejected with a 400. There'll be more behaviors later (inventory checks, payment) but start with just place-order. Walk me through drafting the spec."
-
-When you're done, your `.tdd/features/F1-checkout/` tree has the feature, stories, ACs, architecture notes, and an ordered test list. If you'd rather author by hand, copy `templates/tdd-bootstrap/.tdd/` into your project and edit the files using [`references/spec-format.md`](references/spec-format.md) as the layout reference.
-
-### 2. Build a feature end-to-end (the N=1 default)
-
-The most common flow. One feature, one branch, iterative refinement. The branch IS the feature.
-
-> `/build F1-checkout`
-
-…or:
-
-> "Build the checkout feature."
-
-Scrum-Master picks up the approved spec, runs the design-spec gate (which proposes N=1 for work without opinion gaps), waits for your sign-off, cuts the feature branch off staging, and alternates Navigator + Driver per test list item. After every cycle it runs the smell detectors and pauses to surface any remediation to you. When the list is exhausted, the feature branch goes straight to PR — no promote/synthesize step.
-
-### 3. Race parallel experiments and either promote or synthesize (N≥2)
-
-When the team has a real opinion gap and wants to resolve it by trying competing strategies. You name the strategies; the agent runs them in parallel.
-
-> "Build the checkout feature, but I want to compare two ways of storing the cart — one as a Postgres array column on orders, one as a JSON blob on a separate carts table. Race them and let me pick a winner."
-
-Scrum-Master cuts a branch per strategy, runs the same test list through each, and at convergence presents the comparison report. It asks you to choose:
-
-- **Promote** — one experiment is the clear winner; take it as-is into the feature PR.
-- **Synthesize** — pick capabilities across the experiments (storage schema from one, API surface from the other), renegotiate the spec, and run a fresh cycle on a synthesized branch.
-- **Continue** — let cycles finish.
-- **Abandon all** — stalled population; re-run the design-spec gate.
-
-The `hitlApproved` flag on the promote and synthesize primitives is enforced at the function boundary, so the agent cannot skip this gate.
-
-### CLI cheat sheet
-
-For when you want to run something directly without the agent. Most TDD work goes through `/design` and `/build`; these are useful for debugging or one-off introspection.
-
-| Command | Purpose |
-|---|---|
-| `node scripts/tdd/spec-sync.js <tddDir>` | Walk the `.tdd/` tree and print drift reports. Exit 0 even when reports exist — warn-only by design. |
-| `node scripts/tdd/test-list.js <tddDir> <featureId>` | Regenerate per-AC views from the feature-level master test list. |
-| `bash tests/run_all.sh` (per scaffolded project) | Run every `validate_*.sh` in the project's `tests/` directory — the project's full validation suite. |
+For the human-facing overview (lexicon, roles narrative, how-to-use prompts, project entry points) see [`README.md`](README.md).
 
 ## Hard rules
 
@@ -203,16 +24,365 @@ The contract every agent (Navigator, Driver, Orchestrator) and every human colla
 8. Spike code is throwaway. Promote nothing from a spike branch into a TDD branch except notes.
 9. N=1 mode is iterative refinement. There is no promote/synthesize ceremony — the branch IS the feature.
 
-See [agents/navigator.md](agents/navigator.md) and [agents/driver.md](agents/driver.md) for per-role specializations of these rules.
+See [`agents/navigator.md`](agents/navigator.md) and [`agents/driver.md`](agents/driver.md) for per-role specializations.
+
+## Phases and gates
+
+| Phase | Output | HITL gate |
+|---|---|---|
+| 0 Discovery | Draft `feature.{md,json}` + `story.{md,json}` + `ac.{md,json}` per AC | **Gate 1 — Draft spec** |
+| 1 Architectural review | `layer` + `architectural_notes` populated; `architecture.md` summary | **Gate 2 — Architectural lens** |
+| 2 Test-list construction | Ordered `test-list.{md,json}` at feature level | **Gate 3 — Test list ordering** |
+| 3 Design-spec gate | Experiment plan in `selection-log.md` + `features/<F>/plan.json` | **Gate 4 — Experiment plan** |
+| 4 Implementation | Per-experiment cycles producing tests + code | Continuous: smells; final: promote / synthesize choice |
+
+Refuse to transition if prior-phase artifacts are missing or invalid.
+
+## Agent prompts
+
+Load the per-role prompt for the phase you're in:
+
+- [`agents/architect-reviewer.md`](agents/architect-reviewer.md) — phase 1, populates `layer` and `architectural_notes`, imports `software-design-principles`.
+- [`agents/test-strategist.md`](agents/test-strategist.md) — phase 2, builds the Beck-style ordered test list.
+- [`agents/scrum-master.md`](agents/scrum-master.md) — phases 3 → 4, orchestrates the design-spec gate, spawns experiments, runs cycles, watches smells, surfaces to HITL.
+- [`agents/navigator.md`](agents/navigator.md) — phase 4 PLAN + RED + REVIEW.
+- [`agents/driver.md`](agents/driver.md) — phase 4 GREEN + REFACTOR.
+
+## References
+
+- [`references/spec-format.md`](references/spec-format.md) — full `.tdd/` directory layout + markdown ↔ JSON contract.
+- `scripts/tdd/schemas/` — JSON Schemas validated by `spec-sync.ts`.
+- [`../software-design-principles/SKILL.md`](../software-design-principles/SKILL.md) — engineering canon (SOLID, DRY, DTSTTCPW, layered architecture, cross-cutting concerns, NFRs). Required reading for Architect Reviewer and Navigator.
+
+## Operations
+
+Concrete invocations of the substrate primitives.
+
+### Design-spec gate (phase 3)
+
+```ts
+import { analyzeForGate, recordPlan, writePlan } from "@databricks-solutions/lakebase-app-dev-kit/tdd/design-spec-gate";
+import { canCutAnotherExperiment } from "@databricks-solutions/lakebase-app-dev-kit/tdd/budget";
+
+const analysis = analyzeForGate(".tdd", "F1");
+// analysis.opinion_gaps[]  — items the analyzer flagged as opinion gaps
+// analysis.proposed_plan   — { mode: "N=1" | "N>=2", N, strategies[], budget, rationale }
+
+// Surface to PO. On Gate 4 approval, persist:
+recordPlan(".tdd", analysis.proposed_plan, "kevin@example.com");
+writePlan(".tdd", analysis.proposed_plan);
+
+// Before cutting any experiment, check the budget:
+const ok = canCutAnotherExperiment(".tdd", "F1");
+if (!ok.ok) throw new Error(`budget: ${ok.reason}`);
+```
+
+### Experiment (phase 4)
+
+```ts
+import { cutExperiment, listExperiments, readOutcomes, writeOutcomes, deleteExperiment }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/experiment";
+
+// N=1 — slug matches the feature.
+const feature = await cutExperiment({
+  instance: "proj-checkout",
+  tddDir: ".tdd",
+  featureId: "F1",
+  experimentSlug: "checkout",       // N=1: slug = feature name
+  branch: "checkout",
+  parentBranch: "staging",
+});
+// feature.dir === ".tdd/experiments/F1/checkout"
+// Writes branch.txt, notes.md, outcomes.json (status: "running"), timeline.json.
+
+writeOutcomes(".tdd", "F1", "checkout", { status: "succeeded", tests_passed: 2 });
+
+// Teardown is HITL-gated. deleteBranchToo defaults to false — record survives.
+await deleteExperiment({
+  instance: "proj-checkout",
+  tddDir: ".tdd",
+  featureId: "F1",
+  experimentSlug: "checkout",
+  deleteBranchToo: false,
+});
+```
+
+### Spike (side-mode)
+
+```ts
+import { cutSpike, listSpikes, deleteSpike }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/spike";
+
+await cutSpike({
+  instance: "proj-checkout",
+  tddDir: ".tdd",
+  spikeSlug: "explore-cart-storage",
+  branch: "spike-explore-cart-storage",
+  parentBranch: "staging",
+});
+
+// Notes captured, branch deleted by default (throwaway).
+await deleteSpike({
+  instance: "proj-checkout",
+  tddDir: ".tdd",
+  spikeSlug: "explore-cart-storage",
+});
+// Notes preserved at .tdd/spikes/explore-cart-storage/notes.md.
+```
+
+### Cycle (RED → GREEN → REFACTOR)
+
+```ts
+import { beginCycle, markGreen, markRefactored, flagSmells, listCycles, openBranchDsn }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/run-cycle";
+
+const scope = {
+  tddDir: ".tdd",
+  feature_id: "F1",
+  story_id: "S1",
+  ac_id: "AC1",
+  experiment_slug: "checkout",
+  branch_id: "checkout",
+};
+
+// Open a DSN against the experiment's branch DB (no mocks).
+const dsn = await openBranchDsn({ instance: "proj-checkout", branch_id: "checkout" });
+
+// RED — Navigator writes a failing test, persists the cycle artifact.
+const c1 = beginCycle({
+  ...scope,
+  test_id: "T1",
+  test_description: "POST /orders returns 201 on valid cart",
+  navigator_plan: "force the public boundary to accept a Cart payload",
+});
+
+// GREEN — Driver returns and Navigator reviews.
+markGreen(scope, c1.cycle_id, "added POST handler + repository write");
+
+// Optional REFACTOR — Navigator requests, Driver applies, no outer-boundary test changes.
+markRefactored(scope, c1.cycle_id, "extracted CartRepository");
+
+// Navigator-flagged smells (Hard Rule 1, 4 violations).
+flagSmells(scope, c1.cycle_id, ["test-deletion-attempt"]);
+```
+
+### Smells (after every cycle)
+
+```ts
+import { runDetectorsForScope, writeSmellsLog, readSmellsLog, SMELL_CATALOG }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/smells";
+
+const hits = runDetectorsForScope(".tdd", scope);
+if (hits.length) {
+  writeSmellsLog(".tdd", hits);
+  // Surface each hit + the SMELL_CATALOG remediation to the PO.
+  // Never auto-apply remediations.
+}
+```
+
+### Compare (N≥2 convergence)
+
+```ts
+import { compareExperiments }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/compare-experiments";
+
+const report = compareExperiments(".tdd", "F1");
+// report.rows[].signal       — "winning" | "stalled" | "abandoned" | "running" | "unknown"
+// report.recommendation      — "promote" | "synthesize" | "continue" | "abandon-all"
+// report.rationale           — short explanation surfaced to the PO
+```
+
+### Promote (N≥2, single winner)
+
+```ts
+import { promoteExperiment }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/promote-experiment";
+
+// Refuses to run without hitlApproved: true (PO gate enforced at the function boundary).
+const result = promoteExperiment({
+  tddDir: ".tdd",
+  featureId: "F1",
+  winnerSlug: "exp-postgres-arrays",
+  hitlApproved: true,
+  approverEmail: "kevin@example.com",
+});
+// Winner outcome: status "succeeded". Losers: outcome "abandoned", dirs moved to _archive/.
+// feature.json transitions to "ready-for-review". Appends to selection-log.md.
+```
+
+### Synthesize (N≥2, menu-pick)
+
+```ts
+import { synthesizeExperiments }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/synthesis";
+
+// Refuses to run without hitlApproved: true.
+const result = await synthesizeExperiments({
+  instance: "proj-checkout",
+  tddDir: ".tdd",
+  featureId: "F1",
+  picks: [
+    { source_slug: "exp-postgres-arrays", capability: "storage schema" },
+    { source_slug: "exp-json-blob",       capability: "API surface" },
+  ],
+  synthesizedSlug: "exp-synth",
+  branch: "checkout-synth",
+  parentBranch: "staging",
+  hitlApproved: true,
+  approverEmail: "kevin@example.com",
+});
+// Writes synthesis/<F>/synthesis-<date>.md decision record + synthesized-spec/ subtree.
+// Cuts the synthesized branch. Appends to selection-log.md.
+```
+
+### Spec sync (drift detection)
+
+```ts
+import { validateSpec, readFeature, writeFeature, readWorkflowState, writeWorkflowState }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/spec-sync";
+
+const drift = validateSpec(".tdd");
+// drift[].kind — "schema" | "pair-missing" | "narrative-empty" | "id-mismatch"
+// Warn-only; do not auto-correct narrative drift.
+```
+
+### Test list transformation
+
+```ts
+import { readMasterTestList, writeMasterTestList, viewByAc, viewsForAllAcs, writePerAcViews }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/test-list";
+
+const list = readMasterTestList(".tdd", "F1");
+writePerAcViews(".tdd", "F1", list);
+// Emits .tdd/features/<F>/stories/<S>/test-list-per-ac.json under each story dir.
+```
+
+## Flow patterns
+
+End-to-end orchestrator patterns the Scrum-Master agent runs in response to `/design` and `/build`. Each flow is what the agent assembles from the primitives above; the human-facing prompts that trigger each flow live in [`README.md`](README.md).
+
+### Author + validate spec (response to `/design`)
+
+```ts
+import { writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { validateSpec } from "@databricks-solutions/lakebase-app-dev-kit/tdd/spec-sync";
+
+const tdd = ".tdd";
+const fdir = join(tdd, "features", "F1-checkout");
+const sdir = join(fdir, "stories", "S1-place-order");
+mkdirSync(join(sdir, "acs"), { recursive: true });
+
+writeFileSync(join(fdir, "feature.json"), JSON.stringify({
+  id: "F1", name: "Checkout flow", status: "draft", tdd_mode: "N=1", stories: ["S1"],
+}));
+writeFileSync(join(fdir, "feature.md"), "# Checkout flow\n\nDesign intent.\n");
+
+writeFileSync(join(sdir, "story.json"), JSON.stringify({
+  id: "S1", asA: "shopper", iWantTo: "place an order",
+  soThat: "I receive the goods", feature_id: "F1",
+}));
+writeFileSync(join(sdir, "story.md"), "# Place order\n\nNarrative.\n");
+
+writeFileSync(join(sdir, "acs", "AC1.json"), JSON.stringify({
+  id: "AC1", layer: "API", given: "valid cart", when: "POST /orders",
+  then: "201 with order id", status: "draft", story_id: "S1",
+}));
+writeFileSync(join(sdir, "acs", "AC1.md"), "# AC1\n\nAC narrative.\n");
+
+const drift = validateSpec(tdd);
+if (drift.length) console.warn(drift);
+```
+
+### N=1 cycle end-to-end (response to `/build`, simple case)
+
+```ts
+import { writeMasterTestList } from "@databricks-solutions/lakebase-app-dev-kit/tdd/test-list";
+import { analyzeForGate, writePlan, recordPlan } from "@databricks-solutions/lakebase-app-dev-kit/tdd/design-spec-gate";
+import { cutExperiment, writeOutcomes } from "@databricks-solutions/lakebase-app-dev-kit/tdd/experiment";
+import { beginCycle, markGreen } from "@databricks-solutions/lakebase-app-dev-kit/tdd/run-cycle";
+import { runDetectorsForScope, writeSmellsLog } from "@databricks-solutions/lakebase-app-dev-kit/tdd/smells";
+
+const tdd = ".tdd"; const featureId = "F1";
+
+writeMasterTestList(tdd, { feature_id: featureId, ordered_for: "design-momentum", items: [
+  { id: "T1", description: "POST /orders returns 201 on valid cart", ac_id: "AC1", status: "pending" },
+  { id: "T2", description: "POST /orders rejects empty cart with 400", ac_id: "AC1", status: "pending" },
+]});
+
+const analysis = analyzeForGate(tdd, featureId);   // -> { mode: "N=1", N: 1, ... }
+recordPlan(tdd, analysis.proposed_plan, "kevin@example.com");
+writePlan(tdd, analysis.proposed_plan);
+
+const feature = await cutExperiment({
+  instance: "proj-checkout", tddDir: tdd,
+  featureId, experimentSlug: "checkout", branch: "checkout", parentBranch: "staging",
+});
+
+const scope = { tddDir: tdd, feature_id: featureId, story_id: "S1", ac_id: "AC1",
+                experiment_slug: feature.experiment_slug, branch_id: feature.branch_id };
+
+const c1 = beginCycle({ ...scope, test_id: "T1",
+  test_description: "POST /orders returns 201 on valid cart",
+  navigator_plan: "force the public boundary to accept a Cart payload" });
+markGreen(scope, c1.cycle_id, "added POST handler + repository write");
+
+const hits = runDetectorsForScope(tdd, scope);
+if (hits.length) writeSmellsLog(tdd, hits);
+
+writeOutcomes(tdd, featureId, feature.experiment_slug, { status: "succeeded", tests_passed: 2 });
+```
+
+### N≥2 race + promote/synthesize
+
+```ts
+import { cutExperiment, writeOutcomes } from "@databricks-solutions/lakebase-app-dev-kit/tdd/experiment";
+import { compareExperiments } from "@databricks-solutions/lakebase-app-dev-kit/tdd/compare-experiments";
+import { promoteExperiment } from "@databricks-solutions/lakebase-app-dev-kit/tdd/promote-experiment";
+import { synthesizeExperiments } from "@databricks-solutions/lakebase-app-dev-kit/tdd/synthesis";
+
+const tdd = ".tdd"; const featureId = "F1";
+
+await cutExperiment({ instance: "proj-checkout", tddDir: tdd, featureId,
+  experimentSlug: "exp-postgres-arrays", branch: "checkout-pg-arrays", parentBranch: "staging" });
+await cutExperiment({ instance: "proj-checkout", tddDir: tdd, featureId,
+  experimentSlug: "exp-json-blob", branch: "checkout-json-blob", parentBranch: "staging" });
+
+// ... cycles run on each branch via beginCycle/markGreen ...
+
+writeOutcomes(tdd, featureId, "exp-postgres-arrays", { status: "succeeded", tests_passed: 5 });
+writeOutcomes(tdd, featureId, "exp-json-blob",       { status: "succeeded", tests_passed: 5 });
+
+const report = compareExperiments(tdd, featureId);
+
+if (report.recommendation === "promote") {
+  const winner = report.rows.find((r) => r.signal === "winning")!;
+  promoteExperiment({ tddDir: tdd, featureId, winnerSlug: winner.experiment_slug,
+                      hitlApproved: true, approverEmail: "kevin@example.com" });
+} else if (report.recommendation === "synthesize") {
+  await synthesizeExperiments({
+    instance: "proj-checkout", tddDir: tdd, featureId,
+    picks: [
+      { source_slug: "exp-postgres-arrays", capability: "storage schema" },
+      { source_slug: "exp-json-blob",       capability: "API surface" },
+    ],
+    synthesizedSlug: "exp-synth", branch: "checkout-synth",
+    hitlApproved: true, approverEmail: "kevin@example.com",
+  });
+}
+```
 
 ## Adapters
 
-Bundled: `markdown.ts` (no-op — the spec IS the tracking), `jira.ts` (stub). Project skills wire in the adapter they want via `.tdd/adapters/<name>.json` config.
+Bundled: `markdown.ts` (no-op default — the spec IS the tracking), `jira.ts` (stub). Project skills wire in the adapter they want via `.tdd/adapters/<name>.json` config.
 
-## Project-level entry points
+The `SpecAdapter` interface extends `SyncEventHooks` — implementations may opt into `onPhaseTransition`, `onCycleComplete`, `onSmellDetected` hooks for status-mirroring to external trackers. Adapter failures must degrade gracefully — the on-disk spec is the source of truth.
 
-- **`/design`** — wraps Spec Author + Architect Reviewer + Test Strategist phases. Project-specific JIRA hierarchy creation lives here.
-- **`/build`** — wraps Orchestrator. Project-specific PR/merge ceremony lives here.
-- **`/ship`** — lives in `lakebase-release-workflows`. Not part of this skill.
+## CLI bins
 
-Substrate ships no slash commands. It ships skills + agents + scripts + CLI bins. The MCP server (`apps/mcp-server/`) exposes the tool surface for MCP-capable consumers.
+For non-agent invocation (debugging, CI introspection):
+
+| Command | Purpose |
+|---|---|
+| `node scripts/tdd/spec-sync.js <tddDir>` | Walk the `.tdd/` tree and print drift reports. Exits 0 even when reports exist — warn-only. |
+| `node scripts/tdd/test-list.js <tddDir> <featureId>` | Regenerate per-AC views from the feature-level master test list. |

--- a/tests/bdd/tdd-hard-rules.test.ts
+++ b/tests/bdd/tdd-hard-rules.test.ts
@@ -2,34 +2,11 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
 
-const SKILL_PATH = join(
-  __dirname,
-  "..",
-  "..",
-  "skills",
-  "lakebase-tdd-workflows",
-  "SKILL.md"
-);
-
-const NAV_PATH = join(
-  __dirname,
-  "..",
-  "..",
-  "skills",
-  "lakebase-tdd-workflows",
-  "agents",
-  "navigator.md"
-);
-
-const DRV_PATH = join(
-  __dirname,
-  "..",
-  "..",
-  "skills",
-  "lakebase-tdd-workflows",
-  "agents",
-  "driver.md"
-);
+const SKILL_DIR = join(__dirname, "..", "..", "skills", "lakebase-tdd-workflows");
+const SKILL_PATH = join(SKILL_DIR, "SKILL.md");
+const README_PATH = join(SKILL_DIR, "README.md");
+const NAV_PATH = join(SKILL_DIR, "agents", "navigator.md");
+const DRV_PATH = join(SKILL_DIR, "agents", "driver.md");
 
 const NINE_RULES_PHRASES = [
   "immutable until the test list itself is renegotiated",
@@ -45,25 +22,30 @@ const NINE_RULES_PHRASES = [
 
 describe("lakebase-tdd-workflows hard rules", () => {
   const skill = readFileSync(SKILL_PATH, "utf8");
+  const readme = readFileSync(README_PATH, "utf8");
 
   it("SKILL.md contains a ## Hard rules section", () => {
     expect(skill).toMatch(/^##\s+Hard rules/m);
   });
 
-  it("SKILL.md ships a ## How to use section with worked examples", () => {
-    expect(skill).toMatch(/^##\s+How to use/m);
+  it("README.md ships a ## How to use section with worked prompts", () => {
+    expect(readme).toMatch(/^##\s+How to use/m);
     // Flow 1: spec authoring + drift validation.
-    expect(skill).toMatch(/Author a feature spec/i);
+    expect(readme).toMatch(/Author a feature spec/i);
     // Flow 2: N=1 default — lead with feature-oriented language.
-    expect(skill).toMatch(/Build a feature end-to-end/i);
-    expect(skill).toMatch(/N=1 default/i);
+    expect(readme).toMatch(/Build a feature end-to-end/i);
+    expect(readme).toMatch(/N=1 default/i);
     // Flow 3: N>=2 parallel experiments.
-    expect(skill).toMatch(/Race parallel experiments/i);
+    expect(readme).toMatch(/Race parallel experiments/i);
   });
 
-  it("Lexicon makes feature-vs-experiment terminology explicit for N=1", () => {
-    // When N=1 the experiment IS the feature; SKILL.md must say so somewhere in the lexicon.
-    expect(skill).toMatch(/experiment IS the feature/i);
+  it("README.md lexicon makes feature-vs-experiment terminology explicit for N=1", () => {
+    // When N=1 the experiment IS the feature; README.md lexicon must say so.
+    expect(readme).toMatch(/experiment IS the feature/i);
+  });
+
+  it("SKILL.md points readers to README.md for the human-facing overview", () => {
+    expect(skill).toContain("README.md");
   });
 
   it("SKILL.md has at least 9 numbered rules", () => {


### PR DESCRIPTION
## Summary

`lakebase-tdd-workflows` and `lakebase-scm-workflows` now ship two parallel surfaces:

- **`README.md`** — human-facing overview: when to use, lexicon, roles, phases, operations with directory trees, how-to-use prompts in the cart-checkout domain, CLI cheat sheet, composition. No code.
- **`SKILL.md`** — agent operating contract: hard rules / `.env` contract / git-hook rules / credential single-seam, plus concrete bash + TS code patterns for every primitive and the end-to-end orchestrator flows. Frontmatter unchanged so skill routing still discovers it.

Each SKILL.md opens with a pointer to its README.md; each README.md points back at SKILL.md for the agent contract.

The root `README.md` skill bullets now link to each skill's README.md (humans land on the doc written for them; agents still discover SKILL.md via skill routing).

## Test plan

- [x] `npm test` (347 hermetic tests pass, 44 live-gated skipped)
- [x] `npm run typecheck` clean
- [x] Husky pre-push gate green
- [x] `tdd-hard-rules.test.ts` updated: How-to-use + lexicon assertions now read README.md; hard-rules assertions stay on SKILL.md; new assertion that SKILL.md points readers to README.md

## Out of scope

- `lakebase-release-workflows` and `software-design-principles` — unchanged. Only the two workflow skills the team has been iterating on this week.

This pull request and its description were written by Isaac.