### PR TITLE
feat: branch test runner data layer + parallel orchestration (FEIP-7092)

### DIFF
--- a/.env.template.config
+++ b/.env.template.config
@@ -1,0 +1,49 @@
+# Public mainline configuration for the lakebase-app-dev-kit.
+#
+# This file is committed and sourced by kit entry points (e.g.
+# scripts/run-all-live-tests.sh) to establish the public-default
+# values for every env-overridable knob the substrate exposes.
+#
+# Local overrides live in `.env.local.config` (gitignored). The kit
+# sources THIS file first, then `.env.local.config` if present, so
+# local values win.
+#
+# Adding a new knob: set its public-default URL / value here as a real
+# value (not a comment), document it in `scripts/lakebase/kit-config.ts`,
+# and add the variable name to `.env.local.config` for local override
+# guidance.
+
+# ─── Package registries ───────────────────────────────────────────────
+# Public mainline registries. Override in .env.local.config when your
+# environment requires a proxy (corp network, air-gapped, etc.).
+export LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL=https://repo1.maven.org/maven2
+export LAKEBASE_KIT_REGISTRY_SPRING_INITIALIZR=https://start.spring.io
+export NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
+export PIP_INDEX_URL=https://pypi.org/simple
+export UV_INDEX_URL=https://pypi.org/simple
+export MVNW_REPOURL=https://repo.maven.apache.org/maven2
+
+# ─── Lakebase convention branch TTLs (ms) ─────────────────────────────
+# PSA convention defaults. Override per-tier in .env.local.config when
+# your workspace's max-expiration policy is tighter.
+# 30 days = 2592000000 ms
+export LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS=2592000000
+# 14 days = 1209600000 ms
+export LAKEBASE_KIT_TEST_BRANCH_TTL_MS=1209600000
+export LAKEBASE_KIT_UAT_BRANCH_TTL_MS=1209600000
+# 7 days = 604800000 ms
+export LAKEBASE_KIT_PERF_BRANCH_TTL_MS=604800000
+
+# ─── Lakebase live-test target (used by run-all-live-tests.sh) ─────────
+# Optional. Set when reusing a workspace + project across runs instead
+# of auto-provisioning a fresh one each invocation. Documented here for
+# discoverability; set the actual value in .env.local.config.
+#
+# LAKEBASE_TEST_INSTANCE=
+# LAKEBASE_TEST_BRANCH=
+# LAKEBASE_TEST_PARENT=
+# LAKEBASE_TEST_PROJECT_PATH=
+
+# ─── Databricks workspace authentication ──────────────────────────────
+# Set in .env.local.config (DATABRICKS_HOST or DATABRICKS_CONFIG_PROFILE).
+# The scripts auto-resolve DATABRICKS_HOST from a CLI profile.

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 .env
 .env.*
 !.env.example
+!.env.template.config
 *.vsix
 *.log
 coverage/

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,9 +7,9 @@
   ],
   "_install": [
     "1. From a clone: `npm install && npm run build` (npm `prepare` builds dist/).",
-    "2. Add this server to your client's MCP config — for Claude Desktop, copy the entry below into ~/Library/Application Support/Claude/claude_desktop_config.json under `mcpServers`.",
+    "2. Add this server to your client's MCP config – for Claude Desktop, copy the entry below into ~/Library/Application Support/Claude/claude_desktop_config.json under `mcpServers`.",
     "3. Replace `node ./dist/apps/mcp-server/index.js` with an absolute path if the client doesn't have a cwd inside the repo.",
-    "Note: @modelcontextprotocol/sdk is an OPTIONAL peer dep of this package — kept out of regular `dependencies` so consumers that only import the substrate's TypeScript modules (like lakebase-scm-extension) don't drag the MCP runtime into their node_modules. The dev install in step 1 picks it up via devDependencies."
+    "Note: @modelcontextprotocol/sdk is an OPTIONAL peer dep of this package – kept out of regular `dependencies` so consumers that only import the substrate's TypeScript modules (like lakebase-scm-extension) don't drag the MCP runtime into their node_modules. The dev install in step 1 picks it up via devDependencies."
   ],
   "mcpServers": {
     "lakebase-app-dev-kit": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ This repo is the Lakebase-backed application development kit. See [`README.md`](
 
 Every project created with `lakebase-create-project` gets two top-level scaffolds:
 
-- **`scripts/`** — kit-provided substrate (consumed via git URL pin in the project's package.json).
-- **`.tdd/`** — TDD workflow state read and written by `lakebase-tdd-workflows`. Layout: `features/<F>/`, `experiments/<F>/<exp>/`, `spikes/<slug>/`, `synthesis/<F>/`, `cycles/<F>/<S>/<AC>/`, `selection-log.md`, `smells.json`, `workflow-state.json`. See [`templates/tdd-bootstrap/.tdd/README.md`](templates/tdd-bootstrap/.tdd/README.md) for the canonical reference.
+- **`scripts/`** – kit-provided substrate (consumed via git URL pin in the project's package.json).
+- **`.tdd/`** – TDD workflow state read and written by `lakebase-tdd-workflows`. Layout: `features/<F>/`, `experiments/<F>/<exp>/`, `spikes/<slug>/`, `synthesis/<F>/`, `cycles/<F>/<S>/<AC>/`, `selection-log.md`, `smells.json`, `workflow-state.json`. See [`templates/tdd-bootstrap/.tdd/README.md`](templates/tdd-bootstrap/.tdd/README.md) for the canonical reference.
 
 The `.tdd/` directory is created at scaffold time by `layDownTddScaffold()` in `scripts/lakebase/create-project.ts`. Pass `enableTdd: false` to opt out.
 
@@ -15,7 +15,7 @@ The `.tdd/` directory is created at scaffold time by `layDownTddScaffold()` in `
 
 - Substrate scripts live in `scripts/<domain>/` (lakebase, github, git, tdd, util).
 - Workflow-domain skills live in `skills/<domain>/SKILL.md`. Two kit-authored domains: `lakebase-scm-workflows`, `lakebase-release-workflows`, `lakebase-tdd-workflows`. One shared-canon skill: `software-design-principles`. Vendored devhub skills also live under `skills/`.
-- Templates ship under `templates/`. Treat them as project assets — they end up in scaffolded projects, not in the substrate itself.
+- Templates ship under `templates/`. Treat them as project assets – they end up in scaffolded projects, not in the substrate itself.
 - BDD tests live in `tests/bdd/`. Hermetic by default; live tiers gate on `LAKEBASE_TEST_E2E=1` + `DATABRICKS_HOST`.
 
 When editing scripts, always run `npm run typecheck` before committing. When adding skills or references under `skills/`, regenerate `manifest.json` via `python3 scripts/skills.py`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
   "version": "0.3.0-alpha.21",
-  "description": "Lakebase-backed application development kit — shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
+  "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",

--- a/scripts/lakebase/branch-create.ts
+++ b/scripts/lakebase/branch-create.ts
@@ -25,6 +25,7 @@ import {
   isTtlTooLongError,
   projectPath,
 } from "./branch-utils.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 
 const execFileP = promisify(execFile);
 
@@ -222,8 +223,8 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
     instance: args.instance,
     host: args.host,
     branch: sanitized,
-    timeoutMs: args.readyTimeoutMs ?? 120_000,
-    pollIntervalMs: args.pollIntervalMs ?? 5_000,
+    timeoutMs: args.readyTimeoutMs ?? KIT_TIMEOUTS.readyWait,
+    pollIntervalMs: args.pollIntervalMs ?? KIT_TIMEOUTS.readyPoll,
   });
 }
 
@@ -235,8 +236,8 @@ export interface WaitForBranchReadyArgs extends BranchLookupOpts {
 
 /** Poll until the branch reaches READY state. Throws on timeout. */
 export async function waitForBranchReady(args: WaitForBranchReadyArgs): Promise<LakebaseBranchInfo> {
-  const timeoutMs = args.timeoutMs ?? 120_000;
-  const interval = args.pollIntervalMs ?? 5_000;
+  const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.readyWait;
+  const interval = args.pollIntervalMs ?? KIT_TIMEOUTS.readyPoll;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const branch = await getBranchByName(args.branch, { instance: args.instance, host: args.host });
@@ -264,7 +265,7 @@ async function dbcli(args: string[], host?: string): Promise<string> {
     ? ({ ...process.env, DATABRICKS_HOST: trimmedHost } as NodeJS.ProcessEnv)
     : process.env;
   try {
-    const { stdout } = await execFileP("databricks", args, { env, timeout: 60_000 });
+    const { stdout } = await execFileP("databricks", args, { env, timeout: KIT_TIMEOUTS.cliCreateBranch });
     return stdout.toString();
   } catch (err) {
     const e = err as NodeJS.ErrnoException & { stderr?: string | Buffer };

--- a/scripts/lakebase/branch-create.ts
+++ b/scripts/lakebase/branch-create.ts
@@ -70,6 +70,20 @@ export interface CreateBranchArgs extends BranchLookupOpts {
    * protobuf Duration JSON encoding — bare seconds with trailing "s".
    */
   ttl?: string;
+  /**
+   * Strictness for parentBranch lookup. When `parentBranch` is set but the
+   * named branch does not exist on the project, the substrate's default is
+   * to FALL BACK to the project's default branch with a stderr warning —
+   * which keeps the convention-tier defaults
+   * (CONVENTION_TIER_DEFAULTS.feature.parentBranch="staging", etc.)
+   * usable on projects that don't yet follow the PSA topology.
+   *
+   * Pass `strictParent: true` to opt OUT of the fallback and throw a
+   * typed LakebaseBranchError when the named parent is missing — useful
+   * for hotfix-from-production paths where the lineage MUST match the
+   * caller's expectation. Default: false (fallback enabled).
+   */
+  strictParent?: boolean;
 }
 
 /**
@@ -105,7 +119,41 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
       );
     }
     const validated = asBranchName(args.parentBranch);
-    sourceBranchPath = `${projectPath(args.instance)}/branches/${sanitizeBranchName(validated)}`;
+    // Verify the named parent ACTUALLY exists on the project. Without this
+    // check the substrate previously built the source_branch path via raw
+    // string interpolation; the API then errored with the opaque
+    // "branch id not found". Now: if the parent exists, use it; if not,
+    // fall back to the project default (default behavior) or throw
+    // (strictParent: true). This unblocks the CONVENTION_TIER_DEFAULTS
+    // path on bare-provisioned projects (which have `production` but no
+    // `staging`) while preserving the lineage guarantee for callers who
+    // opt into strict mode.
+    const parent = await getBranchByName(validated, lookup);
+    if (parent) {
+      sourceBranchPath = parent.name;
+    } else if (args.strictParent === true) {
+      throw new LakebaseBranchError(
+        `parentBranch '${validated}' does not exist on project '${args.instance}', ` +
+          `and strictParent: true was set. Either create '${validated}' first ` +
+          `(e.g. cut it off the project default branch) or drop strictParent: true ` +
+          `to fall back to the project default branch.`
+      );
+    } else {
+      const def = await getDefaultBranch(lookup);
+      if (!def) {
+        throw new LakebaseBranchError(
+          `parentBranch '${validated}' does not exist on project '${args.instance}' ` +
+            `and the project has no default branch to fall back to.`
+        );
+      }
+      const defaultLeaf = leafOf(def.name) ?? def.name;
+      process.stderr.write(
+        `[lakebase-branch-create] parentBranch '${validated}' not found on project ` +
+          `'${args.instance}'; falling back to default branch '${defaultLeaf}'. ` +
+          `Pass strictParent: true to throw instead.\n`
+      );
+      sourceBranchPath = def.name;
+    }
   } else if (args.currentBranch && args.currentBranch !== sanitized) {
     const current = await getBranchByName(args.currentBranch, lookup);
     if (current) sourceBranchPath = current.name;

--- a/scripts/lakebase/branch-create.ts
+++ b/scripts/lakebase/branch-create.ts
@@ -37,7 +37,7 @@ export interface CreateBranchArgs extends BranchLookupOpts {
    * "fork from production" hotfix scenarios.
    *
    * Must be a BranchName (the resource-path leaf, e.g. `production`,
-   * `staging`, `feature-x`) — NOT a BranchUid (`br-…`) and NOT a full
+   * `staging`, `feature-x`) – NOT a BranchUid (`br-…`) and NOT a full
    * resource path. The runtime guard inside createBranch will reject a
    * BranchUid-shaped value with a helpful error. Use `asBranchName(s)`
    * at the call site if you have a string of unknown provenance.
@@ -68,19 +68,19 @@ export interface CreateBranchArgs extends BranchLookupOpts {
    * set, Lakebase auto-deletes the branch after this duration relative to
    * create_time. Use for finite-lifetime workflow tiers (feature / test /
    * uat / perf). Mutually exclusive with `noExpiry: true`. Format is the
-   * protobuf Duration JSON encoding — bare seconds with trailing "s".
+   * protobuf Duration JSON encoding – bare seconds with trailing "s".
    */
   ttl?: string;
   /**
    * Strictness for parentBranch lookup. When `parentBranch` is set but the
    * named branch does not exist on the project, the substrate's default is
-   * to FALL BACK to the project's default branch with a stderr warning —
+   * to FALL BACK to the project's default branch with a stderr warning –
    * which keeps the convention-tier defaults
    * (CONVENTION_TIER_DEFAULTS.feature.parentBranch="staging", etc.)
    * usable on projects that don't yet follow the PSA topology.
    *
    * Pass `strictParent: true` to opt OUT of the fallback and throw a
-   * typed LakebaseBranchError when the named parent is missing — useful
+   * typed LakebaseBranchError when the named parent is missing – useful
    * for hotfix-from-production paths where the lineage MUST match the
    * caller's expectation. Default: false (fallback enabled).
    */
@@ -114,7 +114,7 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
       throw new LakebaseBranchError(
         `parentBranch '${args.parentBranch}' looks like a BranchUid (br-… pattern), ` +
           `not a BranchName. Pass the resource-path leaf (e.g. 'production', 'staging', ` +
-          `'feature-add-orders') — the Lakebase API rejects uids in source_branch fields. ` +
+          `'feature-add-orders') – the Lakebase API rejects uids in source_branch fields. ` +
           `If you have a uid and need to resolve it to its name, call resolveBranchId() ` +
           `from branch-utils first.`
       );
@@ -193,7 +193,7 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
   if (args.ttl && args.noExpiry === true) {
     throw new LakebaseBranchError(
       `Cannot set both ttl ("${args.ttl}") and noExpiry: true on the same ` +
-        `branch — they are mutually exclusive. Pass one or the other.`,
+        `branch – they are mutually exclusive. Pass one or the other.`,
     );
   }
   const specObj: { source_branch: string; no_expiry?: boolean; ttl?: string } = {

--- a/scripts/lakebase/branch-create.ts
+++ b/scripts/lakebase/branch-create.ts
@@ -14,12 +14,15 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { delay } from "../util/delay.js";
 import { sanitizeBranchName } from "../util/sanitize-branch-name.js";
+import { asBranchName, looksLikeBranchUid } from "./branch-id.js";
 import {
   LakebaseBranchError,
   LakebaseBranchInfo,
+  LakebaseBranchTtlTooLongError,
   BranchLookupOpts,
   getBranchByName,
   getDefaultBranch,
+  isTtlTooLongError,
   projectPath,
 } from "./branch-utils.js";
 
@@ -30,8 +33,13 @@ export interface CreateBranchArgs extends BranchLookupOpts {
   branch: string;
   /**
    * Explicit parent branch override. Use for "fork from staging" or
-   * "fork from production" hotfix scenarios. Pass the sanitized branch
-   * name, NOT the full resource path.
+   * "fork from production" hotfix scenarios.
+   *
+   * Must be a BranchName (the resource-path leaf, e.g. `production`,
+   * `staging`, `feature-x`) — NOT a BranchUid (`br-…`) and NOT a full
+   * resource path. The runtime guard inside createBranch will reject a
+   * BranchUid-shaped value with a helpful error. Use `asBranchName(s)`
+   * at the call site if you have a string of unknown provenance.
    */
   parentBranch?: string;
   /**
@@ -83,7 +91,21 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
   // create AND for the idempotency-vs-conflict comparison below.
   let sourceBranchPath: string | undefined;
   if (args.parentBranch) {
-    sourceBranchPath = `${projectPath(args.instance)}/branches/${sanitizeBranchName(args.parentBranch)}`;
+    // Runtime guard: parentBranch must be a BranchName (resource-path
+    // leaf), never a BranchUid. The API rejects uids in source_branch
+    // with a confusing "branch id not found" error; asBranchName surfaces
+    // a typed, helpful message instead.
+    if (looksLikeBranchUid(args.parentBranch)) {
+      throw new LakebaseBranchError(
+        `parentBranch '${args.parentBranch}' looks like a BranchUid (br-… pattern), ` +
+          `not a BranchName. Pass the resource-path leaf (e.g. 'production', 'staging', ` +
+          `'feature-add-orders') — the Lakebase API rejects uids in source_branch fields. ` +
+          `If you have a uid and need to resolve it to its name, call resolveBranchId() ` +
+          `from branch-utils first.`
+      );
+    }
+    const validated = asBranchName(args.parentBranch);
+    sourceBranchPath = `${projectPath(args.instance)}/branches/${sanitizeBranchName(validated)}`;
   } else if (args.currentBranch && args.currentBranch !== sanitized) {
     const current = await getBranchByName(args.currentBranch, lookup);
     if (current) sourceBranchPath = current.name;
@@ -134,10 +156,19 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
     specObj.no_expiry = true;
   }
   const spec = JSON.stringify({ spec: specObj });
-  await dbcli(
-    ["postgres", "create-branch", projectPath(args.instance), sanitized, "--json", spec],
-    args.host
-  );
+  try {
+    await dbcli(
+      ["postgres", "create-branch", projectPath(args.instance), sanitized, "--json", spec],
+      args.host
+    );
+  } catch (err) {
+    // Detect the workspace-TTL-policy rejection and rewrap with a typed,
+    // actionable message. Other errors bubble through as-is.
+    if (err instanceof LakebaseBranchError && specObj.ttl && isTtlTooLongError(err.message)) {
+      throw new LakebaseBranchTtlTooLongError(specObj.ttl, err.message);
+    }
+    throw err;
+  }
 
   return waitForBranchReady({
     instance: args.instance,

--- a/scripts/lakebase/branch-delete.ts
+++ b/scripts/lakebase/branch-delete.ts
@@ -9,6 +9,7 @@ import {
   BranchLookupOpts,
   resolveBranchPath,
 } from "./branch-utils.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 
 const execFileP = promisify(execFile);
 
@@ -39,7 +40,7 @@ async function dbcli(args: string[], host?: string): Promise<string> {
     ? ({ ...process.env, DATABRICKS_HOST: trimmedHost } as NodeJS.ProcessEnv)
     : process.env;
   try {
-    const { stdout } = await execFileP("databricks", args, { env, timeout: 30_000 });
+    const { stdout } = await execFileP("databricks", args, { env, timeout: KIT_TIMEOUTS.cliDefault });
     return stdout.toString();
   } catch (err) {
     const e = err as NodeJS.ErrnoException & { stderr?: string | Buffer };

--- a/scripts/lakebase/branch-endpoint.ts
+++ b/scripts/lakebase/branch-endpoint.ts
@@ -9,6 +9,7 @@ import { execFileSync } from "node:child_process";
 import { resolveBranchId, resolveBranchPath } from "./branch-utils.js";
 import { mintCredential } from "./get-connection.js";
 import { DEFAULT_ENDPOINT } from "./constants.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 
 export interface EndpointInfo {
   host: string;
@@ -39,7 +40,7 @@ export async function getEndpoint(args: GetEndpointArgs): Promise<EndpointInfo |
     raw = execFileSync("databricks", ["postgres", "list-endpoints", branchPath, "-o", "json"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      timeout: 30_000,
+      timeout: KIT_TIMEOUTS.cliDefault,
     });
   } catch {
     return undefined;
@@ -122,7 +123,7 @@ export async function ensureEndpoint(args: EnsureEndpointArgs): Promise<Endpoint
     execFileSync(
       "databricks",
       ["postgres", "create-endpoint", branchPath, endpointName, "--json", JSON.stringify(spec)],
-      { stdio: ["ignore", "pipe", "pipe"], timeout: 60_000 }
+      { stdio: ["ignore", "pipe", "pipe"], timeout: KIT_TIMEOUTS.cliCreateEndpoint }
     );
   } catch (err) {
     // Race: the endpoint may have been created between our getEndpoint check
@@ -133,12 +134,12 @@ export async function ensureEndpoint(args: EnsureEndpointArgs): Promise<Endpoint
   }
 
   // Poll until the endpoint reports an actual host
-  const timeoutMs = args.timeoutMs ?? 120_000;
+  const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.readyWait;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const ep = await getEndpoint({ instance: args.instance, branch: branchId, endpointName });
     if (ep?.host) return ep;
-    await new Promise((r) => setTimeout(r, 5_000));
+    await new Promise((r) => setTimeout(r, KIT_TIMEOUTS.readyPoll));
   }
   throw new Error(
     `Endpoint for ${branchPath} did not reach ACTIVE within ${timeoutMs}ms (create succeeded but no host yet)`

--- a/scripts/lakebase/branch-endpoint.ts
+++ b/scripts/lakebase/branch-endpoint.ts
@@ -8,6 +8,7 @@
 import { execFileSync } from "node:child_process";
 import { resolveBranchId, resolveBranchPath } from "./branch-utils.js";
 import { mintCredential } from "./get-connection.js";
+import { DEFAULT_ENDPOINT } from "./constants.js";
 
 export interface EndpointInfo {
   host: string;
@@ -71,7 +72,7 @@ export async function getEndpoint(args: GetEndpointArgs): Promise<EndpointInfo |
  * The async helpers in this file (getEndpoint, ensureEndpoint, getCredential)
  * normalize for you.
  */
-export function endpointPath(instance: string, branch: string, endpointName = "primary"): string {
+export function endpointPath(instance: string, branch: string, endpointName: string = DEFAULT_ENDPOINT): string {
   return `projects/${instance}/branches/${branch}/endpoints/${endpointName}`;
 }
 
@@ -98,7 +99,7 @@ export interface EnsureEndpointArgs {
  * has a reachable endpoint before .env gets rewritten with credentials.
  */
 export async function ensureEndpoint(args: EnsureEndpointArgs): Promise<EndpointInfo> {
-  const endpointName = args.endpointName ?? "primary";
+  const endpointName = args.endpointName ?? DEFAULT_ENDPOINT;
   // Normalize once. Below, branchId flows into both the create-endpoint CLI
   // path and the retry/poll getEndpoint calls.
   const branchId = await resolveBranchId({ instance: args.instance, branch: args.branch });
@@ -163,6 +164,6 @@ export async function getCredential(args: GetCredentialArgs): Promise<{ token: s
   if (!branchPath) {
     throw new Error(`Branch "${args.branch}" not found in instance "${args.instance}"`);
   }
-  const endpointName = args.endpointName ?? "primary";
+  const endpointName = args.endpointName ?? DEFAULT_ENDPOINT;
   return mintCredential(`${branchPath}/endpoints/${endpointName}`);
 }

--- a/scripts/lakebase/branch-id.ts
+++ b/scripts/lakebase/branch-id.ts
@@ -3,12 +3,12 @@
 // A Lakebase branch has TWO distinct identifiers and they are NOT
 // interchangeable in the API:
 //
-//   BranchName  — the human-readable leaf of the resource path
+//   BranchName  – the human-readable leaf of the resource path
 //                 (`production`, `staging`, `feature-add-orders`). Used in
 //                 EVERY API field that takes a branch path or source_branch
 //                 reference. The leaf of `projects/<id>/branches/<NAME>`.
 //
-//   BranchUid   — the system-assigned alphanumeric identifier
+//   BranchUid   – the system-assigned alphanumeric identifier
 //                 (`br-crimson-fire-d28lb2ez`). Returned by `list-branches`
 //                 as the `uid` field. Used only for direct uid lookups in
 //                 the few flows that need them.
@@ -47,7 +47,7 @@ const UID_PATTERN = /^br-[a-z0-9-]+$/;
 
 /**
  * Structural check: does `s` match the BranchUid pattern (`br-…`)? Does
- * NOT prove the uid actually exists — just that the shape matches.
+ * NOT prove the uid actually exists – just that the shape matches.
  */
 export function looksLikeBranchUid(s: string): boolean {
   return UID_PATTERN.test(s);
@@ -55,7 +55,7 @@ export function looksLikeBranchUid(s: string): boolean {
 
 /**
  * Wrap `s` as a BranchName, throwing if `s` looks like a BranchUid
- * (which is almost certainly a programmer error — the API will reject it
+ * (which is almost certainly a programmer error – the API will reject it
  * in path-shaped fields). Use at every kit boundary that receives a
  * branch identifier from outside.
  *
@@ -69,7 +69,7 @@ export function asBranchName(s: string): BranchName {
         `BranchName is the resource-path leaf (e.g. 'production', 'staging', 'feature-add-orders'); ` +
         `BranchUid is the system identifier returned by list-branches as the 'uid' field. ` +
         `The Lakebase API rejects a BranchUid in any path-shaped field. If you really mean a ` +
-        `BranchUid, use asBranchUid() instead — but verify you're calling a function that takes one.`
+        `BranchUid, use asBranchUid() instead – but verify you're calling a function that takes one.`
     );
   }
   return s as BranchName;

--- a/scripts/lakebase/branch-id.ts
+++ b/scripts/lakebase/branch-id.ts
@@ -1,0 +1,111 @@
+// Branded identifier types for Lakebase branches.
+//
+// A Lakebase branch has TWO distinct identifiers and they are NOT
+// interchangeable in the API:
+//
+//   BranchName  — the human-readable leaf of the resource path
+//                 (`production`, `staging`, `feature-add-orders`). Used in
+//                 EVERY API field that takes a branch path or source_branch
+//                 reference. The leaf of `projects/<id>/branches/<NAME>`.
+//
+//   BranchUid   — the system-assigned alphanumeric identifier
+//                 (`br-crimson-fire-d28lb2ez`). Returned by `list-branches`
+//                 as the `uid` field. Used only for direct uid lookups in
+//                 the few flows that need them.
+//
+// The Lakebase API rejects a BranchUid in any path-shaped field with a
+// confusing "branch id not found" error. To make that swap impossible at
+// the type level (and to fail fast at runtime when an upstream returned
+// the wrong identifier), these brands + their constructors are the single
+// seam every branch-id-handling helper in the kit should funnel through.
+//
+// Pattern: strict internals, lenient boundaries. Internal substrate
+// functions take `BranchName` / `BranchUid` directly so the compiler
+// catches accidental swaps. Boundary functions that accept a string from
+// the outside world (CLI bins, MCP tool handlers) validate via the
+// constructors below and surface a typed error message that explains the
+// distinction.
+
+declare const BRAND: unique symbol;
+
+/**
+ * The leaf of a Lakebase branch resource path
+ * (`projects/<id>/branches/<NAME>`). Use in source_branch fields, in
+ * .env LAKEBASE_BRANCH_NAME, and anywhere a CLI subresource URL needs
+ * `{branch}`. NEVER pass a BranchUid where a BranchName is expected.
+ */
+export type BranchName = string & { readonly [BRAND]: "BranchName" };
+
+/**
+ * The system-assigned Lakebase branch uid (`br-crimson-fire-d28lb2ez`).
+ * Returned in the `uid` field of `list-branches` / `get-branch`. Used
+ * only for direct uid lookups. NEVER paste into a path-shaped API field.
+ */
+export type BranchUid = string & { readonly [BRAND]: "BranchUid" };
+
+const UID_PATTERN = /^br-[a-z0-9-]+$/;
+
+/**
+ * Structural check: does `s` match the BranchUid pattern (`br-…`)? Does
+ * NOT prove the uid actually exists — just that the shape matches.
+ */
+export function looksLikeBranchUid(s: string): boolean {
+  return UID_PATTERN.test(s);
+}
+
+/**
+ * Wrap `s` as a BranchName, throwing if `s` looks like a BranchUid
+ * (which is almost certainly a programmer error — the API will reject it
+ * in path-shaped fields). Use at every kit boundary that receives a
+ * branch identifier from outside.
+ *
+ * @throws TypeError when `s` is empty or matches the BranchUid pattern.
+ */
+export function asBranchName(s: string): BranchName {
+  if (!s) throw new TypeError("BranchName cannot be empty");
+  if (looksLikeBranchUid(s)) {
+    throw new TypeError(
+      `'${s}' looks like a BranchUid (br-… pattern), not a BranchName. ` +
+        `BranchName is the resource-path leaf (e.g. 'production', 'staging', 'feature-add-orders'); ` +
+        `BranchUid is the system identifier returned by list-branches as the 'uid' field. ` +
+        `The Lakebase API rejects a BranchUid in any path-shaped field. If you really mean a ` +
+        `BranchUid, use asBranchUid() instead — but verify you're calling a function that takes one.`
+    );
+  }
+  return s as BranchName;
+}
+
+/**
+ * Wrap `s` as a BranchUid, throwing if `s` does not match the `br-…`
+ * pattern. Use only at the few places that genuinely need to pass a uid
+ * (direct uid-based lookups).
+ *
+ * @throws TypeError when `s` is empty or does not match the BranchUid pattern.
+ */
+export function asBranchUid(s: string): BranchUid {
+  if (!s) throw new TypeError("BranchUid cannot be empty");
+  if (!looksLikeBranchUid(s)) {
+    throw new TypeError(
+      `'${s}' is not a BranchUid (must match the br-… pattern). ` +
+        `If you have a BranchName (resource-path leaf like 'production'), use asBranchName() instead.`
+    );
+  }
+  return s as BranchUid;
+}
+
+/**
+ * Extract the BranchName leaf from a full resource path
+ * `projects/<id>/branches/<NAME>`. Returns null when the path is not
+ * shaped that way or when the leaf doesn't pass the BranchName validator
+ * (e.g. it looks like a uid).
+ */
+export function branchNameFromResourcePath(path: string): BranchName | null {
+  if (!path.includes("/branches/")) return null;
+  const leaf = path.split("/branches/").pop();
+  if (!leaf) return null;
+  try {
+    return asBranchName(leaf);
+  } catch {
+    return null;
+  }
+}

--- a/scripts/lakebase/branch-schema.ts
+++ b/scripts/lakebase/branch-schema.ts
@@ -14,6 +14,7 @@ import { getEndpoint, endpointPath as buildEndpointPath } from "./branch-endpoin
 import { resolveBranchId } from "./branch-utils.js";
 import { mintCredential } from "./get-connection.js";
 import { DEFAULT_DATABASE, POSTGRES_PORT } from "./constants.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 
 export interface TableSchema {
   name: string;
@@ -71,8 +72,8 @@ export async function queryBranchSchema(args: QueryBranchSchemaArgs): Promise<Ta
     user: email,
     password: token,
     ssl: { rejectUnauthorized: false }, // Lakebase managed cert
-    connectionTimeoutMillis: 10_000,
-    statement_timeout: 15_000,
+    connectionTimeoutMillis: KIT_TIMEOUTS.pgConnect,
+    statement_timeout: KIT_TIMEOUTS.pgStatement,
   });
 
   try {

--- a/scripts/lakebase/branch-schema.ts
+++ b/scripts/lakebase/branch-schema.ts
@@ -13,6 +13,7 @@ import { Client } from "pg";
 import { getEndpoint, endpointPath as buildEndpointPath } from "./branch-endpoint.js";
 import { resolveBranchId } from "./branch-utils.js";
 import { mintCredential } from "./get-connection.js";
+import { DEFAULT_DATABASE, POSTGRES_PORT } from "./constants.js";
 
 export interface TableSchema {
   name: string;
@@ -60,12 +61,12 @@ export async function queryBranchSchema(args: QueryBranchSchemaArgs): Promise<Ta
     return [];
   }
   const { token, email } = await mintCredential(buildEndpointPath(args.instance, branchId));
-  const database = args.database ?? process.env.PGDATABASE ?? "databricks_postgres";
+  const database = args.database ?? process.env.PGDATABASE ?? DEFAULT_DATABASE;
   const skipFlyway = args.skipFlyway !== false;
 
   const client = new Client({
     host: ep.host,
-    port: 5432,
+    port: POSTGRES_PORT,
     database,
     user: email,
     password: token,

--- a/scripts/lakebase/branch-utils.ts
+++ b/scripts/lakebase/branch-utils.ts
@@ -9,6 +9,7 @@ import {
   type BranchName,
   type BranchUid,
 } from "./branch-id.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 
 const execFileP = promisify(execFile);
 
@@ -291,7 +292,7 @@ async function dbcli(args: string[], host?: string): Promise<string> {
     ? ({ ...process.env, DATABRICKS_HOST: trimmedHost } as NodeJS.ProcessEnv)
     : process.env;
   try {
-    const { stdout } = await execFileP("databricks", args, { env, timeout: 30_000 });
+    const { stdout } = await execFileP("databricks", args, { env, timeout: KIT_TIMEOUTS.cliDefault });
     return stdout.toString();
   } catch (err) {
     const e = err as NodeJS.ErrnoException & { stderr?: string | Buffer };

--- a/scripts/lakebase/branch-utils.ts
+++ b/scripts/lakebase/branch-utils.ts
@@ -65,7 +65,7 @@ export interface LakebaseBranchInfo {
   /**
    * Lakebase-side opaque uid, e.g. `br-broad-sky-d2k5gewt`. Returned by
    * `get-branch` / `list-branches` as the `uid` field. NOT accepted in
-   * any path-shaped API field — the service rejects it with "branch id
+   * any path-shaped API field – the service rejects it with "branch id
    * not found". For source_branch references, `{branch}` URL segments,
    * .env LAKEBASE_BRANCH_NAME, etc., use {@link nameLeaf} instead.
    *
@@ -93,7 +93,7 @@ export interface LakebaseBranchInfo {
    * Use {@link sourceBranchId} for just the leaf segment (a {@link BranchName}).
    */
   sourceBranchName?: string;
-  /** Parent branch leaf — a {@link BranchName} like `staging`. Derived from sourceBranchName. */
+  /** Parent branch leaf – a {@link BranchName} like `staging`. Derived from sourceBranchName. */
   sourceBranchId?: BranchName;
   /** True if this is the project's default branch. */
   isDefault?: boolean;
@@ -188,7 +188,7 @@ export async function resolveBranchPath(
  *
  * Throws when the branch can't be resolved (e.g. uid points at nothing).
  * Fast-path: returns input unchanged for values that don't look like a uid
- * (no `br-` prefix) and don't include a path prefix — avoids a round-trip
+ * (no `br-` prefix) and don't include a path prefix – avoids a round-trip
  * for the common branch_id case.
  */
 export async function resolveBranchId(
@@ -254,7 +254,7 @@ function parseBranch(raw: unknown): LakebaseBranchInfo | undefined {
   if (!name) return undefined;
 
   // BranchName: always the leaf of the resource path. NEVER fall back to
-  // the uid here — a uid in a path-shaped field is exactly the bug this
+  // the uid here – a uid in a path-shaped field is exactly the bug this
   // brand exists to prevent.
   const nameLeaf = branchNameFromResourcePath(name);
   if (!nameLeaf) return undefined;

--- a/scripts/lakebase/branch-utils.ts
+++ b/scripts/lakebase/branch-utils.ts
@@ -3,6 +3,12 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import {
+  asBranchUid,
+  branchNameFromResourcePath,
+  type BranchName,
+  type BranchUid,
+} from "./branch-id.js";
 
 const execFileP = promisify(execFile);
 
@@ -13,27 +19,81 @@ export class LakebaseBranchError extends Error {
   }
 }
 
+/**
+ * Thrown when a branch create request's TTL exceeds the workspace's
+ * maximum branch-expiration policy. The workspace cap varies by
+ * deployment (some allow 30+ days, others cap below 30); the kit's
+ * convention defaults (30d feature / 14d test+uat / 7d perf) may not
+ * fit every workspace.
+ *
+ * Recovery options for the caller:
+ *   - Pass a shorter `ttl` (e.g. "604800s" for 7 days) on createBranch /
+ *     createFeatureBranch / cutExperiment.
+ *   - Pass `noExpiry: true` for branches that should persist (typically
+ *     production / staging tiers, not feature tiers).
+ *   - Probe the project's `history_retention_duration` via get-project
+ *     for a conservative upper bound (often, but not always, the cap).
+ */
+export class LakebaseBranchTtlTooLongError extends LakebaseBranchError {
+  /** The TTL that was attempted (the value passed to the API). */
+  public readonly attemptedTtl: string;
+
+  constructor(attemptedTtl: string, underlyingMessage: string) {
+    super(
+      `Branch create rejected: TTL '${attemptedTtl}' exceeds the workspace's maximum ` +
+        `expiration policy. Pass a shorter ttl arg (e.g. "604800s" for 7 days) or set ` +
+        `noExpiry: true. The workspace cap is not directly exposed by the Lakebase API; ` +
+        `the project's history_retention_duration (from \`databricks postgres get-project\`) ` +
+        `is a conservative starting point.\n\nUnderlying error: ${underlyingMessage}`
+    );
+    this.name = "LakebaseBranchTtlTooLongError";
+    this.attemptedTtl = attemptedTtl;
+  }
+}
+
+/**
+ * Pattern-match the underlying CLI stderr against the workspace
+ * TTL-too-long signal. Exported for the unit-test boundary so the
+ * detection logic stays guarded by tests if Lakebase rewords the error.
+ */
+export function isTtlTooLongError(stderr: string): boolean {
+  return /expiration time exceeds the maximum expiration time/i.test(stderr);
+}
+
 export interface LakebaseBranchInfo {
   /**
-   * Lakebase-side opaque uid, e.g. "br-broad-sky-d2k5gewt". Returned by
-   * `get-branch` / `list-branches` as the `uid` field. NOT accepted as the
-   * `{branch}` path segment in CLI subresource URLs — use {@link branchId} or
-   * the friendly leaf of {@link name} for those.
+   * Lakebase-side opaque uid, e.g. `br-broad-sky-d2k5gewt`. Returned by
+   * `get-branch` / `list-branches` as the `uid` field. NOT accepted in
+   * any path-shaped API field — the service rejects it with "branch id
+   * not found". For source_branch references, `{branch}` URL segments,
+   * .env LAKEBASE_BRANCH_NAME, etc., use {@link nameLeaf} instead.
+   *
+   * Branded {@link BranchUid} so the compiler refuses to accept it where
+   * a {@link BranchName} is expected.
    */
-  uid: string;
-  /** Full resource name, e.g. "projects/proj-abc/branches/feature-x". */
+  uid: BranchUid;
+  /**
+   * Friendly resource-path leaf, e.g. `production`. The {@link BranchName}
+   * form of the branch identifier; the segment after `/branches/` in the
+   * full resource name. THIS is the value to pass into source_branch,
+   * subresource URLs, .env LAKEBASE_BRANCH_NAME, etc.
+   *
+   * Derived from `name` on parse, so it's always present when `name` is.
+   */
+  nameLeaf: BranchName;
+  /** Full resource name, e.g. `projects/proj-abc/branches/feature-x`. */
   name: string;
-  /** "READY", "PROVISIONING", etc. */
+  /** `READY`, `PROVISIONING`, etc. */
   state: string;
   /**
-   * Parent branch full resource name (e.g. "projects/x/branches/staging"),
+   * Parent branch full resource name (e.g. `projects/x/branches/staging`),
    * sourced from `status.source_branch` in the Lakebase API response.
    *
-   * Use {@link sourceBranchId} for just the leaf segment.
+   * Use {@link sourceBranchId} for just the leaf segment (a {@link BranchName}).
    */
   sourceBranchName?: string;
-  /** Parent branch leaf id (e.g. "staging"). Derived from sourceBranchName. */
-  sourceBranchId?: string;
+  /** Parent branch leaf — a {@link BranchName} like `staging`. Derived from sourceBranchName. */
+  sourceBranchId?: BranchName;
   /** True if this is the project's default branch. */
   isDefault?: boolean;
   /**
@@ -191,11 +251,30 @@ function parseBranch(raw: unknown): LakebaseBranchInfo | undefined {
   const r = raw as RawBranch;
   const name = r.name ?? "";
   if (!name) return undefined;
-  const uid = r.uid ?? name.split("/branches/").pop() ?? "";
+
+  // BranchName: always the leaf of the resource path. NEVER fall back to
+  // the uid here — a uid in a path-shaped field is exactly the bug this
+  // brand exists to prevent.
+  const nameLeaf = branchNameFromResourcePath(name);
+  if (!nameLeaf) return undefined;
+
+  // BranchUid: prefer the API's `uid` field. If absent (older shapes),
+  // skip the branch rather than fake it from the leaf, which would be
+  // a BranchName mislabeled as a BranchUid.
+  if (!r.uid) return undefined;
+  let uid;
+  try {
+    uid = asBranchUid(r.uid);
+  } catch {
+    return undefined;
+  }
+
   const sourceBranchName = r.status?.source_branch ?? r.spec?.source_branch;
-  const sourceBranchId = sourceBranchName?.split("/branches/").pop() || undefined;
+  const sourceBranchId = sourceBranchName ? branchNameFromResourcePath(sourceBranchName) ?? undefined : undefined;
+
   return {
     uid,
+    nameLeaf,
     name,
     state: r.status?.current_state ?? r.state ?? "UNKNOWN",
     sourceBranchName,

--- a/scripts/lakebase/constants.ts
+++ b/scripts/lakebase/constants.ts
@@ -1,4 +1,4 @@
-// Shared substrate constants — single source of truth for repeated literals.
+// Shared substrate constants – single source of truth for repeated literals.
 //
 // These are deliberate defaults that the Lakebase service + the kit's
 // documented conventions converge on. They're "hardcoded" in the sense

--- a/scripts/lakebase/constants.ts
+++ b/scripts/lakebase/constants.ts
@@ -1,0 +1,37 @@
+// Shared substrate constants — single source of truth for repeated literals.
+//
+// These are deliberate defaults that the Lakebase service + the kit's
+// documented conventions converge on. They're "hardcoded" in the sense
+// that the value itself doesn't change at runtime, but every callsite
+// reads from here so a future deviation requires touching one place,
+// not the eight files that previously inlined the literal.
+//
+// Every API that consumes one of these MUST accept an override per-call
+// (matching the kit's existing convention). The constant only fixes the
+// default.
+
+/**
+ * TCP port Lakebase serves Postgres on. Used in DSN building and in
+ * direct pg.Client connect calls (schema introspection, etc.). Lakebase
+ * does not expose a per-endpoint port override; the service is fixed
+ * to 5432 by design. If that ever changes, this is the one place to
+ * update.
+ */
+export const POSTGRES_PORT = 5432;
+
+/**
+ * Default Lakebase database name. The service provisions a single
+ * database per branch with this fixed name. Callers override via the
+ * per-call `database` arg or the PGDATABASE env var (in the standard
+ * pg-tooling order: explicit arg → PGDATABASE → DEFAULT_DATABASE).
+ */
+export const DEFAULT_DATABASE = "databricks_postgres";
+
+/**
+ * Default Lakebase endpoint name on a branch. The service currently
+ * provisions exactly one endpoint named "primary" per branch; callers
+ * that want a different identifier pass `endpointName` explicitly.
+ * If Lakebase ever exposes multi-endpoint branches the constant stays
+ * "primary" (the default behavior) and callers opt into the new name.
+ */
+export const DEFAULT_ENDPOINT = "primary";

--- a/scripts/lakebase/convention-branches.ts
+++ b/scripts/lakebase/convention-branches.ts
@@ -59,6 +59,14 @@ export interface CreateConventionBranchArgs extends BranchLookupOpts {
   parentBranch?: string;
   /** Override the TTL. Defaults to the tier's value (see CONVENTION_TIER_DEFAULTS). */
   ttl?: string;
+  /**
+   * Forwarded to createBranch. When the convention's default parent (e.g.
+   * "staging") doesn't exist on the project, the substrate falls back to
+   * the project default branch with a stderr warning. Set strictParent:
+   * true to throw instead — useful for hotfix-from-production paths where
+   * the lineage MUST match the convention.
+   */
+  strictParent?: boolean;
 }
 
 /**
@@ -75,6 +83,7 @@ export async function createFeatureBranch(
     branch: args.branch,
     parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.feature.parentBranch,
     ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.feature.ttl,
+    strictParent: args.strictParent,
   });
 }
 
@@ -88,6 +97,7 @@ export async function createTestBranch(
     branch: args.branch,
     parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.test.parentBranch,
     ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.test.ttl,
+    strictParent: args.strictParent,
   });
 }
 
@@ -101,6 +111,7 @@ export async function createUatBranch(
     branch: args.branch,
     parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.uat.parentBranch,
     ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.uat.ttl,
+    strictParent: args.strictParent,
   });
 }
 
@@ -114,5 +125,6 @@ export async function createPerfBranch(
     branch: args.branch,
     parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.perf.parentBranch,
     ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.perf.ttl,
+    strictParent: args.strictParent,
   });
 }

--- a/scripts/lakebase/convention-branches.ts
+++ b/scripts/lakebase/convention-branches.ts
@@ -1,5 +1,5 @@
 /**
- * Branch convention helpers — `createFeatureBranch / createTestBranch /
+ * Branch convention helpers – `createFeatureBranch / createTestBranch /
  * createUatBranch / createPerfBranch`.
  *
  * The PSA branching methodology (see
@@ -12,7 +12,7 @@
  *                  ├── uat       (user acceptance)
  *                  └── perf      (performance / load)
  *
- * Each is finite-lifetime — tied to a specific dev cycle, not a permanent
+ * Each is finite-lifetime – tied to a specific dev cycle, not a permanent
  * tier. So unlike `createLongRunningBranch` (which sets `no_expiry: true`
  * for the prod/staging tiers), these helpers default to a Lakebase TTL.
  *
@@ -64,7 +64,7 @@ export interface CreateConventionBranchArgs extends BranchLookupOpts {
    * Forwarded to createBranch. When the convention's default parent (e.g.
    * "staging") doesn't exist on the project, the substrate falls back to
    * the project default branch with a stderr warning. Set strictParent:
-   * true to throw instead — useful for hotfix-from-production paths where
+   * true to throw instead – useful for hotfix-from-production paths where
    * the lineage MUST match the convention.
    */
   strictParent?: boolean;
@@ -72,7 +72,7 @@ export interface CreateConventionBranchArgs extends BranchLookupOpts {
 
 /**
  * Cut a feature-tier Lakebase branch off `staging` with a 30-day TTL.
- * Lakebase deletes the branch automatically when the TTL expires — useful
+ * Lakebase deletes the branch automatically when the TTL expires – useful
  * for feature dev cycles where the branch lives only as long as the work.
  */
 export async function createFeatureBranch(

--- a/scripts/lakebase/convention-branches.ts
+++ b/scripts/lakebase/convention-branches.ts
@@ -28,28 +28,29 @@
 
 import { createBranch as createLakebaseBranch } from "./branch-create.js";
 import { LakebaseBranchInfo, BranchLookupOpts } from "./branch-utils.js";
-
-/** Lakebase TTL format is protobuf Duration JSON: "<seconds>s". */
-const DAY_SECONDS = 86_400;
-const ttlDays = (days: number): string => `${days * DAY_SECONDS}s`;
+import { KIT_TIMEOUTS, formatLakebaseTtl } from "./kit-config.js";
 
 /**
  * Tier defaults. Exported so tests + future tickets can introspect.
  *
  * **Workspace TTL caveat:** the PSA-convention TTLs below (30d feature,
  * 14d test/uat, 7d perf) are the documented norms but some Lakebase
- * workspaces enforce a tighter maximum-expiration policy. When a
- * workspace rejects a TTL, the substrate raises
- * {@link LakebaseBranchTtlTooLongError} with a typed, actionable message.
- * Callers can either override `ttl` per-call or set `noExpiry: true`
- * for the long-running tiers. The `history_retention_duration` field on
+ * workspaces enforce a tighter maximum-expiration policy. Workspaces
+ * with tighter caps can override each tier's default via the matching
+ * env var on KIT_TIMEOUTS (e.g.
+ * `LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS=604800000` for 7-day feature
+ * branches). When a workspace rejects a TTL even after override,
+ * the substrate raises {@link LakebaseBranchTtlTooLongError} with a
+ * typed, actionable message. Callers can also override `ttl` per-call
+ * or set `noExpiry: true` for the long-running tiers. The
+ * `history_retention_duration` field on
  * `databricks postgres get-project` is a conservative starting point.
  */
 export const CONVENTION_TIER_DEFAULTS = {
-  feature: { ttl: ttlDays(30), parentBranch: "staging" },
-  test: { ttl: ttlDays(14), parentBranch: "staging" },
-  uat: { ttl: ttlDays(14), parentBranch: "staging" },
-  perf: { ttl: ttlDays(7), parentBranch: "staging" },
+  feature: { ttl: formatLakebaseTtl(KIT_TIMEOUTS.featureBranchTtlMs), parentBranch: "staging" },
+  test: { ttl: formatLakebaseTtl(KIT_TIMEOUTS.testBranchTtlMs), parentBranch: "staging" },
+  uat: { ttl: formatLakebaseTtl(KIT_TIMEOUTS.uatBranchTtlMs), parentBranch: "staging" },
+  perf: { ttl: formatLakebaseTtl(KIT_TIMEOUTS.perfBranchTtlMs), parentBranch: "staging" },
 } as const;
 
 export interface CreateConventionBranchArgs extends BranchLookupOpts {

--- a/scripts/lakebase/convention-branches.ts
+++ b/scripts/lakebase/convention-branches.ts
@@ -33,7 +33,18 @@ import { LakebaseBranchInfo, BranchLookupOpts } from "./branch-utils.js";
 const DAY_SECONDS = 86_400;
 const ttlDays = (days: number): string => `${days * DAY_SECONDS}s`;
 
-/** Tier defaults. Exported so tests + future tickets can introspect. */
+/**
+ * Tier defaults. Exported so tests + future tickets can introspect.
+ *
+ * **Workspace TTL caveat:** the PSA-convention TTLs below (30d feature,
+ * 14d test/uat, 7d perf) are the documented norms but some Lakebase
+ * workspaces enforce a tighter maximum-expiration policy. When a
+ * workspace rejects a TTL, the substrate raises
+ * {@link LakebaseBranchTtlTooLongError} with a typed, actionable message.
+ * Callers can either override `ttl` per-call or set `noExpiry: true`
+ * for the long-running tiers. The `history_retention_duration` field on
+ * `databricks postgres get-project` is a conservative starting point.
+ */
 export const CONVENTION_TIER_DEFAULTS = {
   feature: { ttl: ttlDays(30), parentBranch: "staging" },
   test: { ttl: ttlDays(14), parentBranch: "staging" },

--- a/scripts/lakebase/create-project.ts
+++ b/scripts/lakebase/create-project.ts
@@ -258,7 +258,7 @@ export { writeEnvFile, verifyHooks, verifyWorkflows, verifyProject };
  * both when the substrate is consumed via git URL (dist + src co-located) and
  * when it's invoked directly from a dev clone.
  *
- * Safe to call when <targetDir>/.tdd/ already exists — existing files are not
+ * Safe to call when <targetDir>/.tdd/ already exists – existing files are not
  * overwritten so a project that already started TDD work is preserved.
  */
 export function layDownTddScaffold(targetDir: string): void {

--- a/scripts/lakebase/detect-language.cli.ts
+++ b/scripts/lakebase/detect-language.cli.ts
@@ -35,7 +35,7 @@ function parseProjectDir(argv: string[]): string {
 
 function printHelpAndExit(): never {
   process.stdout.write(
-    `lakebase-detect-language — print the project's language\n\n` +
+    `lakebase-detect-language – print the project's language\n\n` +
       `Usage:\n` +
       `  lakebase-detect-language [--project-dir <path>]\n\n` +
       `Output (stdout): one of "java", "python", "nodejs"\n` +

--- a/scripts/lakebase/get-connection.ts
+++ b/scripts/lakebase/get-connection.ts
@@ -18,6 +18,7 @@ import { createLakebasePool } from "@databricks/lakebase";
 import type { Pool } from "pg";
 import { resolveBranchId } from "./branch-utils.js";
 import { DEFAULT_DATABASE, DEFAULT_ENDPOINT, POSTGRES_PORT } from "./constants.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 // AppKit / @databricks/lakebase re-exports a WorkspaceClient type that
 // matches what createLakebasePool expects. We accept `unknown` at the API
 // boundary so this module doesn't have to take a hard SDK dep just to type
@@ -184,7 +185,7 @@ function dbcli(args: string[]): string {
     return execFileSync("databricks", args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      timeout: 30_000,
+      timeout: KIT_TIMEOUTS.cliDefault,
     });
   } catch (err) {
     const e = err as NodeJS.ErrnoException & { stderr?: string | Buffer };

--- a/scripts/lakebase/get-connection.ts
+++ b/scripts/lakebase/get-connection.ts
@@ -17,6 +17,7 @@ import { execFileSync } from "node:child_process";
 import { createLakebasePool } from "@databricks/lakebase";
 import type { Pool } from "pg";
 import { resolveBranchId } from "./branch-utils.js";
+import { DEFAULT_DATABASE, DEFAULT_ENDPOINT, POSTGRES_PORT } from "./constants.js";
 // AppKit / @databricks/lakebase re-exports a WorkspaceClient type that
 // matches what createLakebasePool expects. We accept `unknown` at the API
 // boundary so this module doesn't have to take a hard SDK dep just to type
@@ -78,8 +79,8 @@ export interface DsnResult {
 export function getConnection(args: DsnArgs): Promise<DsnResult>;
 export function getConnection(args: PoolArgs): Promise<Pool>;
 export async function getConnection(args: ConnectionArgs): Promise<DsnResult | Pool> {
-  const endpointName = args.endpointName ?? "primary";
-  const database = args.database ?? process.env.PGDATABASE ?? "databricks_postgres";
+  const endpointName = args.endpointName ?? DEFAULT_ENDPOINT;
+  const database = args.database ?? process.env.PGDATABASE ?? DEFAULT_DATABASE;
   // Normalize once at the entry point. Every downstream CLI path uses
   // branchId; callers can hand us uid / branch_id / full path.
   const branchId = await resolveBranchId({ instance: args.instance, branch: args.branch });
@@ -88,8 +89,8 @@ export async function getConnection(args: ConnectionArgs): Promise<DsnResult | P
   if (args.output === "dsn") {
     const host = await resolveEndpointHost(args.instance, branchId);
     const { token, email } = await mintCredential(endpointPath);
-    const url = buildPostgresUrl({ host, port: 5432, database, user: email, password: token });
-    return { url, host, port: 5432, database, user: email, endpointPath };
+    const url = buildPostgresUrl({ host, port: POSTGRES_PORT, database, user: email, password: token });
+    return { url, host, port: POSTGRES_PORT, database, user: email, endpointPath };
   }
 
   // output === "pool"

--- a/scripts/lakebase/kit-config.ts
+++ b/scripts/lakebase/kit-config.ts
@@ -1,0 +1,75 @@
+// Centralized timeout + polling configuration for the substrate.
+//
+// Every CLI invocation, every wait-for-READY loop, every git operation
+// previously had its own inline literal timeout scattered through the
+// codebase. Drift across copies (one path bumped to 60s, another still
+// 30s) is the failure mode this module exists to prevent.
+//
+// Each field is env-overridable so ops folks can tune behavior at
+// runtime without code changes. Read once at module load to keep the
+// hot path branch-free.
+
+function intFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+export interface KitTimeouts {
+  /** Default `databricks` CLI invocation budget (list-branches, get-branch, get-endpoint, etc.). */
+  cliDefault: number;
+  /** `databricks postgres create-branch` budget. Slightly higher than the default to absorb the server-side branch provisioning latency. */
+  cliCreateBranch: number;
+  /** `databricks postgres create-endpoint` budget. Long-running on the server side. */
+  cliCreateEndpoint: number;
+  /** Wait-for-READY budget for branch + endpoint state polls. */
+  readyWait: number;
+  /** Poll interval inside wait-for-READY loops. */
+  readyPoll: number;
+  /** Postgres connection-establishment timeout (used in pg.Client / pg.Pool config). */
+  pgConnect: number;
+  /** Postgres statement timeout (per-query budget on direct pg.Client calls). */
+  pgStatement: number;
+  /** Short local git ops (status / rev-parse / verify / branch -d). */
+  gitDefault: number;
+  /** Local git checkout (slightly higher than gitDefault to absorb working-tree work). */
+  gitCheckout: number;
+  /** Git operations that hit the network (ls-remote). */
+  gitNetwork: number;
+  /** Git push timeout. */
+  gitPush: number;
+  /** Long-running CLI ops outside the postgres surface (gh repo create, runner registration, etc.). */
+  cliLong: number;
+  /** Short-lived helper commands (which, version probes, env reads). */
+  cmdShort: number;
+  /** Spring Initializr metadata cache TTL. */
+  initializrCacheTtl: number;
+}
+
+/**
+ * Resolved at module load. Override any field via the matching
+ * `LAKEBASE_KIT_TIMEOUT_*` env var, e.g.:
+ *
+ *   LAKEBASE_KIT_TIMEOUT_CLI_DEFAULT_MS=45000  # bump default CLI budget to 45s
+ *   LAKEBASE_KIT_TIMEOUT_READY_WAIT_MS=300000  # 5-min branch-ready budget
+ *
+ * Invalid values (non-numeric, ≤ 0) fall back to the documented default.
+ */
+export const KIT_TIMEOUTS: KitTimeouts = {
+  cliDefault: intFromEnv("LAKEBASE_KIT_TIMEOUT_CLI_DEFAULT_MS", 30_000),
+  cliCreateBranch: intFromEnv("LAKEBASE_KIT_TIMEOUT_CLI_CREATE_BRANCH_MS", 60_000),
+  cliCreateEndpoint: intFromEnv("LAKEBASE_KIT_TIMEOUT_CLI_CREATE_ENDPOINT_MS", 60_000),
+  readyWait: intFromEnv("LAKEBASE_KIT_TIMEOUT_READY_WAIT_MS", 120_000),
+  readyPoll: intFromEnv("LAKEBASE_KIT_TIMEOUT_READY_POLL_MS", 5_000),
+  pgConnect: intFromEnv("LAKEBASE_KIT_TIMEOUT_PG_CONNECT_MS", 10_000),
+  pgStatement: intFromEnv("LAKEBASE_KIT_TIMEOUT_PG_STATEMENT_MS", 15_000),
+  gitDefault: intFromEnv("LAKEBASE_KIT_TIMEOUT_GIT_DEFAULT_MS", 5_000),
+  gitCheckout: intFromEnv("LAKEBASE_KIT_TIMEOUT_GIT_CHECKOUT_MS", 10_000),
+  gitNetwork: intFromEnv("LAKEBASE_KIT_TIMEOUT_GIT_NETWORK_MS", 15_000),
+  gitPush: intFromEnv("LAKEBASE_KIT_TIMEOUT_GIT_PUSH_MS", 30_000),
+  cliLong: intFromEnv("LAKEBASE_KIT_TIMEOUT_CLI_LONG_MS", 60_000),
+  cmdShort: intFromEnv("LAKEBASE_KIT_TIMEOUT_CMD_SHORT_MS", 5_000),
+  initializrCacheTtl: intFromEnv("LAKEBASE_KIT_INITIALIZR_CACHE_TTL_MS", 10 * 60 * 1000),
+};

--- a/scripts/lakebase/kit-config.ts
+++ b/scripts/lakebase/kit-config.ts
@@ -51,7 +51,7 @@ export interface KitTimeouts {
   // The four short-lived tier flavors (feature/test/uat/perf) each have
   // a documented default expiry. Workspaces with a tighter
   // maximum-expiration policy can lower these via the matching env var
-  // — substrate will format `<seconds>s` for the Lakebase API at the
+  // – substrate will format `<seconds>s` for the Lakebase API at the
   // call site. The defaults below match the PSA convention:
   //   feature: 30d, test: 14d, uat: 14d, perf: 7d
   /** Default TTL for feature-tier branches (createFeatureBranch / cutExperiment). */
@@ -111,7 +111,7 @@ export function formatLakebaseTtl(ms: number): string {
 // dev-environment provisioning. Each defaults to the mainline registry;
 // override via the matching env var when running against a proxied or
 // air-gapped environment (e.g. Databricks-internal proxies for Maven
-// Central / npm / PyPI — see internal docs for the setup).
+// Central / npm / PyPI – see internal docs for the setup).
 
 export interface KitRegistries {
   /**

--- a/scripts/lakebase/kit-config.ts
+++ b/scripts/lakebase/kit-config.ts
@@ -46,7 +46,25 @@ export interface KitTimeouts {
   cmdShort: number;
   /** Spring Initializr metadata cache TTL. */
   initializrCacheTtl: number;
+  // ── PSA convention branch TTLs (ms) ────────────────────────────────
+  //
+  // The four short-lived tier flavors (feature/test/uat/perf) each have
+  // a documented default expiry. Workspaces with a tighter
+  // maximum-expiration policy can lower these via the matching env var
+  // — substrate will format `<seconds>s` for the Lakebase API at the
+  // call site. The defaults below match the PSA convention:
+  //   feature: 30d, test: 14d, uat: 14d, perf: 7d
+  /** Default TTL for feature-tier branches (createFeatureBranch / cutExperiment). */
+  featureBranchTtlMs: number;
+  /** Default TTL for test-tier branches (createTestBranch). */
+  testBranchTtlMs: number;
+  /** Default TTL for uat-tier branches (createUatBranch). */
+  uatBranchTtlMs: number;
+  /** Default TTL for perf-tier branches (createPerfBranch). */
+  perfBranchTtlMs: number;
 }
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
 
 /**
  * Resolved at module load. Override any field via the matching
@@ -72,4 +90,61 @@ export const KIT_TIMEOUTS: KitTimeouts = {
   cliLong: intFromEnv("LAKEBASE_KIT_TIMEOUT_CLI_LONG_MS", 60_000),
   cmdShort: intFromEnv("LAKEBASE_KIT_TIMEOUT_CMD_SHORT_MS", 5_000),
   initializrCacheTtl: intFromEnv("LAKEBASE_KIT_INITIALIZR_CACHE_TTL_MS", 10 * 60 * 1000),
+  featureBranchTtlMs: intFromEnv("LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS", 30 * DAY_MS),
+  testBranchTtlMs: intFromEnv("LAKEBASE_KIT_TEST_BRANCH_TTL_MS", 14 * DAY_MS),
+  uatBranchTtlMs: intFromEnv("LAKEBASE_KIT_UAT_BRANCH_TTL_MS", 14 * DAY_MS),
+  perfBranchTtlMs: intFromEnv("LAKEBASE_KIT_PERF_BRANCH_TTL_MS", 7 * DAY_MS),
+};
+
+/**
+ * Format an ms-typed TTL as the Lakebase API's protobuf Duration JSON
+ * encoding (`<seconds>s`). Used by CONVENTION_TIER_DEFAULTS when
+ * formatting branch TTLs for create-branch specs.
+ */
+export function formatLakebaseTtl(ms: number): string {
+  return `${Math.floor(ms / 1000)}s`;
+}
+
+// ── Package registry URLs ──────────────────────────────────────────────
+//
+// Public package-registry endpoints the kit hits during scaffolding +
+// dev-environment provisioning. Each defaults to the mainline registry;
+// override via the matching env var when running against a proxied or
+// air-gapped environment (e.g. Databricks-internal proxies for Maven
+// Central / npm / PyPI — see internal docs for the setup).
+
+export interface KitRegistries {
+  /**
+   * Maven Central root. Used to download the Flyway CLI in
+   * scripts/run-live-tests.sh and for any future Maven-resolved
+   * artifact pulls.
+   *
+   * Default: https://repo1.maven.org/maven2  (mainline Maven Central)
+   * Override: `LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL=https://your-proxy/maven2`
+   */
+  mavenCentral: string;
+  /**
+   * Spring Initializr base URL. Used by spring-initializr.ts to
+   * fetch starter projects + metadata.
+   *
+   * Default: https://start.spring.io  (mainline Spring Initializr)
+   * Override: `LAKEBASE_KIT_REGISTRY_SPRING_INITIALIZR=https://your-mirror`
+   */
+  springInitializr: string;
+}
+
+function urlFromEnv(name: string, fallback: string): string {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  // Trim trailing slashes so callers can safely concat `/path` segments.
+  return raw.replace(/\/+$/, "");
+}
+
+/**
+ * Resolved at module load. Override any field via the matching
+ * `LAKEBASE_KIT_REGISTRY_*` env var.
+ */
+export const KIT_REGISTRIES: KitRegistries = {
+  mavenCentral: urlFromEnv("LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL", "https://repo1.maven.org/maven2"),
+  springInitializr: urlFromEnv("LAKEBASE_KIT_REGISTRY_SPRING_INITIALIZR", "https://start.spring.io"),
 };

--- a/scripts/lakebase/lakebase-project.ts
+++ b/scripts/lakebase/lakebase-project.ts
@@ -76,9 +76,9 @@ export async function deleteLakebaseProject(args: LakebaseProjectArgs): Promise<
  * (the resource-path leaf, e.g. `production`), NOT its {@link BranchUid}.
  *
  * Why this returns BranchName specifically: every API field that takes a
- * branch reference — `source_branch` in create-branch specs, the
+ * branch reference – `source_branch` in create-branch specs, the
  * `{branch}` segment in `branches/{x}/endpoints/...` URLs, .env
- * LAKEBASE_BRANCH_NAME — wants the path leaf, not the uid. Returning a
+ * LAKEBASE_BRANCH_NAME – wants the path leaf, not the uid. Returning a
  * uid here (the prior contract under the misleading name
  * `getDefaultBranchId`) caused a "branch id not found" error from the
  * service when the value was substituted into source_branch.

--- a/scripts/lakebase/lakebase-project.ts
+++ b/scripts/lakebase/lakebase-project.ts
@@ -6,6 +6,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { branchNameFromResourcePath, type BranchName } from "./branch-id.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 
 const execFileP = promisify(execFile);
 
@@ -178,7 +179,7 @@ async function dbcli(args: string[], host?: string): Promise<string> {
   try {
     const { stdout } = await execFileP("databricks", args, {
       env: env as NodeJS.ProcessEnv,
-      timeout: 30_000,
+      timeout: KIT_TIMEOUTS.cliDefault,
     });
     return stdout.toString();
   } catch (err) {

--- a/scripts/lakebase/lakebase-project.ts
+++ b/scripts/lakebase/lakebase-project.ts
@@ -5,6 +5,7 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { branchNameFromResourcePath, type BranchName } from "./branch-id.js";
 
 const execFileP = promisify(execFile);
 
@@ -69,7 +70,38 @@ export async function deleteLakebaseProject(args: LakebaseProjectArgs): Promise<
  * Returns the empty string if the default branch isn't ready yet (the
  * extension treats that as non-fatal in createProject step 4).
  */
-export async function getDefaultBranchId(args: LakebaseProjectArgs): Promise<string> {
+/**
+ * Resolve the project's default branch and return its {@link BranchName}
+ * (the resource-path leaf, e.g. `production`), NOT its {@link BranchUid}.
+ *
+ * Why this returns BranchName specifically: every API field that takes a
+ * branch reference — `source_branch` in create-branch specs, the
+ * `{branch}` segment in `branches/{x}/endpoints/...` URLs, .env
+ * LAKEBASE_BRANCH_NAME — wants the path leaf, not the uid. Returning a
+ * uid here (the prior contract under the misleading name
+ * `getDefaultBranchId`) caused a "branch id not found" error from the
+ * service when the value was substituted into source_branch.
+ *
+ * Returns null when the project has no default branch or the CLI errored.
+ */
+/**
+ * Pure helper: extract the default branch's BranchName from a parsed
+ * list-branches response. Exported so the regression contract is
+ * directly unit-testable without mocking the Databricks CLI.
+ *
+ * Always derives from `name`, never from `uid`. A BranchUid in this slot
+ * would be silently wrong: the API rejects uids in path-shaped fields
+ * (which is the only place this function's return value belongs).
+ */
+export function findDefaultBranchName(items: BranchMetadata[]): BranchName | null {
+  const def = items.find((b) => b.status?.default === true || b.is_default === true);
+  if (!def || !def.name) return null;
+  return branchNameFromResourcePath(def.name);
+}
+
+export async function getDefaultBranchName(
+  args: LakebaseProjectArgs
+): Promise<BranchName | null> {
   try {
     const raw = await dbcli(
       ["postgres", "list-branches", `projects/${args.projectId}`, "-o", "json"],
@@ -81,15 +113,25 @@ export async function getDefaultBranchId(args: LakebaseProjectArgs): Promise<str
     const items: BranchMetadata[] = Array.isArray(parsed)
       ? parsed
       : parsed.branches ?? parsed.items ?? [];
-    const def = items.find((b) => b.status?.default === true || b.is_default === true);
-    if (!def) return "";
-    return def.uid ?? def.name?.split("/branches/").pop() ?? "";
+    return findDefaultBranchName(items);
   } catch {
-    return "";
+    return null;
   }
 }
 
-interface BranchMetadata {
+/**
+ * @deprecated Renamed to {@link getDefaultBranchName}. The old name was
+ * ambiguous ("Id" of what?) and the old implementation returned the
+ * BranchUid, which is wrong for every caller that passes it into a
+ * path-shaped API field. This shim now returns the BranchName as a bare
+ * string for transitional callers; remove after the next major bump.
+ */
+export async function getDefaultBranchId(args: LakebaseProjectArgs): Promise<string> {
+  const name = await getDefaultBranchName(args);
+  return name ?? "";
+}
+
+export interface BranchMetadata {
   uid?: string;
   name?: string;
   status?: { default?: boolean };

--- a/scripts/lakebase/paired-branch.ts
+++ b/scripts/lakebase/paired-branch.ts
@@ -31,6 +31,7 @@ import { mintCredential } from "./get-connection.js";
 import { sanitizeBranchName } from "../util/sanitize-branch-name.js";
 import { updateEnvConnection } from "./env-file.js";
 import { DEFAULT_DATABASE, POSTGRES_PORT } from "./constants.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 
 // ─── Internal git helpers ───────────────────────────────────────
 
@@ -39,7 +40,7 @@ function gitCurrentBranch(cwd: string): string {
     cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: 5_000,
+    timeout: KIT_TIMEOUTS.gitDefault,
   }).trim();
 }
 
@@ -48,7 +49,7 @@ function gitHasLocalBranch(cwd: string, branch: string): boolean {
     execFileSync("git", ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`], {
       cwd,
       stdio: "ignore",
-      timeout: 5_000,
+      timeout: KIT_TIMEOUTS.gitDefault,
     });
     return true;
   } catch {
@@ -60,7 +61,7 @@ function gitCheckoutNewBranch(cwd: string, branch: string): void {
   execFileSync("git", ["checkout", "-b", branch], {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: 10_000,
+    timeout: KIT_TIMEOUTS.gitCheckout,
   });
 }
 
@@ -68,7 +69,7 @@ function gitCheckoutExistingBranch(cwd: string, branch: string): void {
   execFileSync("git", ["checkout", branch], {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: 10_000,
+    timeout: KIT_TIMEOUTS.gitCheckout,
   });
 }
 
@@ -76,7 +77,7 @@ function gitDeleteLocalBranch(cwd: string, branch: string, force = true): void {
   execFileSync("git", ["branch", force ? "-D" : "-d", branch], {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: 5_000,
+    timeout: KIT_TIMEOUTS.gitDefault,
   });
 }
 
@@ -85,7 +86,7 @@ function gitHasRemoteBranch(cwd: string, remote: string, branch: string): boolea
     const out = execFileSync(
       "git",
       ["ls-remote", "--exit-code", "--heads", remote, branch],
-      { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 15_000 }
+      { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: KIT_TIMEOUTS.gitNetwork }
     );
     return out.trim().length > 0;
   } catch {
@@ -97,7 +98,7 @@ function gitDeleteRemoteBranch(cwd: string, remote: string, branch: string): voi
   execFileSync("git", ["push", remote, "--delete", branch], {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: 30_000,
+    timeout: KIT_TIMEOUTS.gitPush,
   });
 }
 
@@ -183,7 +184,7 @@ export async function createPairedBranch(
       ready = await waitForBranchReady({
         instance: args.instance,
         branch: sanitized,
-        timeoutMs: args.readyTimeoutMs ?? 120_000,
+        timeoutMs: args.readyTimeoutMs ?? KIT_TIMEOUTS.readyWait,
       });
     } catch (err) {
       warnings.push(
@@ -578,7 +579,7 @@ export async function checkoutPaired(args: CheckoutPairedArgs): Promise<Checkout
             await waitForBranchReady({
               instance,
               branch: branchId,
-              timeoutMs: args.readyTimeoutMs ?? 120_000,
+              timeoutMs: args.readyTimeoutMs ?? KIT_TIMEOUTS.readyWait,
             });
           } catch (err) {
             warnings.push(
@@ -601,7 +602,7 @@ export async function checkoutPaired(args: CheckoutPairedArgs): Promise<Checkout
   const ep = await ensureEndpoint({
     instance,
     branch: lakebaseBranch,
-    timeoutMs: args.readyTimeoutMs ?? 120_000,
+    timeoutMs: args.readyTimeoutMs ?? KIT_TIMEOUTS.readyWait,
   });
   const { token, email } = await mintCredential(endpointPath(instance, lakebaseBranch));
   const dsn = buildDsn(ep.host, database, email, token);

--- a/scripts/lakebase/paired-branch.ts
+++ b/scripts/lakebase/paired-branch.ts
@@ -30,6 +30,7 @@ import {
 import { mintCredential } from "./get-connection.js";
 import { sanitizeBranchName } from "../util/sanitize-branch-name.js";
 import { updateEnvConnection } from "./env-file.js";
+import { DEFAULT_DATABASE, POSTGRES_PORT } from "./constants.js";
 
 // ─── Internal git helpers ───────────────────────────────────────
 
@@ -109,7 +110,7 @@ function readEnvVar(envPath: string, key: string): string | undefined {
 }
 
 function buildDsn(host: string, database: string, user: string, password: string): string {
-  const u = new URL(`postgresql://${host}:5432/${encodeURIComponent(database)}`);
+  const u = new URL(`postgresql://${host}:${POSTGRES_PORT}/${encodeURIComponent(database)}`);
   u.username = encodeURIComponent(user);
   u.password = encodeURIComponent(password);
   u.searchParams.set("sslmode", "require");
@@ -166,7 +167,7 @@ export async function createPairedBranch(
   const sanitized = sanitizeBranchName(args.branch);
   const createGitBranch = args.createGitBranch !== false;
   const syncEnv = args.syncEnv !== false;
-  const database = args.database ?? process.env.PGDATABASE ?? "databricks_postgres";
+  const database = args.database ?? process.env.PGDATABASE ?? DEFAULT_DATABASE;
 
   // 1. Create Lakebase branch (idempotent if already exists with same name)
   const branch = await createBranch({
@@ -379,7 +380,7 @@ export async function syncEnvToCurrentBranch(args: SyncEnvArgs): Promise<SyncEnv
   }
   const rawBranch = args.branch ?? gitCurrentBranch(args.cwd);
   const sanitized = sanitizeBranchName(rawBranch);
-  const database = args.database ?? process.env.PGDATABASE ?? "databricks_postgres";
+  const database = args.database ?? process.env.PGDATABASE ?? DEFAULT_DATABASE;
 
   const ep = await getEndpoint({ instance, branch: sanitized });
   if (!ep?.host) {
@@ -511,7 +512,7 @@ export async function checkoutPaired(args: CheckoutPairedArgs): Promise<Checkout
     );
   }
   const branchId = sanitizeBranchName(rawBranch);
-  const database = args.database ?? process.env.PGDATABASE ?? "databricks_postgres";
+  const database = args.database ?? process.env.PGDATABASE ?? DEFAULT_DATABASE;
 
   // 3. Resolve "previous Lakebase branch" – caller arg wins over .env
   const previousBranch =

--- a/scripts/lakebase/runner-setup.ts
+++ b/scripts/lakebase/runner-setup.ts
@@ -21,6 +21,7 @@ import * as tar from "tar";
 import findJavaHome from "find-java-home";
 import treeKill from "tree-kill";
 import { delay } from "../util/delay.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 import {
   createRegistrationToken,
   getRunnerIdByName,
@@ -137,7 +138,7 @@ export function stopRunner(projectName: string): void {
     // Legacy fallback for runners whose pid we don't know.
     try {
       cp.execSync(`pkill -9 -f "${dir.replace(/\//g, "\\/")}.*Runner" 2>/dev/null || true`, {
-        timeout: 5000,
+        timeout: KIT_TIMEOUTS.cmdShort,
       });
     } catch {
       /* ignore */
@@ -272,7 +273,7 @@ export async function setupRunner(args: SetupRunnerArgs): Promise<RunnerInfo> {
     const regToken = await createRegistrationToken(args.fullRepoName);
     cp.execSync(
       `./config.sh --url "https://github.com/${args.fullRepoName}" --token "${regToken}" --name "${name}" --labels self-hosted --unattended --replace`,
-      { cwd: dir, timeout: 60_000 }
+      { cwd: dir, timeout: KIT_TIMEOUTS.cliLong }
     );
   }
 

--- a/scripts/lakebase/schema-diff.ts
+++ b/scripts/lakebase/schema-diff.ts
@@ -14,6 +14,7 @@
 import { execFileSync } from "node:child_process";
 import type { Pool } from "pg";
 import { getConnection } from "./get-connection.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 
 export interface SchemaColumn {
   name: string;
@@ -298,6 +299,6 @@ function dbcli(args: string[]): string {
   return execFileSync("databricks", args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: 30_000,
+    timeout: KIT_TIMEOUTS.cliDefault,
   });
 }

--- a/scripts/lakebase/spring-initializr.ts
+++ b/scripts/lakebase/spring-initializr.ts
@@ -18,6 +18,7 @@ import { sanitizeArtifactId } from "../util/maven-coords.js";
 import { copyDirSubstituted } from "../util/copy-dir-substituted.js";
 import { extractZipToDir } from "../util/zip-extract.js";
 import { patchPomForLakebase } from "../util/pom-patch.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
 
 export type SpringJvmLanguage = "java" | "kotlin";
 
@@ -59,7 +60,7 @@ interface MetadataCache {
 }
 
 const METADATA_ACCEPT = "application/vnd.initializr.v2.3+json";
-const CACHE_TTL_MS = 10 * 60 * 1000;
+const CACHE_TTL_MS = KIT_TIMEOUTS.initializrCacheTtl;
 const DEFAULT_BASE_URL = "https://start.spring.io";
 const DEPENDENCIES = "web,data-jpa,postgresql,flyway";
 

--- a/scripts/lakebase/spring-initializr.ts
+++ b/scripts/lakebase/spring-initializr.ts
@@ -18,7 +18,7 @@ import { sanitizeArtifactId } from "../util/maven-coords.js";
 import { copyDirSubstituted } from "../util/copy-dir-substituted.js";
 import { extractZipToDir } from "../util/zip-extract.js";
 import { patchPomForLakebase } from "../util/pom-patch.js";
-import { KIT_TIMEOUTS } from "./kit-config.js";
+import { KIT_REGISTRIES, KIT_TIMEOUTS } from "./kit-config.js";
 
 export type SpringJvmLanguage = "java" | "kotlin";
 
@@ -61,7 +61,7 @@ interface MetadataCache {
 
 const METADATA_ACCEPT = "application/vnd.initializr.v2.3+json";
 const CACHE_TTL_MS = KIT_TIMEOUTS.initializrCacheTtl;
-const DEFAULT_BASE_URL = "https://start.spring.io";
+const DEFAULT_BASE_URL = KIT_REGISTRIES.springInitializr;
 const DEPENDENCIES = "web,data-jpa,postgresql,flyway";
 
 /** SNAPSHOT, RC, milestone, alpha/beta versions are not GA. */

--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -257,9 +257,6 @@ export LAKEBASE_TEST_BRANCH="$BRANCH"
 export LAKEBASE_TEST_PARENT="$PARENT"
 export LAKEBASE_TEST_HOST="$DATABRICKS_HOST"
 export LAKEBASE_TEST_PROFILE="$PROFILE"
-# Resource-path form of the project id; unlocks tdd-experiment-lifecycle's
-# live describe (which uses it as cutExperiment's instance argument).
-export LAKEBASE_TEST_PROJECT_PATH="projects/$PROJECT_ID"
 # Optional fields: only set when the user provides them. Tests have
 # sensible defaults if absent.
 export LAKEBASE_TEST_COMPARISON_BRANCH="${LAKEBASE_TEST_COMPARISON_BRANCH:-$BRANCH}"

--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -45,13 +45,24 @@
 #   --teardown                 After a green run, delete the auto-provisioned project.
 #                              No-op when --project was supplied.
 #   --no-prompt                Skip the grace period entirely (for CI).
+#   --no-github-runner         Skip the FEIP-7138 self-hosted-runner live test
+#                              (default: enabled). Requires GitHub auth on the
+#                              host (gh CLI logged in or GITHUB_TOKEN env).
+#   --no-migrate-tools         Skip auto-provisioning alembic/flyway tools and
+#                              leave migrate-live + migrate-live-flyway gated
+#                              on whatever is already on PATH (default: enabled).
 #   --help                     This help.
 #
-# What is NOT unlocked by this script:
-#   - tests/integration/detect-language-via-self-hosted-runner.test.ts
-#     (needs a self-hosted GitHub Actions runner registered).
-#   - LAKEBASE_TEST_PROJECT_PATH-gated TDD live tests (need a Databricks
-#     workspace path; deferred until the TDD scaffolder lands one).
+# What this script unlocks (every live-gated test in the kit):
+#   - All LAKEBASE_TEST_E2E-gated suites (cut-experiment, paired-branch,
+#     branch-create/delete, branch-utils, branch-endpoint, etc.).
+#   - migrate-live + migrate-live-flyway via auto-provisioned venv + tools.
+#   - tdd-experiment-lifecycle live describe (LAKEBASE_TEST_PROJECT_PATH).
+#   - detect-language-via-self-hosted-runner via --include-github-runner
+#     (LAKEBASE_TEST_E2E_GITHUB=1; pass --no-github-runner to opt out).
+# A clean run reports zero contributor-actionable skips. Skips that remain
+# are pure assertion-shape decisions inside the test files themselves
+# (e.g. kit-config defaults vs env overrides).
 #
 # What this script gates on (substrate convention):
 #   LAKEBASE_TEST_NO_TEARDOWN=1 is set by default. Failed runs leave the
@@ -79,6 +90,8 @@ DATABASE=""
 FEATURE_TTL_DAYS=""
 TEARDOWN_ON_GREEN=0
 NO_PROMPT=0
+INCLUDE_GITHUB_RUNNER=1
+INCLUDE_MIGRATE_TOOLS=1
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -92,6 +105,8 @@ while [[ $# -gt 0 ]]; do
     --feature-ttl-days)   FEATURE_TTL_DAYS="$2"; shift 2 ;;
     --teardown)           TEARDOWN_ON_GREEN=1; shift ;;
     --no-prompt)          NO_PROMPT=1; shift ;;
+    --no-github-runner)   INCLUDE_GITHUB_RUNNER=0; shift ;;
+    --no-migrate-tools)   INCLUDE_MIGRATE_TOOLS=0; shift ;;
     --help|-h)
       # `sed '$d'` drops the trailing `set -euo pipefail` line that closes
       # the range. Cross-platform: `head -n -1` is GNU-only (BSD head on
@@ -242,6 +257,9 @@ export LAKEBASE_TEST_BRANCH="$BRANCH"
 export LAKEBASE_TEST_PARENT="$PARENT"
 export LAKEBASE_TEST_HOST="$DATABRICKS_HOST"
 export LAKEBASE_TEST_PROFILE="$PROFILE"
+# Resource-path form of the project id; unlocks tdd-experiment-lifecycle's
+# live describe (which uses it as cutExperiment's instance argument).
+export LAKEBASE_TEST_PROJECT_PATH="projects/$PROJECT_ID"
 # Optional fields: only set when the user provides them. Tests have
 # sensible defaults if absent.
 export LAKEBASE_TEST_COMPARISON_BRANCH="${LAKEBASE_TEST_COMPARISON_BRANCH:-$BRANCH}"
@@ -278,6 +296,78 @@ green "  LAKEBASE_TEST_INSTANCE=$LAKEBASE_TEST_INSTANCE"
 green "  LAKEBASE_TEST_BRANCH=$LAKEBASE_TEST_BRANCH  LAKEBASE_TEST_PARENT=$LAKEBASE_TEST_PARENT"
 green "  LAKEBASE_TEST_E2E=1  LAKEBASE_TEST_INITIALIZR=1  PEER_DEP_INTEGRATION=1"
 green "  LAKEBASE_TEST_NO_TEARDOWN=1  (per substrate convention)"
+
+# Provision the per-suite tooling that migrate-live + migrate-live-flyway
+# gate on (alembic, sqlalchemy, psycopg2-binary; flyway + java). Both
+# blocks are idempotent: a cached venv / Flyway tree skips download.
+# Pass --no-migrate-tools to leave PATH untouched (e.g. on machines with
+# the tools pre-installed via brew / apt).
+FLYWAY_VERSION="10.20.1"
+if [[ "$INCLUDE_MIGRATE_TOOLS" -eq 1 ]]; then
+  VENV="$REPO_ROOT/.venv-live-tests"
+  if [[ ! -x "$VENV/bin/alembic" ]]; then
+    blue ""
+    blue "==> Provisioning Python venv at $VENV (one-time setup, alembic + deps)"
+    python3 -m venv "$VENV"
+    "$VENV/bin/pip" install --quiet --upgrade pip
+    "$VENV/bin/pip" install --quiet alembic sqlalchemy psycopg2-binary
+  fi
+  green "  using alembic from $VENV/bin/alembic"
+  export PATH="$VENV/bin:$PATH"
+
+  FLYWAY_HOME="$REPO_ROOT/.tools-live-tests/flyway-$FLYWAY_VERSION"
+  if command -v flyway >/dev/null 2>&1; then
+    green "  using flyway from $(command -v flyway) (pre-installed)"
+  elif [[ -x "$FLYWAY_HOME/flyway" ]]; then
+    green "  using flyway from $FLYWAY_HOME/flyway (cached)"
+    export PATH="$FLYWAY_HOME:$PATH"
+  else
+    blue ""
+    blue "==> Provisioning Flyway CLI $FLYWAY_VERSION at $FLYWAY_HOME (one-time setup)"
+    mkdir -p "$REPO_ROOT/.tools-live-tests"
+    ZIP="$REPO_ROOT/.tools-live-tests/flyway-commandline-$FLYWAY_VERSION.zip"
+    MAVEN_CENTRAL="${LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL:-https://repo1.maven.org/maven2}"
+    URL="${MAVEN_CENTRAL%/}/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.zip"
+    if [[ ! -f "$ZIP" ]]; then
+      if ! curl --fail --silent --show-error --location -o "$ZIP" "$URL"; then
+        red ""
+        red "  Could not download Flyway from $URL"
+        yellow "  Workarounds: install Flyway via brew/apt and re-run, or pass --no-migrate-tools."
+        exit 1
+      fi
+    fi
+    unzip -q -d "$REPO_ROOT/.tools-live-tests" "$ZIP"
+    rm -f "$ZIP"
+    if [[ ! -x "$FLYWAY_HOME/flyway" ]]; then
+      red "  flyway extracted but $FLYWAY_HOME/flyway is missing or not executable"
+      exit 1
+    fi
+    green "  using flyway from $FLYWAY_HOME/flyway"
+    export PATH="$FLYWAY_HOME:$PATH"
+  fi
+fi
+
+# FEIP-7138 self-hosted-runner suite: register a real runner against a
+# fresh private repo and prove npx --package=github:... routing works
+# end-to-end. Defaults to enabled (per the "no exceptions" policy) and
+# opts out via --no-github-runner. Requires GitHub auth on the host
+# (gh CLI logged in OR GITHUB_TOKEN env). The test creates a real repo
+# scoped to the contributor's login; on assertion FAIL the repo and
+# runner are preserved per the kit's never-teardown-on-failure rule.
+if [[ "$INCLUDE_GITHUB_RUNNER" -eq 1 ]]; then
+  export LAKEBASE_TEST_E2E_GITHUB=1
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    green "  LAKEBASE_TEST_E2E_GITHUB=1  (gh CLI auth detected)"
+  elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    green "  LAKEBASE_TEST_E2E_GITHUB=1  (GITHUB_TOKEN env detected)"
+  else
+    yellow "  LAKEBASE_TEST_E2E_GITHUB=1  (no gh auth or GITHUB_TOKEN visible)"
+    yellow "  The suite will error fast if auth cannot be resolved at run-time."
+    yellow "  To opt out, re-run with --no-github-runner."
+  fi
+else
+  yellow "  --no-github-runner: skipping FEIP-7138 self-hosted-runner suite"
+fi
 
 # Build dist so the integration tests import the latest compiled substrate.
 blue ""

--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -177,7 +177,7 @@ else
   yellow "==> About to create a fresh Lakebase project"
   yellow "    workspace:  $DATABRICKS_HOST"
   yellow "    project:    $PROJECT_ID  (NEW)"
-  yellow "    teardown:   $( [[ $TEARDOWN_ON_GREEN == 1 ]] && echo 'on green run' || echo 'DISABLED — manual cleanup required at end' )"
+  yellow "    teardown:   $( [[ $TEARDOWN_ON_GREEN == 1 ]] && echo 'on green run' || echo 'DISABLED – manual cleanup required at end' )"
   yellow ""
   if [[ "$NO_PROMPT" != "1" ]]; then
     yellow "    Press Ctrl-C in the next ${GRACE_SECONDS} seconds to abort. Pass --no-prompt to skip in CI, or --grace-seconds to tune."
@@ -189,7 +189,7 @@ else
   green "  created: $PROJECT_ID"
 fi
 
-# Resolve the default branch name (leaf of name, never uid — see
+# Resolve the default branch name (leaf of name, never uid – see
 # scripts/lakebase/branch-id.ts for the rationale).
 DEFAULT_BRANCH="$(databricks postgres list-branches "projects/$PROJECT_ID" --profile "$PROFILE" -o json 2>&1 | python3 -c "
 import json, sys
@@ -231,7 +231,7 @@ export LAKEBASE_TEST_COMPARISON_BRANCH="${LAKEBASE_TEST_COMPARISON_BRANCH:-$BRAN
 # LAKEBASE_TEST_DATABASE: explicit --database flag wins; otherwise leave
 # whatever the caller's env already has (which may itself be unset).
 # When unset, the substrate falls back to DEFAULT_DATABASE
-# (scripts/lakebase/constants.ts) — single source of truth, no duplication.
+# (scripts/lakebase/constants.ts) – single source of truth, no duplication.
 if [[ -n "$DATABASE" ]]; then
   export LAKEBASE_TEST_DATABASE="$DATABASE"
 fi

--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -123,6 +123,23 @@ if [[ -z "$PROFILE" ]]; then
   exit 2
 fi
 
+# Load .env.template.config (public defaults, committed) then
+# .env.local.config (local overrides, gitignored). Both use `export
+# VAR=value` so values propagate to child processes (npx vitest, etc.).
+# Variables passed inline at script invocation are stomped by the
+# template; if you need an invocation-time override, set it in
+# .env.local.config or pass via the script's --flags.
+if [[ -f "$REPO_ROOT/.env.template.config" ]]; then
+  blue "==> Sourcing .env.template.config (public defaults)"
+  # shellcheck source=/dev/null
+  . "$REPO_ROOT/.env.template.config"
+fi
+if [[ -f "$REPO_ROOT/.env.local.config" ]]; then
+  blue "==> Sourcing .env.local.config (local overrides)"
+  # shellcheck source=/dev/null
+  . "$REPO_ROOT/.env.local.config"
+fi
+
 blue "==> Resolving workspace host from profile '$PROFILE'"
 if ! command -v databricks >/dev/null 2>&1; then
   red "  databricks CLI not on PATH"
@@ -242,7 +259,10 @@ fi
 # tdd-synthesis paths. We compute ms = days * 86_400_000 here so the
 # substrate's existing convention defaults pick it up.
 if [[ -n "$FEATURE_TTL_DAYS" ]]; then
-  export LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS="$(( FEATURE_TTL_DAYS * 86_400_000 ))"
+  # Bash arithmetic: avoid underscore separators (86_400_000 is parsed as
+  # octal in some bash modes and fails with "value too great for base").
+  # Plain digits work everywhere.
+  export LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS="$(( FEATURE_TTL_DAYS * 86400000 ))"
   green "  LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS=$LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS  (${FEATURE_TTL_DAYS}d)"
 fi
 # Unlock the live Initializr fetch + the MCP peer-dep integration check.

--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -65,9 +65,14 @@
 # (e.g. kit-config defaults vs env overrides).
 #
 # What this script gates on (substrate convention):
-#   LAKEBASE_TEST_NO_TEARDOWN=1 is set by default. Failed runs leave the
-#   project + branches in place. The user must explicitly pass --teardown
-#   to enable post-run cleanup, and even then only on a fully-green run.
+#   LAKEBASE_TEST_NO_TEARDOWN=1 is set by default. The orchestrator-level
+#   Lakebase project (live-all-<ts>) is preserved on a failed run so the
+#   user can inspect; pass --teardown to delete on a fully-green run.
+#   Per-suite ephemera (migrate-7091, migrate-7098 Lakebase projects, the
+#   FEIP-7138 GitHub repo + runner) clean themselves up on green and
+#   preserve on fail. The orchestrator and per-suite teardown rules are
+#   independent; LAKEBASE_TEST_NO_TEARDOWN does NOT block per-suite
+#   cleanup of green tests.
 
 set -euo pipefail
 

--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -15,10 +15,12 @@
 #     provisioned project after a green run.
 #
 # Usage:
-#   scripts/run-all-live-tests.sh --profile <name>           # auto-provision + full suite
-#   scripts/run-all-live-tests.sh --profile <name> --project <id>   # reuse an existing project
-#   scripts/run-all-live-tests.sh --profile <name> --teardown       # delete the project on green
-#   scripts/run-all-live-tests.sh --profile <name> --no-prompt      # CI mode (skip the 5s grace)
+#   scripts/run-all-live-tests.sh --profile <name>                       # auto-provision + full suite
+#   scripts/run-all-live-tests.sh --profile <name> --project <id>        # reuse an existing project
+#   scripts/run-all-live-tests.sh --profile <name> --teardown            # delete the project on green
+#   scripts/run-all-live-tests.sh --profile <name> --no-prompt           # CI mode (skip grace period)
+#   scripts/run-all-live-tests.sh --profile <name> \
+#     --project-prefix smoke-ci- --grace-seconds 10 --database my_db     # fully parameterized invocation
 #
 # Required:
 #   --profile <name>     A `databricks` CLI profile (from ~/.databrickscfg).
@@ -26,14 +28,20 @@
 #                        `databricks auth env --profile <name>`.
 #
 # Optional:
-#   --project <id>       Use an existing Lakebase project (skips auto-provision).
-#                        Default branch is auto-discovered via list-branches.
-#   --branch <name>      Override LAKEBASE_TEST_BRANCH (default: project's default branch).
-#   --parent <name>      Override LAKEBASE_TEST_PARENT (default: same as --branch).
-#   --teardown           After a green run, delete the auto-provisioned project.
-#                        No-op when --project was supplied.
-#   --no-prompt          Skip the 5-second creation grace period (for CI).
-#   --help               This help.
+#   --project <id>             Use an existing Lakebase project (skips auto-provision).
+#                              Default branch is auto-discovered via list-branches.
+#   --branch <name>            Override LAKEBASE_TEST_BRANCH (default: project's default branch).
+#   --parent <name>            Override LAKEBASE_TEST_PARENT (default: same as --branch).
+#   --project-prefix <prefix>  Prefix for auto-provisioned project ids. Default: "live-all-".
+#                              The full id becomes <prefix><unix-timestamp>.
+#   --grace-seconds <n>        Seconds to wait before creating the project (Ctrl-C abort
+#                              window). Default: 5. Use 0 + --no-prompt for CI.
+#   --database <name>          LAKEBASE_TEST_DATABASE override. Default: unset, so the
+#                              substrate falls back to DEFAULT_DATABASE (constants.ts).
+#   --teardown                 After a green run, delete the auto-provisioned project.
+#                              No-op when --project was supplied.
+#   --no-prompt                Skip the grace period entirely (for CI).
+#   --help                     This help.
 #
 # What is NOT unlocked by this script:
 #   - tests/integration/detect-language-via-self-hosted-runner.test.ts
@@ -61,19 +69,28 @@ PROFILE=""
 PROJECT_ID=""
 BRANCH_OVERRIDE=""
 PARENT_OVERRIDE=""
+PROJECT_PREFIX="live-all-"
+GRACE_SECONDS=5
+DATABASE=""
 TEARDOWN_ON_GREEN=0
 NO_PROMPT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --profile)    PROFILE="$2"; shift 2 ;;
-    --project)    PROJECT_ID="$2"; shift 2 ;;
-    --branch)     BRANCH_OVERRIDE="$2"; shift 2 ;;
-    --parent)     PARENT_OVERRIDE="$2"; shift 2 ;;
-    --teardown)   TEARDOWN_ON_GREEN=1; shift ;;
-    --no-prompt)  NO_PROMPT=1; shift ;;
+    --profile)         PROFILE="$2"; shift 2 ;;
+    --project)         PROJECT_ID="$2"; shift 2 ;;
+    --branch)          BRANCH_OVERRIDE="$2"; shift 2 ;;
+    --parent)          PARENT_OVERRIDE="$2"; shift 2 ;;
+    --project-prefix)  PROJECT_PREFIX="$2"; shift 2 ;;
+    --grace-seconds)   GRACE_SECONDS="$2"; shift 2 ;;
+    --database)        DATABASE="$2"; shift 2 ;;
+    --teardown)        TEARDOWN_ON_GREEN=1; shift ;;
+    --no-prompt)       NO_PROMPT=1; shift ;;
     --help|-h)
-      sed -n '2,/^set -euo pipefail/p' "$0" | sed 's/^# \{0,1\}//' | head -n -1
+      # `sed '$d'` drops the trailing `set -euo pipefail` line that closes
+      # the range. Cross-platform: `head -n -1` is GNU-only (BSD head on
+      # macOS errors with "illegal line count -- -1").
+      sed -n '2,/^set -euo pipefail/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d'
       exit 0
       ;;
     *)
@@ -83,6 +100,11 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if ! [[ "$GRACE_SECONDS" =~ ^[0-9]+$ ]]; then
+  red "--grace-seconds must be a non-negative integer (got: $GRACE_SECONDS)"
+  exit 2
+fi
 
 if [[ -z "$PROFILE" ]]; then
   red "--profile is required."
@@ -139,7 +161,7 @@ if [[ -n "$PROJECT_ID" ]]; then
   fi
   green "  project exists, READY"
 else
-  PROJECT_ID="live-all-$(date +%s)"
+  PROJECT_ID="${PROJECT_PREFIX}$(date +%s)"
   yellow ""
   yellow "==> About to create a fresh Lakebase project"
   yellow "    workspace:  $DATABRICKS_HOST"
@@ -147,8 +169,8 @@ else
   yellow "    teardown:   $( [[ $TEARDOWN_ON_GREEN == 1 ]] && echo 'on green run' || echo 'DISABLED — manual cleanup required at end' )"
   yellow ""
   if [[ "$NO_PROMPT" != "1" ]]; then
-    yellow "    Press Ctrl-C in the next 5 seconds to abort. Pass --no-prompt to skip in CI."
-    sleep 5
+    yellow "    Press Ctrl-C in the next ${GRACE_SECONDS} seconds to abort. Pass --no-prompt to skip in CI, or --grace-seconds to tune."
+    sleep "$GRACE_SECONDS"
   fi
   blue "==> Creating Lakebase project $PROJECT_ID (long-running, ~30s)"
   databricks postgres create-project "$PROJECT_ID" --profile "$PROFILE" -o json >/dev/null
@@ -195,7 +217,13 @@ export LAKEBASE_TEST_PROFILE="$PROFILE"
 # Optional fields: only set when the user provides them. Tests have
 # sensible defaults if absent.
 export LAKEBASE_TEST_COMPARISON_BRANCH="${LAKEBASE_TEST_COMPARISON_BRANCH:-$BRANCH}"
-export LAKEBASE_TEST_DATABASE="${LAKEBASE_TEST_DATABASE:-databricks_postgres}"
+# LAKEBASE_TEST_DATABASE: explicit --database flag wins; otherwise leave
+# whatever the caller's env already has (which may itself be unset).
+# When unset, the substrate falls back to DEFAULT_DATABASE
+# (scripts/lakebase/constants.ts) — single source of truth, no duplication.
+if [[ -n "$DATABASE" ]]; then
+  export LAKEBASE_TEST_DATABASE="$DATABASE"
+fi
 # Unlock the live Initializr fetch + the MCP peer-dep integration check.
 # Both are network/integration-side and the gate is just a "yes please".
 export LAKEBASE_TEST_INITIALIZR=1

--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# Run the kit's FULL test suite, including every env-gated live test,
+# against a real Databricks workspace. One command, one project, all
+# env vars set sensibly.
+#
+# Differs from scripts/run-live-tests.sh:
+#   - Auto-resolves DATABRICKS_HOST from a `databricks` CLI profile.
+#   - Provisions a fresh Lakebase project on demand (or accepts an
+#     existing project id via --project).
+#   - Sets every additional env var the kit's tests gate on
+#     (LAKEBASE_TEST_INITIALIZR, PEER_DEP_INTEGRATION, the four
+#     LAKEBASE_TEST_INSTANCE/BRANCH/PARENT/HOST identifiers, etc.).
+#   - Defaults to NO TEARDOWN on failure (the kit's convention; failed
+#     state must survive for inspection). Use --teardown to delete the
+#     provisioned project after a green run.
+#
+# Usage:
+#   scripts/run-all-live-tests.sh --profile <name>           # auto-provision + full suite
+#   scripts/run-all-live-tests.sh --profile <name> --project <id>   # reuse an existing project
+#   scripts/run-all-live-tests.sh --profile <name> --teardown       # delete the project on green
+#   scripts/run-all-live-tests.sh --profile <name> --no-prompt      # CI mode (skip the 5s grace)
+#
+# Required:
+#   --profile <name>     A `databricks` CLI profile (from ~/.databrickscfg).
+#                        DATABRICKS_HOST is auto-resolved via
+#                        `databricks auth env --profile <name>`.
+#
+# Optional:
+#   --project <id>       Use an existing Lakebase project (skips auto-provision).
+#                        Default branch is auto-discovered via list-branches.
+#   --branch <name>      Override LAKEBASE_TEST_BRANCH (default: project's default branch).
+#   --parent <name>      Override LAKEBASE_TEST_PARENT (default: same as --branch).
+#   --teardown           After a green run, delete the auto-provisioned project.
+#                        No-op when --project was supplied.
+#   --no-prompt          Skip the 5-second creation grace period (for CI).
+#   --help               This help.
+#
+# What is NOT unlocked by this script:
+#   - tests/integration/detect-language-via-self-hosted-runner.test.ts
+#     (needs a self-hosted GitHub Actions runner registered).
+#   - LAKEBASE_TEST_PROJECT_PATH-gated TDD live tests (need a Databricks
+#     workspace path; deferred until the TDD scaffolder lands one).
+#
+# What this script gates on (substrate convention):
+#   LAKEBASE_TEST_NO_TEARDOWN=1 is set by default. Failed runs leave the
+#   project + branches in place. The user must explicitly pass --teardown
+#   to enable post-run cleanup, and even then only on a fully-green run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+blue()   { printf '\033[34m%s\033[0m\n' "$*"; }
+
+PROFILE=""
+PROJECT_ID=""
+BRANCH_OVERRIDE=""
+PARENT_OVERRIDE=""
+TEARDOWN_ON_GREEN=0
+NO_PROMPT=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)    PROFILE="$2"; shift 2 ;;
+    --project)    PROJECT_ID="$2"; shift 2 ;;
+    --branch)     BRANCH_OVERRIDE="$2"; shift 2 ;;
+    --parent)     PARENT_OVERRIDE="$2"; shift 2 ;;
+    --teardown)   TEARDOWN_ON_GREEN=1; shift ;;
+    --no-prompt)  NO_PROMPT=1; shift ;;
+    --help|-h)
+      sed -n '2,/^set -euo pipefail/p' "$0" | sed 's/^# \{0,1\}//' | head -n -1
+      exit 0
+      ;;
+    *)
+      red "Unknown flag: $1"
+      red "See $0 --help"
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$PROFILE" ]]; then
+  red "--profile is required."
+  red "See $0 --help"
+  exit 2
+fi
+
+blue "==> Resolving workspace host from profile '$PROFILE'"
+if ! command -v databricks >/dev/null 2>&1; then
+  red "  databricks CLI not on PATH"
+  red "  install: https://docs.databricks.com/dev-tools/cli/install.html"
+  exit 1
+fi
+
+RAW_AUTH_ENV="$(databricks auth env --profile "$PROFILE" 2>&1 || true)"
+DATABRICKS_HOST="$(printf '%s\n' "$RAW_AUTH_ENV" | python3 -c "
+import json, sys
+try:
+  d = json.load(sys.stdin)
+  host = (d.get('env') or {}).get('DATABRICKS_HOST', '').rstrip('/')
+  print(host)
+except Exception:
+  print('')
+")"
+
+if [[ -z "$DATABRICKS_HOST" ]]; then
+  red "  Could not resolve DATABRICKS_HOST from profile '$PROFILE'."
+  red "  Try: databricks auth login --profile $PROFILE"
+  exit 1
+fi
+green "  DATABRICKS_HOST = $DATABRICKS_HOST"
+export DATABRICKS_HOST
+export DATABRICKS_CONFIG_PROFILE="$PROFILE"
+
+# Token freshness reminder. OAuth tokens from `databricks auth login` rotate
+# silently; PAT-based profiles stay until revoked. The 60-second sanity probe
+# below catches expired tokens before we attempt destructive ops.
+blue "==> Auth sanity check (current-user me)"
+if ! databricks current-user me --profile "$PROFILE" -o json >/dev/null 2>&1; then
+  red "  Auth probe failed. Token may be expired."
+  red "  Try: databricks auth login --profile $PROFILE"
+  exit 1
+fi
+green "  auth OK"
+
+# Resolve or provision the Lakebase project.
+PROVISIONED=0
+if [[ -n "$PROJECT_ID" ]]; then
+  blue ""
+  blue "==> Using existing Lakebase project: $PROJECT_ID"
+  if ! databricks postgres get-project "projects/$PROJECT_ID" --profile "$PROFILE" -o json >/dev/null 2>&1; then
+    red "  Project '$PROJECT_ID' not found on $DATABRICKS_HOST"
+    exit 1
+  fi
+  green "  project exists, READY"
+else
+  PROJECT_ID="live-all-$(date +%s)"
+  yellow ""
+  yellow "==> About to create a fresh Lakebase project"
+  yellow "    workspace:  $DATABRICKS_HOST"
+  yellow "    project:    $PROJECT_ID  (NEW)"
+  yellow "    teardown:   $( [[ $TEARDOWN_ON_GREEN == 1 ]] && echo 'on green run' || echo 'DISABLED — manual cleanup required at end' )"
+  yellow ""
+  if [[ "$NO_PROMPT" != "1" ]]; then
+    yellow "    Press Ctrl-C in the next 5 seconds to abort. Pass --no-prompt to skip in CI."
+    sleep 5
+  fi
+  blue "==> Creating Lakebase project $PROJECT_ID (long-running, ~30s)"
+  databricks postgres create-project "$PROJECT_ID" --profile "$PROFILE" -o json >/dev/null
+  PROVISIONED=1
+  green "  created: $PROJECT_ID"
+fi
+
+# Resolve the default branch name (leaf of name, never uid — see
+# scripts/lakebase/branch-id.ts for the rationale).
+DEFAULT_BRANCH="$(databricks postgres list-branches "projects/$PROJECT_ID" --profile "$PROFILE" -o json 2>&1 | python3 -c "
+import json, sys
+try:
+  d = json.load(sys.stdin)
+  items = d if isinstance(d, list) else d.get('branches') or d.get('items') or []
+  for b in items:
+    if (b.get('status') or {}).get('default') or b.get('is_default'):
+      name = b.get('name', '')
+      print(name.split('/branches/')[-1] if '/branches/' in name else '')
+      break
+except Exception:
+  pass
+")"
+
+if [[ -z "$DEFAULT_BRANCH" ]]; then
+  red "  Could not resolve default branch for project $PROJECT_ID"
+  exit 1
+fi
+green "  default branch (leaf, not uid): $DEFAULT_BRANCH"
+
+BRANCH="${BRANCH_OVERRIDE:-$DEFAULT_BRANCH}"
+PARENT="${PARENT_OVERRIDE:-$BRANCH}"
+
+# Export everything every env-gated test in the kit looks at. The list was
+# derived by greping process.env.* across tests/. Each block notes which
+# tests are unlocked.
+blue ""
+blue "==> Exporting env vars"
+export LAKEBASE_TEST_E2E=1
+export LAKEBASE_TEST_INSTANCE="$PROJECT_ID"
+export LAKEBASE_TEST_BRANCH="$BRANCH"
+export LAKEBASE_TEST_PARENT="$PARENT"
+export LAKEBASE_TEST_HOST="$DATABRICKS_HOST"
+export LAKEBASE_TEST_PROFILE="$PROFILE"
+# Optional fields: only set when the user provides them. Tests have
+# sensible defaults if absent.
+export LAKEBASE_TEST_COMPARISON_BRANCH="${LAKEBASE_TEST_COMPARISON_BRANCH:-$BRANCH}"
+export LAKEBASE_TEST_DATABASE="${LAKEBASE_TEST_DATABASE:-databricks_postgres}"
+# Unlock the live Initializr fetch + the MCP peer-dep integration check.
+# Both are network/integration-side and the gate is just a "yes please".
+export LAKEBASE_TEST_INITIALIZR=1
+export PEER_DEP_INTEGRATION=1
+# Substrate convention: failed live runs MUST leave the project + branches
+# in place so the user can inspect. Only --teardown switches this off, and
+# even then only after a fully-green run.
+export LAKEBASE_TEST_NO_TEARDOWN=1
+
+green "  LAKEBASE_TEST_INSTANCE=$LAKEBASE_TEST_INSTANCE"
+green "  LAKEBASE_TEST_BRANCH=$LAKEBASE_TEST_BRANCH  LAKEBASE_TEST_PARENT=$LAKEBASE_TEST_PARENT"
+green "  LAKEBASE_TEST_E2E=1  LAKEBASE_TEST_INITIALIZR=1  PEER_DEP_INTEGRATION=1"
+green "  LAKEBASE_TEST_NO_TEARDOWN=1  (per substrate convention)"
+
+# Build dist so the integration tests import the latest compiled substrate.
+blue ""
+blue "==> Building dist/"
+npm run build >/dev/null
+green "  dist ready"
+
+# Run the full suite. vitest discovers every test; the env above unlocks
+# each gated describe block.
+blue ""
+blue "==> Running full suite (vitest, every gated describe unlocked)"
+RUN_STATUS=0
+npx vitest run 2>&1 | tee /tmp/run-all-live-tests.out || RUN_STATUS=$?
+
+green ""
+green "==> Run complete (exit $RUN_STATUS)"
+SKIP_COUNT="$(grep -oE 'Tests +[0-9]+ passed.*[0-9]+ skipped' /tmp/run-all-live-tests.out | tail -1 || true)"
+[[ -n "$SKIP_COUNT" ]] && yellow "  $SKIP_COUNT"
+
+if [[ "$RUN_STATUS" -eq 0 && "$TEARDOWN_ON_GREEN" -eq 1 && "$PROVISIONED" -eq 1 ]]; then
+  yellow ""
+  yellow "==> Green run + --teardown specified. Deleting $PROJECT_ID..."
+  if databricks postgres delete-project "projects/$PROJECT_ID" --profile "$PROFILE" 2>&1 | tail -3; then
+    green "  deleted $PROJECT_ID"
+  else
+    red "  delete failed; manual cleanup needed:"
+    red "    databricks postgres delete-project projects/$PROJECT_ID --profile $PROFILE"
+  fi
+elif [[ "$PROVISIONED" -eq 1 ]]; then
+  yellow ""
+  yellow "==> Project preserved (per never-teardown-on-failure convention):"
+  yellow "    project:    $PROJECT_ID"
+  yellow "    workspace:  $DATABRICKS_HOST"
+  yellow "    cleanup:    databricks postgres delete-project projects/$PROJECT_ID --profile $PROFILE"
+fi
+
+exit "$RUN_STATUS"

--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -38,6 +38,10 @@
 #                              window). Default: 5. Use 0 + --no-prompt for CI.
 #   --database <name>          LAKEBASE_TEST_DATABASE override. Default: unset, so the
 #                              substrate falls back to DEFAULT_DATABASE (constants.ts).
+#   --feature-ttl-days <n>     Override the kit's 30-day default feature branch TTL.
+#                              Use on workspaces with a tighter maximum-expiration
+#                              policy (e.g. --feature-ttl-days 7). Sets
+#                              LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS for the run.
 #   --teardown                 After a green run, delete the auto-provisioned project.
 #                              No-op when --project was supplied.
 #   --no-prompt                Skip the grace period entirely (for CI).
@@ -72,20 +76,22 @@ PARENT_OVERRIDE=""
 PROJECT_PREFIX="live-all-"
 GRACE_SECONDS=5
 DATABASE=""
+FEATURE_TTL_DAYS=""
 TEARDOWN_ON_GREEN=0
 NO_PROMPT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --profile)         PROFILE="$2"; shift 2 ;;
-    --project)         PROJECT_ID="$2"; shift 2 ;;
-    --branch)          BRANCH_OVERRIDE="$2"; shift 2 ;;
-    --parent)          PARENT_OVERRIDE="$2"; shift 2 ;;
-    --project-prefix)  PROJECT_PREFIX="$2"; shift 2 ;;
-    --grace-seconds)   GRACE_SECONDS="$2"; shift 2 ;;
-    --database)        DATABASE="$2"; shift 2 ;;
-    --teardown)        TEARDOWN_ON_GREEN=1; shift ;;
-    --no-prompt)       NO_PROMPT=1; shift ;;
+    --profile)            PROFILE="$2"; shift 2 ;;
+    --project)            PROJECT_ID="$2"; shift 2 ;;
+    --branch)             BRANCH_OVERRIDE="$2"; shift 2 ;;
+    --parent)             PARENT_OVERRIDE="$2"; shift 2 ;;
+    --project-prefix)     PROJECT_PREFIX="$2"; shift 2 ;;
+    --grace-seconds)      GRACE_SECONDS="$2"; shift 2 ;;
+    --database)           DATABASE="$2"; shift 2 ;;
+    --feature-ttl-days)   FEATURE_TTL_DAYS="$2"; shift 2 ;;
+    --teardown)           TEARDOWN_ON_GREEN=1; shift ;;
+    --no-prompt)          NO_PROMPT=1; shift ;;
     --help|-h)
       # `sed '$d'` drops the trailing `set -euo pipefail` line that closes
       # the range. Cross-platform: `head -n -1` is GNU-only (BSD head on
@@ -103,6 +109,11 @@ done
 
 if ! [[ "$GRACE_SECONDS" =~ ^[0-9]+$ ]]; then
   red "--grace-seconds must be a non-negative integer (got: $GRACE_SECONDS)"
+  exit 2
+fi
+
+if [[ -n "$FEATURE_TTL_DAYS" ]] && ! [[ "$FEATURE_TTL_DAYS" =~ ^[0-9]+$ ]]; then
+  red "--feature-ttl-days must be a positive integer (got: $FEATURE_TTL_DAYS)"
   exit 2
 fi
 
@@ -223,6 +234,16 @@ export LAKEBASE_TEST_COMPARISON_BRANCH="${LAKEBASE_TEST_COMPARISON_BRANCH:-$BRAN
 # (scripts/lakebase/constants.ts) — single source of truth, no duplication.
 if [[ -n "$DATABASE" ]]; then
   export LAKEBASE_TEST_DATABASE="$DATABASE"
+fi
+
+# LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS: explicit --feature-ttl-days flag wins.
+# Workspaces with maximum-expiration policies tighter than 30 days (the
+# kit's default) need this for cutExperiment / createFeatureBranch /
+# tdd-synthesis paths. We compute ms = days * 86_400_000 here so the
+# substrate's existing convention defaults pick it up.
+if [[ -n "$FEATURE_TTL_DAYS" ]]; then
+  export LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS="$(( FEATURE_TTL_DAYS * 86_400_000 ))"
+  green "  LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS=$LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS  (${FEATURE_TTL_DAYS}d)"
 fi
 # Unlock the live Initializr fetch + the MCP peer-dep integration check.
 # Both are network/integration-side and the gate is just a "yes please".

--- a/scripts/run-live-tests.sh
+++ b/scripts/run-live-tests.sh
@@ -139,7 +139,7 @@ if [[ "$MODE" == "migrate" || "$MODE" == "all" ]]; then
     ZIP="$REPO_ROOT/.tools-live-tests/flyway-commandline-$FLYWAY_VERSION.zip"
     # Maven Central base URL. Override via LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL
     # when running against a proxied / air-gapped env (e.g. Databricks-internal
-    # Maven proxy — see the internal package-registry proxy setup doc).
+    # Maven proxy – see the internal package-registry proxy setup doc).
     MAVEN_CENTRAL="${LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL:-https://repo1.maven.org/maven2}"
     URL="${MAVEN_CENTRAL%/}/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.zip"
     if [[ ! -f "$ZIP" ]]; then

--- a/scripts/run-live-tests.sh
+++ b/scripts/run-live-tests.sh
@@ -137,7 +137,11 @@ if [[ "$MODE" == "migrate" || "$MODE" == "all" ]]; then
     blue "==> Provisioning Flyway CLI $FLYWAY_VERSION at $FLYWAY_HOME (one-time setup)"
     mkdir -p "$REPO_ROOT/.tools-live-tests"
     ZIP="$REPO_ROOT/.tools-live-tests/flyway-commandline-$FLYWAY_VERSION.zip"
-    URL="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.zip"
+    # Maven Central base URL. Override via LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL
+    # when running against a proxied / air-gapped env (e.g. Databricks-internal
+    # Maven proxy — see the internal package-registry proxy setup doc).
+    MAVEN_CENTRAL="${LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL:-https://repo1.maven.org/maven2}"
+    URL="${MAVEN_CENTRAL%/}/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.zip"
     if [[ ! -f "$ZIP" ]]; then
       if ! curl --fail --silent --show-error --location -o "$ZIP" "$URL"; then
         red ""

--- a/scripts/tdd/artifacts.ts
+++ b/scripts/tdd/artifacts.ts
@@ -1,0 +1,121 @@
+// Per-cycle artifact persistence for TDD experiments.
+//
+// On-disk layout:
+//
+//   .tdd/experiments/<F>/<exp>/artifacts/<cycle-id>/<name>
+//
+// Where <name> may include subdirectories (e.g. "traces/network.har").
+//
+// The orchestrator writes here after every cycle (Playwright traces, vitest
+// junit output, screenshots, repro scripts). The comparison-report renderer
+// (FEIP-7208) reads listings via listArtifacts to surface what's available
+// when the PO is deciding promote vs synthesize.
+//
+// Gitignored by default in scaffolded projects: artifacts can be large and
+// rebuilding them from logs is cheap. The scaffold step that writes the
+// project's .gitignore is owned by lakebase-create-project + slice 4 of
+// FEIP-7092 (orchestration), not this module.
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "fs";
+import { dirname, join, relative } from "path";
+
+export interface WriteArtifactArgs {
+  tddDir: string;
+  featureId: string;
+  experimentSlug: string;
+  cycleId: string;
+  /**
+   * Relative path within the cycle's artifacts dir. May include subdirs
+   * (e.g. "traces/spec-1.zip"). Intermediate dirs are created on demand.
+   */
+  name: string;
+  /** Content to write. Strings are written as UTF-8; Buffers as-is. */
+  content: string | Buffer;
+}
+
+export interface ArtifactEntry {
+  name: string;
+  path: string;
+  cycle_id: string;
+  size: number;
+  modified: string;
+}
+
+function artifactsRoot(tddDir: string, featureId: string, experimentSlug: string): string {
+  return join(tddDir, "experiments", featureId, experimentSlug, "artifacts");
+}
+
+function cycleDir(args: { tddDir: string; featureId: string; experimentSlug: string; cycleId: string }): string {
+  return join(artifactsRoot(args.tddDir, args.featureId, args.experimentSlug), args.cycleId);
+}
+
+export function writeArtifact(args: WriteArtifactArgs): string {
+  if (!args.name || args.name.startsWith("/") || args.name.includes("..")) {
+    throw new Error(`writeArtifact: invalid name '${args.name}'`);
+  }
+  const dest = join(cycleDir(args), args.name);
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, args.content);
+  return dest;
+}
+
+/**
+ * List artifacts under an experiment. If cycleId is provided, scope to that
+ * cycle; otherwise enumerate across all cycles. Returns entries with
+ * cycle-relative names so consumers can stable-sort by (cycle_id, name).
+ */
+export function listArtifacts(
+  tddDir: string,
+  featureId: string,
+  experimentSlug: string,
+  cycleId?: string
+): ArtifactEntry[] {
+  const root = artifactsRoot(tddDir, featureId, experimentSlug);
+  if (!existsSync(root)) return [];
+  const entries: ArtifactEntry[] = [];
+  const cycleIds = cycleId
+    ? [cycleId].filter((c) => existsSync(join(root, c)))
+    : readdirSync(root).filter((c) => statSync(join(root, c)).isDirectory());
+  for (const c of cycleIds) {
+    const cycleRoot = join(root, c);
+    for (const relPath of walkFiles(cycleRoot)) {
+      const abs = join(cycleRoot, relPath);
+      const stat = statSync(abs);
+      entries.push({
+        name: relPath,
+        path: abs,
+        cycle_id: c,
+        size: stat.size,
+        modified: stat.mtime.toISOString(),
+      });
+    }
+  }
+  return entries;
+}
+
+export function readArtifact(args: {
+  tddDir: string;
+  featureId: string;
+  experimentSlug: string;
+  cycleId: string;
+  name: string;
+}): Buffer | null {
+  const path = join(cycleDir(args), args.name);
+  if (!existsSync(path)) return null;
+  return readFileSync(path);
+}
+
+function walkFiles(root: string): string[] {
+  const out: string[] = [];
+  function recurse(dir: string) {
+    for (const entry of readdirSync(dir)) {
+      const abs = join(dir, entry);
+      const stat = statSync(abs);
+      if (stat.isDirectory()) recurse(abs);
+      else if (stat.isFile()) out.push(relative(root, abs));
+    }
+  }
+  recurse(root);
+  out.sort();
+  return out;
+}

--- a/scripts/tdd/budget.ts
+++ b/scripts/tdd/budget.ts
@@ -61,7 +61,7 @@ export function checkBudget(snapshot: BudgetSnapshot): BudgetViolation[] {
 
 export function canCutAnotherExperiment(tddDir: string, featureId: string): { ok: boolean; reason?: string } {
   const snap = snapshotBudget(tddDir, featureId);
-  if (!snap) return { ok: false, reason: "no plan recorded — run design-spec-gate first" };
+  if (!snap) return { ok: false, reason: "no plan recorded – run design-spec-gate first" };
   if (snap.concurrent_branches_in_use >= snap.concurrent_branches_limit) {
     return {
       ok: false,

--- a/scripts/tdd/compare-experiments.ts
+++ b/scripts/tdd/compare-experiments.ts
@@ -1,5 +1,8 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
 import { listExperiments, readOutcomes } from "./experiment";
-import type { ExperimentOutcomes } from "./experiment";
+import type { ExperimentOutcomes, ExperimentTag, TagOutcome } from "./experiment";
+import { listArtifacts } from "./artifacts";
 
 export interface ExperimentRow {
   experiment_slug: string;
@@ -10,14 +13,74 @@ export interface ExperimentRow {
   schema_diff_summary?: string;
   code_diff_lines?: number;
   signal: "winning" | "stalled" | "abandoned" | "running" | "unknown";
+  // Structured-payload fields (FEIP-7092 slice 4). Backwards compatible:
+  // older callers reading the prior shape ignore these.
+  by_tag?: Partial<Record<ExperimentTag, TagOutcome>>;
+  cycle_count: number;
+  artifact_count: number;
+  duration_ms?: number;
+}
+
+export interface TagMatrixRow {
+  tag: ExperimentTag;
+  /** Per-experiment cell; null when this experiment reported no data for this tag. */
+  cells: Record<string, TagOutcome | null>;
 }
 
 export interface ComparisonReport {
   feature_id: string;
   generated_at: string;
   rows: ExperimentRow[];
+  /**
+   * Tag × experiment matrix. One row per tag any experiment reported.
+   * Empty when no experiment recorded per-tag outcomes yet (early-stage
+   * race or projects that don't use the tag-aware runner).
+   * Consumed by the comparison-report renderer (FEIP-7208).
+   */
+  matrix: TagMatrixRow[];
   recommendation: "promote" | "synthesize" | "continue" | "abandon-all";
   rationale: string;
+}
+
+function readCycleCount(experimentDir: string): number {
+  const timelinePath = join(experimentDir, "timeline.json");
+  if (!existsSync(timelinePath)) return 0;
+  try {
+    const timeline = JSON.parse(readFileSync(timelinePath, "utf8")) as {
+      entries?: unknown[];
+    };
+    return Array.isArray(timeline.entries) ? timeline.entries.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function readDurationMs(experimentDir: string): number | undefined {
+  const path = join(experimentDir, "runtime.json");
+  if (!existsSync(path)) return undefined;
+  try {
+    const r = JSON.parse(readFileSync(path, "utf8")) as { duration_ms?: number };
+    return typeof r.duration_ms === "number" ? r.duration_ms : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildMatrix(tddDir: string, featureId: string, rows: ExperimentRow[]): TagMatrixRow[] {
+  void tddDir;
+  void featureId;
+  const tagsSeen = new Set<ExperimentTag>();
+  for (const r of rows) {
+    if (!r.by_tag) continue;
+    for (const tag of Object.keys(r.by_tag) as ExperimentTag[]) {
+      tagsSeen.add(tag);
+    }
+  }
+  const orderedTags: ExperimentTag[] = (["api", "e2e", "infra"] as ExperimentTag[]).filter((t) => tagsSeen.has(t));
+  return orderedTags.map((tag) => ({
+    tag,
+    cells: Object.fromEntries(rows.map((r) => [r.experiment_slug, r.by_tag?.[tag] ?? null])),
+  }));
 }
 
 export function compareExperiments(tddDir: string, featureId: string): ComparisonReport {
@@ -33,13 +96,19 @@ export function compareExperiments(tddDir: string, featureId: string): Compariso
       schema_diff_summary: o?.schema_diff_summary,
       code_diff_lines: o?.code_diff_lines,
       signal: classifySignal(o),
+      by_tag: o?.by_tag,
+      cycle_count: readCycleCount(exp.dir),
+      artifact_count: listArtifacts(tddDir, featureId, exp.experiment_slug).length,
+      duration_ms: readDurationMs(exp.dir),
     };
   });
+  const matrix = buildMatrix(tddDir, featureId, rows);
   const { recommendation, rationale } = recommend(rows);
   return {
     feature_id: featureId,
     generated_at: new Date().toISOString(),
     rows,
+    matrix,
     recommendation,
     rationale,
   };

--- a/scripts/tdd/compare-experiments.ts
+++ b/scripts/tdd/compare-experiments.ts
@@ -133,23 +133,23 @@ function recommend(rows: ExperimentRow[]): { recommendation: ComparisonReport["r
   if (winners.length === 1 && running.length === 0) {
     return {
       recommendation: "promote",
-      rationale: `1 winning experiment, no others still running — promote ${winners[0].experiment_slug}.`,
+      rationale: `1 winning experiment, no others still running – promote ${winners[0].experiment_slug}.`,
     };
   }
   if (winners.length >= 2) {
     return {
       recommendation: "synthesize",
-      rationale: `${winners.length} winning experiments — Product Owner menu-picks; spec gets renegotiated.`,
+      rationale: `${winners.length} winning experiments – Product Owner menu-picks; spec gets renegotiated.`,
     };
   }
   if (winners.length === 0 && running.length === 0 && stalled.length === rows.length && rows.length > 0) {
     return {
       recommendation: "abandon-all",
-      rationale: `All ${rows.length} experiments stalled — re-run design-spec gate.`,
+      rationale: `All ${rows.length} experiments stalled – re-run design-spec gate.`,
     };
   }
   return {
     recommendation: "continue",
-    rationale: `${winners.length} winning, ${running.length} running, ${stalled.length} stalled — let cycles finish or HITL intervene.`,
+    rationale: `${winners.length} winning, ${running.length} running, ${stalled.length} stalled – let cycles finish or HITL intervene.`,
   };
 }

--- a/scripts/tdd/design-spec-gate.ts
+++ b/scripts/tdd/design-spec-gate.ts
@@ -65,8 +65,8 @@ export function analyzeForGate(tddDir: string, featureId: string): GateAnalysis 
     },
     rationale:
       mode === "N=1"
-        ? "Fewer than 2 opinion gaps detected — refine iteratively on a single branch."
-        : `${gaps.length} opinion gaps detected — race up to 3 parallel strategies, then HITL chooses promote vs synthesize.`,
+        ? "Fewer than 2 opinion gaps detected – refine iteratively on a single branch."
+        : `${gaps.length} opinion gaps detected – race up to 3 parallel strategies, then HITL chooses promote vs synthesize.`,
   };
   return { feature_id: featureId, opinion_gaps: gaps, proposed_plan: proposed };
 }
@@ -88,7 +88,7 @@ export function recordPlan(tddDir: string, plan: ExperimentPlan, deciderEmail?: 
   const ts = new Date().toISOString();
   const lines = [
     "",
-    `## ${ts} — Experiment plan for ${plan.feature_id}`,
+    `## ${ts} – Experiment plan for ${plan.feature_id}`,
     `- **Mode:** ${plan.mode} (N=${plan.N})`,
     `- **Budget:** ${plan.budget.concurrent_branches} concurrent, ${plan.budget.wall_clock_minutes} min wall-clock, ${plan.budget.agent_pairs} agent pair(s)`,
     `- **Strategies:**`,

--- a/scripts/tdd/experiment.ts
+++ b/scripts/tdd/experiment.ts
@@ -33,7 +33,7 @@ export interface ExperimentOutcomes {
   // authoritative totals; `by_tag` is a breakdown for downstream renderers
   // (comparison report, feature-status) and the per-tag smell detectors
   // (e.g. e2e-row-perma-red in FEIP-7094). Sum across tags is not enforced
-  // to match the totals — mid-cycle reporting and untagged tests are valid.
+  // to match the totals – mid-cycle reporting and untagged tests are valid.
   by_tag?: Partial<Record<ExperimentTag, TagOutcome>>;
 }
 

--- a/scripts/tdd/experiment.ts
+++ b/scripts/tdd/experiment.ts
@@ -10,12 +10,31 @@ function branchIdOf(info: LakebaseBranchInfo): string {
   return leaf;
 }
 
+// Tag flavors mirror the AC layer values from the spec format. The Driver's
+// tag-to-runner map keys off these (FEIP-7094): [API] → vitest, [E2E] →
+// Playwright, [Infra] → migration / schema-diff smoke. The substrate keeps
+// the names lowercase here; the spec format capitalises them ("API" / "E2E"
+// / "Infra") for display.
+export type ExperimentTag = "api" | "e2e" | "infra";
+
+export interface TagOutcome {
+  passed: number;
+  failed: number;
+}
+
 export interface ExperimentOutcomes {
   tests_passed?: number;
   tests_failed?: number;
   schema_diff_summary?: string;
   code_diff_lines?: number;
   status: "running" | "succeeded" | "failed" | "abandoned";
+  // Per-tag breakdown. Each tag is optional (a project may not exercise
+  // every flavor). When present, `tests_passed` + `tests_failed` remain
+  // authoritative totals; `by_tag` is a breakdown for downstream renderers
+  // (comparison report, feature-status) and the per-tag smell detectors
+  // (e.g. e2e-row-perma-red in FEIP-7094). Sum across tags is not enforced
+  // to match the totals — mid-cycle reporting and untagged tests are valid.
+  by_tag?: Partial<Record<ExperimentTag, TagOutcome>>;
 }
 
 export interface CutExperimentArgs extends BranchLookupOpts {

--- a/scripts/tdd/parallel-runner.ts
+++ b/scripts/tdd/parallel-runner.ts
@@ -10,7 +10,7 @@
 // run-cycle.ts to drive an actual TDD cycle.
 
 export interface ExperimentRunInput {
-  /** Stable identifier — matches an `.tdd/experiments/<F>/<slug>/` dir. */
+  /** Stable identifier – matches an `.tdd/experiments/<F>/<slug>/` dir. */
   slug: string;
   /** Free-form payload the runner can consume (strategy, branch, etc.). */
   context?: Record<string, unknown>;

--- a/scripts/tdd/parallel-runner.ts
+++ b/scripts/tdd/parallel-runner.ts
@@ -1,0 +1,107 @@
+// Bounded-concurrency runner for parallel experiment execution.
+//
+// The orchestrator calls this when phase 4 (Implementation) cuts N>=2
+// experiments. Each experiment runs its own cycle loop; this module
+// schedules them so the budget's `concurrent_branches` cap is honored
+// and a failure in one experiment does NOT abort the others.
+//
+// The runner is injected so tests stay hermetic (no real Lakebase calls).
+// The orchestrator's real runner integrates with experiment.ts +
+// run-cycle.ts to drive an actual TDD cycle.
+
+export interface ExperimentRunInput {
+  /** Stable identifier — matches an `.tdd/experiments/<F>/<slug>/` dir. */
+  slug: string;
+  /** Free-form payload the runner can consume (strategy, branch, etc.). */
+  context?: Record<string, unknown>;
+}
+
+export interface ExperimentRunSuccess<T> {
+  slug: string;
+  status: "succeeded";
+  value: T;
+  duration_ms: number;
+}
+
+export interface ExperimentRunFailure {
+  slug: string;
+  status: "failed";
+  error: { message: string; stack?: string };
+  duration_ms: number;
+}
+
+export type ExperimentRunResult<T> = ExperimentRunSuccess<T> | ExperimentRunFailure;
+
+export interface RunExperimentsArgs<T> {
+  experiments: ExperimentRunInput[];
+  /**
+   * Max in-flight experiments. Hard cap honored even when more are queued.
+   * Sourced from `.tdd/features/<F>/plan.json` `budget.concurrent_branches`
+   * by the orchestrator.
+   */
+  concurrency: number;
+  /** Async runner for one experiment. Errors are caught and reported. */
+  runner: (input: ExperimentRunInput) => Promise<T>;
+}
+
+export interface RunExperimentsResult<T> {
+  results: ExperimentRunResult<T>[];
+  total_duration_ms: number;
+  /** Peak in-flight count observed during the run. */
+  peak_in_flight: number;
+}
+
+export async function runExperimentsInParallel<T>(
+  args: RunExperimentsArgs<T>
+): Promise<RunExperimentsResult<T>> {
+  if (args.concurrency < 1) {
+    throw new Error(`runExperimentsInParallel: concurrency must be >= 1 (got ${args.concurrency})`);
+  }
+
+  const start = Date.now();
+  const queue = [...args.experiments];
+  const results: ExperimentRunResult<T>[] = [];
+  let inFlight = 0;
+  let peakInFlight = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const exp = queue.shift();
+      if (!exp) return;
+      inFlight++;
+      if (inFlight > peakInFlight) peakInFlight = inFlight;
+      const expStart = Date.now();
+      try {
+        const value = await args.runner(exp);
+        results.push({
+          slug: exp.slug,
+          status: "succeeded",
+          value,
+          duration_ms: Date.now() - expStart,
+        });
+      } catch (err) {
+        results.push({
+          slug: exp.slug,
+          status: "failed",
+          error: {
+            message: err instanceof Error ? err.message : String(err),
+            stack: err instanceof Error ? err.stack : undefined,
+          },
+          duration_ms: Date.now() - expStart,
+        });
+      } finally {
+        inFlight--;
+      }
+    }
+  }
+
+  const workerCount = Math.min(args.concurrency, args.experiments.length);
+  const workers = Array.from({ length: workerCount }, () => worker());
+  await Promise.all(workers);
+
+  return {
+    results,
+    total_duration_ms: Date.now() - start,
+    peak_in_flight: peakInFlight,
+  };
+}

--- a/scripts/tdd/promote-experiment.ts
+++ b/scripts/tdd/promote-experiment.ts
@@ -70,7 +70,7 @@ export function promoteExperiment(args: PromoteArgs): PromoteResult {
     feature.status = "ready-for-review";
     writeFeature(tddDir, feature);
   } catch {
-    // No feature.json — caller's responsibility. Don't block promotion.
+    // No feature.json – caller's responsibility. Don't block promotion.
   }
 
   // Append to selection log
@@ -78,7 +78,7 @@ export function promoteExperiment(args: PromoteArgs): PromoteResult {
   const ts = new Date().toISOString();
   const lines = [
     "",
-    `## ${ts} — Promote ${winnerSlug} for ${featureId}`,
+    `## ${ts} – Promote ${winnerSlug} for ${featureId}`,
     `- **Winner:** ${winnerSlug} (branch ${winner.branch_id})`,
     losers.length > 0
       ? `- **Archived:** ${losers.map((l) => l.experiment_slug).join(", ")}`

--- a/scripts/tdd/run-cycle.ts
+++ b/scripts/tdd/run-cycle.ts
@@ -80,7 +80,7 @@ export interface OpenBranchDsnArgs {
 /**
  * Open a DSN against the experiment's Lakebase branch so the test runner
  * (Vitest / Jest / Pytest / Flyway / etc.) can connect to a real per-branch DB.
- * Returned DSN strings are scoped to the experiment branch — not staging, not prod.
+ * Returned DSN strings are scoped to the experiment branch – not staging, not prod.
  */
 export async function openBranchDsn(args: OpenBranchDsnArgs): Promise<DsnResult> {
   return getConnection({

--- a/scripts/tdd/synthesis.ts
+++ b/scripts/tdd/synthesis.ts
@@ -79,7 +79,7 @@ export async function synthesizeExperiments(args: SynthesizeArgs): Promise<Synth
   ].join("\n");
   writeFileSync(decisionFile, decisionBody);
 
-  // Synthesized spec subtree — copy the most-recent winning spec (or the first pick) as a starting point
+  // Synthesized spec subtree – copy the most-recent winning spec (or the first pick) as a starting point
   const synthesizedSpecDir = join(synthesisDir, "synthesized-spec");
   mkdirSync(synthesizedSpecDir, { recursive: true });
   const seedFeatureDir = locateFeatureDir(tddDir, featureId);
@@ -95,7 +95,7 @@ export async function synthesizeExperiments(args: SynthesizeArgs): Promise<Synth
   const logPath = join(tddDir, "selection-log.md");
   const logLines = [
     "",
-    `## ${ts} — Synthesize ${featureId}`,
+    `## ${ts} – Synthesize ${featureId}`,
     `- **Synthesized experiment:** ${synthesizedSlug}`,
     `- **Picks:**`,
     ...picks.map((p) => `  - ${p.source_slug}: ${p.capability}`),

--- a/skills/lakebase-scm-workflows/README.md
+++ b/skills/lakebase-scm-workflows/README.md
@@ -1,8 +1,8 @@
 # lakebase-scm-workflows
 
-Opinionated git-to-Lakebase branch-pairing workflows. The agent surface for the same Node.js scripts that the [`databricks-solutions/lakebase-scm-extension`](https://github.com/databricks-solutions/lakebase-scm-extension) calls from its VS Code/Cursor commands — one canonical executable surface, two presentation layers.
+Opinionated git-to-Lakebase branch-pairing workflows. The agent surface for the same Node.js scripts that the [`databricks-solutions/lakebase-scm-extension`](https://github.com/databricks-solutions/lakebase-scm-extension) calls from its VS Code/Cursor commands – one canonical executable surface, two presentation layers.
 
-This README is the human-facing overview. The agent's operating contract — when `.env` matters, how the git hooks behave, the credential single-seam, concrete code patterns — lives in [`SKILL.md`](SKILL.md).
+This README is the human-facing overview. The agent's operating contract – when `.env` matters, how the git hooks behave, the credential single-seam, concrete code patterns – lives in [`SKILL.md`](SKILL.md).
 
 > Composes on top of the dev-hub skill [`databricks-lakebase`](https://github.com/databricks/databricks-agent-skills) (Lakebase Postgres CLI basics). It does not shadow it.
 
@@ -10,9 +10,9 @@ This README is the human-facing overview. The agent's operating contract — whe
 
 The control plane and data plane are owned by other Databricks artifacts. Install/configure them once before using this skill:
 
-- `databricks postgres ...` CLI — documented by the dev-hub skill [`databricks-lakebase`](https://github.com/databricks/databricks-agent-skills). Install via `databricks aitools install databricks-lakebase`.
-- `@databricks/lakebase` npm package — drop-in `pg.Pool` with OAuth refresh.
-- `@databricks/appkit` npm package — Lakebase plugin and OBO (`asUser(req)`).
+- `databricks postgres ...` CLI – documented by the dev-hub skill [`databricks-lakebase`](https://github.com/databricks/databricks-agent-skills). Install via `databricks aitools install databricks-lakebase`.
+- `@databricks/lakebase` npm package – drop-in `pg.Pool` with OAuth refresh.
+- `@databricks/appkit` npm package – Lakebase plugin and OBO (`asUser(req)`).
 
 ## Installing the substrate
 
@@ -34,23 +34,23 @@ For agent use (running `node scripts/lakebase/<verb>.js` directly), clone this r
 
 Each operation is a CLI bin invocation that returns JSON on stdout. JS callers can import the same functions from the package.
 
-- `create-project` — bootstrap a fresh Lakebase-paired project
-- `schema-diff` — parent-aware diff between two Lakebase branches
-- `branch-create` / `branch-delete` — Lakebase branch lifecycle
-- `create-paired-branch` / `delete-paired-branch` / `checkout-paired` / `sync-env-to-current-branch` — paired ops that keep git + Lakebase + `.env` in lockstep
-- `get-endpoint` / `ensure-endpoint` / `get-credential` — branch endpoint + raw token/email
-- `query-branch-schema` / `query-branch-tables` — live pg introspection
-- `get-project-info` — project metadata (uid, display name, state)
-- `create-pull-request` / `get-pull-request` / `merge-pull-request` / `merge-paired-pull-request` — PR flow
-- `get-pull-request-reviews` / `get-pull-request-files` / `get-pull-request-comments` / `list-issue-comments` / `list-workflow-runs` — PR introspection
+- `create-project` – bootstrap a fresh Lakebase-paired project
+- `schema-diff` – parent-aware diff between two Lakebase branches
+- `branch-create` / `branch-delete` – Lakebase branch lifecycle
+- `create-paired-branch` / `delete-paired-branch` / `checkout-paired` / `sync-env-to-current-branch` – paired ops that keep git + Lakebase + `.env` in lockstep
+- `get-endpoint` / `ensure-endpoint` / `get-credential` – branch endpoint + raw token/email
+- `query-branch-schema` / `query-branch-tables` – live pg introspection
+- `get-project-info` – project metadata (uid, display name, state)
+- `create-pull-request` / `get-pull-request` / `merge-pull-request` / `merge-paired-pull-request` – PR flow
+- `get-pull-request-reviews` / `get-pull-request-files` / `get-pull-request-comments` / `list-issue-comments` / `list-workflow-runs` – PR introspection
 
 ## Under the covers
 
-What the substrate does on your behalf, in user-journey order. You don't invoke these primitives directly — the agent does, in response to the prompts in [How to use](#how-to-use). The exception is `create-project`, which is a one-shot bootstrap you can also run yourself via the `lakebase-create-project` bin (see the CLI cheat sheet).
+What the substrate does on your behalf, in user-journey order. You don't invoke these primitives directly – the agent does, in response to the prompts in [How to use](#how-to-use). The exception is `create-project`, which is a one-shot bootstrap you can also run yourself via the `lakebase-create-project` bin (see the CLI cheat sheet).
 
 ### 1. Create-project
 
-End-to-end project bootstrap — the first thing you'll touch. This is the one operation you may also run yourself via the `lakebase-create-project` bin; the agent prompt in [How to use](#how-to-use) flow 1 is the conversational equivalent.
+End-to-end project bootstrap – the first thing you'll touch. This is the one operation you may also run yourself via the `lakebase-create-project` bin; the agent prompt in [How to use](#how-to-use) flow 1 is the conversational equivalent.
 
 When create-project finishes you get a scaffolded layout shaped like:
 
@@ -67,7 +67,7 @@ When create-project finishes you get a scaffolded layout shaped like:
   README.md, .gitignore, package.json/pom.xml/pyproject.toml, ...
 ```
 
-Eleven steps run in order: GitHub repo creation, repo-visibility wait, clone or git-init, Lakebase project creation, default-branch resolution, language scaffold (Spring Initializr for Java/Kotlin, static templates for Python/Node), CI secrets sync, self-hosted runner setup (or GitHub-hosted), initial commit + push, and a health check. The non-fatal steps (secrets sync, runner setup, hook verification) collect into a warnings list rather than aborting. Hard-fatal errors (GitHub repo creation, Lakebase project creation, git push) abort and roll nothing back — manual cleanup is on you.
+Eleven steps run in order: GitHub repo creation, repo-visibility wait, clone or git-init, Lakebase project creation, default-branch resolution, language scaffold (Spring Initializr for Java/Kotlin, static templates for Python/Node), CI secrets sync, self-hosted runner setup (or GitHub-hosted), initial commit + push, and a health check. The non-fatal steps (secrets sync, runner setup, hook verification) collect into a warnings list rather than aborting. Hard-fatal errors (GitHub repo creation, Lakebase project creation, git push) abort and roll nothing back – manual cleanup is on you.
 
 ### 2. Branch lifecycle
 
@@ -75,33 +75,33 @@ Once the project exists, every piece of feature work starts by cutting a paired 
 
 **Parent resolution.** When the agent creates a branch, it picks the parent in this order: an explicit override you specified ("branch from prod for this hotfix"), then a "branch I'm currently on" hint (git-like fork semantics), then the project's default branch (usually `production`). The "current branch" hint is ignored if it equals the target.
 
-**Names.** Whatever you call the branch in conversation gets sanitized to a Lakebase id — lowercase, alphanumeric + hyphens, 3–63 chars. The substrate accepts a uid, the sanitized name, or the full resource path interchangeably when looking the branch up later.
+**Names.** Whatever you call the branch in conversation gets sanitized to a Lakebase id – lowercase, alphanumeric + hyphens, 3–63 chars. The substrate accepts a uid, the sanitized name, or the full resource path interchangeably when looking the branch up later.
 
-**Idempotency.** Asking to create a branch that already exists returns the existing one unchanged. Deletion is not idempotent — asking to delete a branch that doesn't exist surfaces an error to you rather than silently succeeding.
+**Idempotency.** Asking to create a branch that already exists returns the existing one unchanged. Deletion is not idempotent – asking to delete a branch that doesn't exist surfaces an error to you rather than silently succeeding.
 
 ### 3. Endpoint + credential
 
-With a branch in hand, the next step is to connect to its database. The agent mints a Lakebase credential for that branch on demand — short-lived OAuth token, scoped to that branch only.
+With a branch in hand, the next step is to connect to its database. The agent mints a Lakebase credential for that branch on demand – short-lived OAuth token, scoped to that branch only.
 
 When it needs a DSN string (for `psql`, Flyway, Alembic, etc.) it gets one shaped like `postgresql://...`. When it needs a connection pool from JS/TS code, it gets a `pg.Pool` with auto-refresh built in. When it needs raw endpoint metadata (host + provisioning state), it gets that without touching credentials.
 
-All of this funnels through one substrate helper — the single credential-minting seam — so a CI grep guard can detect any second code path trying to bypass it. You don't need to think about this; it just means there's exactly one place to look when credential issues arise.
+All of this funnels through one substrate helper – the single credential-minting seam – so a CI grep guard can detect any second code path trying to bypass it. You don't need to think about this; it just means there's exactly one place to look when credential issues arise.
 
 ### 4. Schema introspection
 
 Once you're connected, you may want to see the current shape of the branch. The agent queries `information_schema` over the branch's DSN and returns the live tables and columns.
 
-Skips `flyway_schema_history` by default — that table is migration metadata, not schema content. Returns an empty list when the branch is still provisioning (the endpoint has no host yet); the agent polls until it's ready.
+Skips `flyway_schema_history` by default – that table is migration metadata, not schema content. Returns an empty list when the branch is still provisioning (the endpoint has no host yet); the agent polls until it's ready.
 
 ### 5. Schema-diff
 
-When you're ready to share work, the agent compares your branch against its parent — the branch's `sourceBranchId` in Lakebase metadata — so a feature branch forked from `staging` diffs against `staging`, not against `production`. When the source can't be resolved, falls back to the project's default branch.
+When you're ready to share work, the agent compares your branch against its parent – the branch's `sourceBranchId` in Lakebase metadata – so a feature branch forked from `staging` diffs against `staging`, not against `production`. When the source can't be resolved, falls back to the project's default branch.
 
 The diff comes back as a structured summary: tables added / removed / modified, columns added / removed / type-changed, and an `inSync` boolean for the whole branch. You'd ask: "show me the diff" or "what changed since I forked." The `prepare-commit-msg` hook calls this automatically on a feature branch's first commit so the diff lands in the PR body for review.
 
 ## How to use
 
-Four flows — shown as what you'd prompt your agent to do, using a running cart-checkout example (a project called `proj-checkout`, branch `feature-add-orders`). The bins listed in the CLI cheat sheet are also valid direct entry points; the prompts here are how you'd ask without remembering flags.
+Four flows – shown as what you'd prompt your agent to do, using a running cart-checkout example (a project called `proj-checkout`, branch `feature-add-orders`). The bins listed in the CLI cheat sheet are also valid direct entry points; the prompts here are how you'd ask without remembering flags.
 
 ### 1. Bootstrap a new Lakebase-paired project
 
@@ -121,15 +121,15 @@ The agent cuts the paired Lakebase branch, runs `git checkout -b feature-add-ord
 
 > "Open a PR from `feature-add-orders` to `staging` for `my-org/proj-checkout` titled 'Add orders table'. Include the schema diff in the body."
 
-In most cases you don't even need to ask — the `prepare-commit-msg` hook (installed by `create-project`) already writes the schema diff into the first commit on a feature branch, so `gh pr create` or the GitHub UI picks it up automatically. The prompt above is for when you want the agent to do it programmatically (catching drift between PR-open and PR-merge by re-running the diff is the job of CI's `pr.yml`).
+In most cases you don't even need to ask – the `prepare-commit-msg` hook (installed by `create-project`) already writes the schema diff into the first commit on a feature branch, so `gh pr create` or the GitHub UI picks it up automatically. The prompt above is for when you want the agent to do it programmatically (catching drift between PR-open and PR-merge by re-running the diff is the job of CI's `pr.yml`).
 
 ### 4. Recover when a checkout left the DSN pointing at the wrong branch
 
 Happens when the post-checkout hook is missing, disabled, or you switched branches outside git (e.g. via an IDE that skipped hooks). The DSN in `.env` still points at the previous branch.
 
-> "My `.env` DSN looks stale — refresh it to point at the Lakebase branch matching the git branch I'm currently on."
+> "My `.env` DSN looks stale – refresh it to point at the Lakebase branch matching the git branch I'm currently on."
 
-The agent reads the current git branch, calls `lakebase-get-connection --output dsn --write-env` for that branch, and confirms the new `DATABASE_URL`. If you hit this often, ask: "Reinstall the git hooks" — that runs `bash .githooks/install.sh`.
+The agent reads the current git branch, calls `lakebase-get-connection --output dsn --write-env` for that branch, and confirms the new `DATABASE_URL`. If you hit this often, ask: "Reinstall the git hooks" – that runs `bash .githooks/install.sh`.
 
 ## CLI cheat sheet
 
@@ -140,9 +140,9 @@ The agent reads the current git branch, calls `lakebase-get-connection --output 
 | `lakebase-schema-diff` | Parent-aware schema diff between any branch and its parent (or a comparison override). |
 | `lakebase-github-token` | Resolve the GitHub token via the same auth chain CI uses. Useful for debugging permission issues. |
 | `lakebase-migrate` | Apply / rollback / status / list schema migrations against a branch. |
-| `lakebase-mcp-server` | Stdio MCP server exposing every script as an MCP tool — for Claude Desktop / OpenAI Codex consumers. |
+| `lakebase-mcp-server` | Stdio MCP server exposing every script as an MCP tool – for Claude Desktop / OpenAI Codex consumers. |
 
 ## Composition
 
 - **TDD on Lakebase-paired projects**: paired with [`lakebase-tdd-workflows`](../lakebase-tdd-workflows/README.md). This skill owns branch + schema + PR plumbing; TDD-workflows layers experiment / cycle / synthesis on top.
-- **Inside VS Code/Cursor**: the [`lakebase-scm-extension`](https://github.com/databricks-solutions/lakebase-scm-extension) consumes the same substrate via npm dep — same operations, different presentation layer.
+- **Inside VS Code/Cursor**: the [`lakebase-scm-extension`](https://github.com/databricks-solutions/lakebase-scm-extension) consumes the same substrate via npm dep – same operations, different presentation layer.

--- a/skills/lakebase-scm-workflows/SKILL.md
+++ b/skills/lakebase-scm-workflows/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 parent: databricks-lakebase
 ---
 
-# lakebase-scm-workflows — agent contract
+# lakebase-scm-workflows – agent contract
 
 Agent-facing contract: operating rules (`.env`, git hooks, credential single-seam), concrete code patterns for each substrate primitive, and reference pointers.
 
@@ -15,13 +15,13 @@ For the human-facing overview (prerequisites, installation, prompts, journey, CL
 
 **FIRST**: load the parent `databricks-lakebase` skill for Lakebase Postgres CLI basics (project / branch / endpoint shapes, name formats, "never delete the production branch" rule). This skill composes on top of it.
 
-## Project state — when `.env` matters
+## Project state – when `.env` matters
 
-The substrate API takes explicit args (`instance`, `branch`, etc.) on every public function — agents can drive every operation without a project `.env` at all. **But** when an agent is acting AS the developer in a checked-out paired project, the project's `.env` is the source of truth for "which Lakebase branch is this workspace currently paired with."
+The substrate API takes explicit args (`instance`, `branch`, etc.) on every public function – agents can drive every operation without a project `.env` at all. **But** when an agent is acting AS the developer in a checked-out paired project, the project's `.env` is the source of truth for "which Lakebase branch is this workspace currently paired with."
 
 | Agent context | `.env` contract |
 |---|---|
-| In a checked-out paired project (Claude Code / Cursor / Genie Code on a developer's machine) | **Respect it.** Read `LAKEBASE_PROJECT_ID` to derive `instance`. After `git checkout`, call `syncEnvToCurrentBranch({ cwd })` so `.env` matches the new branch — otherwise the bundled CI scripts (`refresh-token.sh`, `flyway-migrate.sh`) and the git hooks operate on stale credentials. |
+| In a checked-out paired project (Claude Code / Cursor / Genie Code on a developer's machine) | **Respect it.** Read `LAKEBASE_PROJECT_ID` to derive `instance`. After `git checkout`, call `syncEnvToCurrentBranch({ cwd })` so `.env` matches the new branch – otherwise the bundled CI scripts (`refresh-token.sh`, `flyway-migrate.sh`) and the git hooks operate on stale credentials. |
 | Sandbox / no workspace (Claude Desktop, OpenAI Agent Builder, exploratory) | **Ignore it.** Pass `instance` and `branch` explicitly per call. Substrate never requires `.env`. |
 | Bootstrapping a new project | **N/A.** `createProject` creates the `.env` for you as step 7. No `.env` exists before that. |
 
@@ -45,7 +45,7 @@ LAKEBASE_PROJECT_ID=my-app
 
 If you're an agent dropping into a project mid-session, read these first to know what `instance` to pass to every subsequent operation.
 
-## Sync without an IDE — the git hooks
+## Sync without an IDE – the git hooks
 
 The construct that keeps a Lakebase branch and a git branch in sync in a plain terminal session (no extension, no explicit substrate call) is the **bundled git hooks** that `scaffoldAll` / `installHooks` drops into `.git/hooks/` during project bootstrap. They are the default-on automatic sync mechanism. Agents driving raw `git` commands inherit them for free.
 
@@ -53,21 +53,21 @@ The construct that keeps a Lakebase branch and a git branch in sync in a plain t
 |---|---|---|
 | `post-checkout` | `git checkout <branch>` | Reads new current branch → finds matching Lakebase branch → mints fresh credential → rewrites `.env` connection block. **The primary sync mechanism.** |
 | `post-merge` | `git merge` | Runs Flyway migrations against the now-current Lakebase branch so schema catches up. |
-| `pre-push` | `git push` | Schema-diff guard — surfaces unmigrated changes before remote sees them. |
+| `pre-push` | `git push` | Schema-diff guard – surfaces unmigrated changes before remote sees them. |
 | `prepare-commit-msg` | `git commit` | Embeds Lakebase branch context in commit messages so the schema-diff CI workflow can find them. |
 
 **Practical implications for an agent:**
 
-1. **Don't fight the hooks.** If you run `git checkout feature-x` in a paired project, `.env` auto-updates. Don't also call `syncEnvToCurrentBranch` defensively — let the hook own that side of the workflow.
-2. **Hooks don't create branches.** They sync state after-the-fact. To CREATE a Lakebase branch (which has no git equivalent), use the substrate's `createPairedBranch` — it creates the Lakebase side first, then `git checkout -b` triggers the hook to populate credentials.
-3. **If hooks aren't installed, re-arm them.** Some workflows clone a paired project without scaffolding (e.g. cloning someone else's checkout). The substrate's `installHooks(projectDir)` is the recovery — copies `scripts/post-checkout.sh` and siblings into `.git/hooks/` with the right permissions.
-4. **For pure-API sessions (no checkout) the hooks are irrelevant.** A Claude Desktop sandbox or OpenAI Agent Builder session that just calls `getConnection({ instance, branch })` doesn't have a `.git/` to install hooks into — and doesn't need them. The hooks only matter when an agent (or human) is driving a working tree with `git` commands.
+1. **Don't fight the hooks.** If you run `git checkout feature-x` in a paired project, `.env` auto-updates. Don't also call `syncEnvToCurrentBranch` defensively – let the hook own that side of the workflow.
+2. **Hooks don't create branches.** They sync state after-the-fact. To CREATE a Lakebase branch (which has no git equivalent), use the substrate's `createPairedBranch` – it creates the Lakebase side first, then `git checkout -b` triggers the hook to populate credentials.
+3. **If hooks aren't installed, re-arm them.** Some workflows clone a paired project without scaffolding (e.g. cloning someone else's checkout). The substrate's `installHooks(projectDir)` is the recovery – copies `scripts/post-checkout.sh` and siblings into `.git/hooks/` with the right permissions.
+4. **For pure-API sessions (no checkout) the hooks are irrelevant.** A Claude Desktop sandbox or OpenAI Agent Builder session that just calls `getConnection({ instance, branch })` doesn't have a `.git/` to install hooks into – and doesn't need them. The hooks only matter when an agent (or human) is driving a working tree with `git` commands.
 
 The bundled hook scripts live in `templates/project/common/scripts/`.
 
-## Credential handoff — two helpers, one pattern
+## Credential handoff – two helpers, one pattern
 
-Two narrow auth seams — one for Lakebase, one for GitHub. Both follow the same shape: single module, dynamic-runtime fallback chain, CI grep guard preventing any other file from resolving credentials directly.
+Two narrow auth seams – one for Lakebase, one for GitHub. Both follow the same shape: single module, dynamic-runtime fallback chain, CI grep guard preventing any other file from resolving credentials directly.
 
 ### GitHub
 
@@ -98,7 +98,7 @@ const pool = await getConnection({ output: "pool", instance, branch });
 // -> @databricks/lakebase pg.Pool with refresh-on-connect
 ```
 
-DSN and Pool resolve to the same database via the same OAuth substrate. Never call `databricks postgres generate-database-credential` from anywhere else in your code — a CI grep guard fails the build if you do. Full docs: [`references/get-connection.md`](references/get-connection.md).
+DSN and Pool resolve to the same database via the same OAuth substrate. Never call `databricks postgres generate-database-credential` from anywhere else in your code – a CI grep guard fails the build if you do. Full docs: [`references/get-connection.md`](references/get-connection.md).
 
 ## Operations
 
@@ -132,7 +132,7 @@ const result = await createProject({
   githubOwner: "my-org",
   language: "java",
   runnerType: "self-hosted",
-  enableTdd: true,                // default: true — lays down .tdd/ scaffold
+  enableTdd: true,                // default: true – lays down .tdd/ scaffold
 });
 ```
 
@@ -143,7 +143,7 @@ Eleven-step orchestration. Non-fatal failures (CI secrets sync, runner setup, ho
 Lakebase branch CRUD. Git-side operations stay with the caller; these scripts handle the paired Lakebase side.
 
 ```bash
-# Create a paired Lakebase branch — parent resolves from explicit override,
+# Create a paired Lakebase branch – parent resolves from explicit override,
 # then "branch I'm currently on" hint, then project default.
 node scripts/lakebase/branch-create.js \
   --instance proj-checkout --branch feature-add-orders \
@@ -160,8 +160,8 @@ import { createBranch, waitForBranchReady, deleteBranch }
 const branch = await createBranch({
   instance: "proj-checkout",
   branch: "feature-add-orders",     // sanitized to Lakebase id (lowercase, alphanumeric+hyphen, 3-63 chars)
-  parentBranch: "staging",            // optional — overrides "current" hint and default
-  currentBranch: "main",              // optional — git-like "fork from current" semantics
+  parentBranch: "staging",            // optional – overrides "current" hint and default
+  currentBranch: "main",              // optional – git-like "fork from current" semantics
   timeoutMs: 120_000,                 // default: 2min poll budget
 });
 
@@ -169,11 +169,11 @@ await deleteBranch({ instance: "proj-checkout", branch: branch.uid });
 ```
 
 **Parent resolution precedence:**
-1. `parentBranch` arg (explicit override — "branch from prod" / "branch from staging" hotfix)
-2. `currentBranch` arg (git-like "fork from the branch you're on") — skipped if it equals the target
+1. `parentBranch` arg (explicit override – "branch from prod" / "branch from staging" hotfix)
+2. `currentBranch` arg (git-like "fork from the branch you're on") – skipped if it equals the target
 3. Project default branch (usually `production`)
 
-**Idempotency.** `createBranch` returns the existing branch unchanged if one with the same sanitized name already exists. Delete is NOT idempotent — throws when the branch isn't found.
+**Idempotency.** `createBranch` returns the existing branch unchanged if one with the same sanitized name already exists. Delete is NOT idempotent – throws when the branch isn't found.
 
 ### 3. Endpoint + credential
 
@@ -218,11 +218,11 @@ const schema = await queryBranchSchema({ instance, branch });
 const tables = await queryBranchTables({ instance, branch });
 ```
 
-Skips `flyway_schema_history` by default. Returns `[]` when the endpoint has no host yet (branch still provisioning) — caller can poll.
+Skips `flyway_schema_history` by default. Returns `[]` when the endpoint has no host yet (branch still provisioning) – caller can poll.
 
 ### 5. Schema-diff
 
-Parent-aware schema diff between two Lakebase branches. Compares the target branch against its parent (the branch's `sourceBranchId` in Lakebase metadata) — for a feature forked from `staging`, that means diff vs `staging`, not vs `production`. Falls back to the project's default branch when the source can't be resolved.
+Parent-aware schema diff between two Lakebase branches. Compares the target branch against its parent (the branch's `sourceBranchId` in Lakebase metadata) – for a feature forked from `staging`, that means diff vs `staging`, not vs `production`. Falls back to the project's default branch when the source can't be resolved.
 
 ```bash
 lakebase-schema-diff --instance proj-checkout --branch feature-add-orders
@@ -261,7 +261,7 @@ const diff = await getSchemaDiff({
 }
 ```
 
-`migrations` is always empty in the script output — that's a workspace-file concern, not a Lakebase-side one. The extension layer fills it in locally when rendering. `prodColumns` is named for legacy modal compatibility; it carries the parent (comparison) columns regardless of whether the comparison target is production.
+`migrations` is always empty in the script output – that's a workspace-file concern, not a Lakebase-side one. The extension layer fills it in locally when rendering. `prodColumns` is named for legacy modal compatibility; it carries the parent (comparison) columns regardless of whether the comparison target is production.
 
 ### PR flow
 
@@ -295,7 +295,7 @@ await createPullRequest({
 
 ## References
 
-- [`references/get-connection.md`](references/get-connection.md) — Lakebase credential seam (DSN + Pool, OAuth refresh, fallback chain).
-- [`references/github-auth.md`](references/github-auth.md) — GitHub token seam (env → VS Code session → `gh auth token`).
-- Parent skill: [`databricks-lakebase`](https://github.com/databricks/databricks-agent-skills) — Postgres CLI surface this skill composes on.
-- Sibling skill: [`../lakebase-tdd-workflows/SKILL.md`](../lakebase-tdd-workflows/SKILL.md) — TDD workflow on paired branches; consumes `createBranch`, `getSchemaDiff`, `getConnection` from this skill.
+- [`references/get-connection.md`](references/get-connection.md) – Lakebase credential seam (DSN + Pool, OAuth refresh, fallback chain).
+- [`references/github-auth.md`](references/github-auth.md) – GitHub token seam (env → VS Code session → `gh auth token`).
+- Parent skill: [`databricks-lakebase`](https://github.com/databricks/databricks-agent-skills) – Postgres CLI surface this skill composes on.
+- Sibling skill: [`../lakebase-tdd-workflows/SKILL.md`](../lakebase-tdd-workflows/SKILL.md) – TDD workflow on paired branches; consumes `createBranch`, `getSchemaDiff`, `getConnection` from this skill.

--- a/skills/lakebase-tdd-workflows/README.md
+++ b/skills/lakebase-tdd-workflows/README.md
@@ -2,7 +2,7 @@
 
 Substrate for test-driven development on paired Lakebase branches. Canonical Beck-style RED → GREEN → REFACTOR composed with paired-branch primitives (cheap experiments, parent-aware schema diff, real per-branch databases) and HITL gates at every phase boundary.
 
-This README is the human-facing overview. The agent's operating contract — hard rules, function names, code patterns — lives in [`SKILL.md`](SKILL.md).
+This README is the human-facing overview. The agent's operating contract – hard rules, function names, code patterns – lives in [`SKILL.md`](SKILL.md).
 
 ## When to use
 
@@ -21,8 +21,8 @@ This README is the human-facing overview. The agent's operating contract — har
 | **Test list** | Beck's planning artifact. Ordered list of behavioral scenarios that define done. Lives at feature level. |
 | **Cycle** | One RED → GREEN → REFACTOR pass for a single test list item. |
 | **Spike** | Throwaway exploration on a Lakebase branch. No test list, no rigor. Goal: learn. Code is never promoted as-is. |
-| **Experiment** | A rigorous TDD branch — has a test list, runs cycles, ends with working code + tests. When N=1, the experiment IS the feature. The substrate uses "experiment" as the internal noun so the same primitives generalize to N≥2. |
-| **N=1 (the default — just a feature)** | One branch, iterative refinement. The branch IS the feature. No promote/synthesize ceremony, no compare report. This is what most work looks like. |
+| **Experiment** | A rigorous TDD branch – has a test list, runs cycles, ends with working code + tests. When N=1, the experiment IS the feature. The substrate uses "experiment" as the internal noun so the same primitives generalize to N≥2. |
+| **N=1 (the default – just a feature)** | One branch, iterative refinement. The branch IS the feature. No promote/synthesize ceremony, no compare report. This is what most work looks like. |
 | **N≥2 (parallel experiments)** | Deliberate race between competing strategies. Used when the design-spec gate finds opinion gaps the team genuinely wants to resolve by trying them. HITL chooses promote vs synthesize at the end. |
 | **Promote** | (N≥2 only) Take one experiment as-is into the feature PR. The losers are archived. |
 | **Synthesize** | (N≥2 only) PO menu-picks capabilities across experiments; spec is renegotiated; a fresh TDD cycle on a new branch produces the final code. |
@@ -35,7 +35,7 @@ The substrate API keeps "experiment" as the noun so the same primitives serve bo
 
 | Role | Responsibility | Agent prompt |
 |---|---|---|
-| **Spec Author** | Composes the initial draft spec — features, stories, ACs. | (Project skill, e.g. `/design`.) |
+| **Spec Author** | Composes the initial draft spec – features, stories, ACs. | (Project skill, e.g. `/design`.) |
 | **Architect Reviewer** | Applies layering lens; populates `layer` and `architectural_notes` per AC; imports `software-design-principles`. | [`agents/architect-reviewer.md`](agents/architect-reviewer.md) |
 | **Test Strategist** | Converts annotated ACs into a Beck-style ordered test list; emits per-AC views. | [`agents/test-strategist.md`](agents/test-strategist.md) |
 | **Orchestrator (Scrum-Master)** | Runs design-spec gate; spawns experiments to budget; runs cycles; watches smells; presents outcomes to HITL. | [`agents/scrum-master.md`](agents/scrum-master.md) |
@@ -47,21 +47,21 @@ The substrate API keeps "experiment" as the noun so the same primitives serve bo
 
 | Phase | Output | HITL gate |
 |---|---|---|
-| 0 Discovery | Draft `feature.{md,json}` + `story.{md,json}` + `ac.{md,json}` per AC | **Gate 1 — Draft spec** |
-| 1 Architectural review | Layer + architectural_notes populated; `architecture.md` summary | **Gate 2 — Architectural lens** |
-| 2 Test-list construction | Ordered `test-list.{md,json}` at feature level | **Gate 3 — Test list ordering** |
-| 3 Design-spec gate | Experiment plan in `selection-log.md` (N, strategies, budget) | **Gate 4 — Experiment plan** |
+| 0 Discovery | Draft `feature.{md,json}` + `story.{md,json}` + `ac.{md,json}` per AC | **Gate 1 – Draft spec** |
+| 1 Architectural review | Layer + architectural_notes populated; `architecture.md` summary | **Gate 2 – Architectural lens** |
+| 2 Test-list construction | Ordered `test-list.{md,json}` at feature level | **Gate 3 – Test list ordering** |
+| 3 Design-spec gate | Experiment plan in `selection-log.md` (N, strategies, budget) | **Gate 4 – Experiment plan** |
 | 4 Implementation | Per-experiment cycles producing tests + code | Continuous: smells; final: promote / synthesize choice |
 
 Each phase has a defined predecessor + artifact contract. The orchestrator refuses to transition if prior artifacts are missing or invalid.
 
 ## Operations
 
-What the substrate does on your behalf, in user-journey order. You don't invoke these directly — the agent does, in response to the prompts in [How to use](#how-to-use).
+What the substrate does on your behalf, in user-journey order. You don't invoke these directly – the agent does, in response to the prompts in [How to use](#how-to-use).
 
 ### 1. Design-spec gate
 
-Once the test list is approved (Gate 3), the agent runs the design-spec gate analyzer — phase 3. It scans the list for opinion-gap signals (keywords like "either", "consider", "alternatively", "decide", "TBD") and proposes either N=1 (iterative refinement) or N≥2 (parallel race), with strategies and a resource budget (concurrent branches, wall-clock minutes, agent-pair count).
+Once the test list is approved (Gate 3), the agent runs the design-spec gate analyzer – phase 3. It scans the list for opinion-gap signals (keywords like "either", "consider", "alternatively", "decide", "TBD") and proposes either N=1 (iterative refinement) or N≥2 (parallel race), with strategies and a resource budget (concurrent branches, wall-clock minutes, agent-pair count).
 
 The proposal is conservative by design: the analyzer's job is to surface the choice to the PO, not to decide. The PO signs off at Gate 4. The plan and the decision are persisted here:
 
@@ -75,13 +75,13 @@ The proposal is conservative by design: the analyzer's job is to surface the cho
 
 ### 2. Experiment
 
-With the plan approved, the agent cuts branches per the plan — one for N=1, multiple for N≥2 — and runs cycles against them in phase 4 (Implementation). Each experiment gets its own subdirectory:
+With the plan approved, the agent cuts branches per the plan – one for N=1, multiple for N≥2 – and runs cycles against them in phase 4 (Implementation). Each experiment gets its own subdirectory:
 
 ```
 .tdd/
   experiments/
     F1-checkout/
-      checkout/                  ← single experiment (N=1) — slug matches the feature
+      checkout/                  ← single experiment (N=1) – slug matches the feature
         branch.txt               ← Lakebase branch id
         notes.md                 ← strategy + learning notes
         outcomes.json            ← { status, tests_passed, tests_failed, schema_diff_summary, ... }
@@ -98,7 +98,7 @@ Teardown is HITL-gated: the experiment record is preserved on disk by default ev
 
 ### 3. Spike
 
-Side-mode for exploration that sits outside the main flow. No test list, no gates, no rigor. The agent runs this when you ask to "spike X" or "explore whether Y is possible" — typically before authoring a spec, to de-risk a choice you'll later put into the design-spec gate.
+Side-mode for exploration that sits outside the main flow. No test list, no gates, no rigor. The agent runs this when you ask to "spike X" or "explore whether Y is possible" – typically before authoring a spec, to de-risk a choice you'll later put into the design-spec gate.
 
 ```
 .tdd/
@@ -108,19 +108,19 @@ Side-mode for exploration that sits outside the main flow. No test list, no gate
       notes.md                   ← learning that carries forward; survives branch teardown
 ```
 
-The branch is deleted by default after notes are captured. **Spike code is never promoted into a TDD branch** — only the learning carries over.
+The branch is deleted by default after notes are captured. **Spike code is never promoted into a TDD branch** – only the learning carries over.
 
-Before cutting any new experiment, the orchestrator checks the budget — at the concurrent-branch or wall-clock limit, it asks the PO to extend or stop, rather than cutting anyway.
+Before cutting any new experiment, the orchestrator checks the budget – at the concurrent-branch or wall-clock limit, it asks the PO to extend or stop, rather than cutting anyway.
 
 ## How to use
 
-Three flows — shown as what you'd prompt your agent to do, using a cart-checkout example throughout. The agent reads [`SKILL.md`](SKILL.md) (plus the Scrum-Master / Navigator / Driver agent prompts) and runs the underlying substrate primitives on your behalf.
+Three flows – shown as what you'd prompt your agent to do, using a cart-checkout example throughout. The agent reads [`SKILL.md`](SKILL.md) (plus the Scrum-Master / Navigator / Driver agent prompts) and runs the underlying substrate primitives on your behalf.
 
-The project-level slash commands `/design` and `/build` are the canonical entry points. They're thin wrappers that project skills install on top of this substrate — they handle project-specific concerns (JIRA hierarchy, IDE branch suggestions, manual review gates) and delegate the workflow facilitation here. If a slash command isn't installed in your project, just describe what you want to your agent directly; the prompts below work either way.
+The project-level slash commands `/design` and `/build` are the canonical entry points. They're thin wrappers that project skills install on top of this substrate – they handle project-specific concerns (JIRA hierarchy, IDE branch suggestions, manual review gates) and delegate the workflow facilitation here. If a slash command isn't installed in your project, just describe what you want to your agent directly; the prompts below work either way.
 
 ### 1. Author a feature spec
 
-Just describe what you want to build. The design agent walks Spec Author → Architect Reviewer → Test Strategist and asks you to sign off at each HITL gate; you don't need to tell it about schemas, file layout, IDs, or which questions to ask — that's its job.
+Just describe what you want to build. The design agent walks Spec Author → Architect Reviewer → Test Strategist and asks you to sign off at each HITL gate; you don't need to tell it about schemas, file layout, IDs, or which questions to ask – that's its job.
 
 > `/design`
 
@@ -140,20 +140,20 @@ The most common flow. One feature, one branch, iterative refinement. The branch 
 
 > "Build the checkout feature."
 
-Scrum-Master picks up the approved spec, runs the design-spec gate (which proposes N=1 for work without opinion gaps), waits for your sign-off, cuts the feature branch off staging, and alternates Navigator + Driver per test list item. After every cycle it runs the smell detectors and pauses to surface any remediation to you. When the list is exhausted, the feature branch goes straight to PR — no promote/synthesize step.
+Scrum-Master picks up the approved spec, runs the design-spec gate (which proposes N=1 for work without opinion gaps), waits for your sign-off, cuts the feature branch off staging, and alternates Navigator + Driver per test list item. After every cycle it runs the smell detectors and pauses to surface any remediation to you. When the list is exhausted, the feature branch goes straight to PR – no promote/synthesize step.
 
 ### 3. Race parallel experiments and either promote or synthesize (N≥2)
 
 When the team has a real opinion gap and wants to resolve it by trying competing strategies. You name the strategies; the agent runs them in parallel.
 
-> "Build the checkout feature, but I want to compare two ways of storing the cart — one as a Postgres array column on orders, one as a JSON blob on a separate carts table. Race them and let me pick a winner."
+> "Build the checkout feature, but I want to compare two ways of storing the cart – one as a Postgres array column on orders, one as a JSON blob on a separate carts table. Race them and let me pick a winner."
 
 Scrum-Master cuts a branch per strategy, runs the same test list through each, and at convergence presents the comparison report. It asks you to choose:
 
-- **Promote** — one experiment is the clear winner; take it as-is into the feature PR.
-- **Synthesize** — pick capabilities across the experiments (storage schema from one, API surface from the other), renegotiate the spec, and run a fresh cycle on a synthesized branch.
-- **Continue** — let cycles finish.
-- **Abandon all** — stalled population; re-run the design-spec gate.
+- **Promote** – one experiment is the clear winner; take it as-is into the feature PR.
+- **Synthesize** – pick capabilities across the experiments (storage schema from one, API surface from the other), renegotiate the spec, and run a fresh cycle on a synthesized branch.
+- **Continue** – let cycles finish.
+- **Abandon all** – stalled population; re-run the design-spec gate.
 
 The `hitlApproved` flag on the promote and synthesize primitives is enforced at the function boundary, so the agent cannot skip this gate.
 
@@ -163,20 +163,20 @@ For when you want to run something directly without the agent. Most TDD work goe
 
 | Command | Purpose |
 |---|---|
-| `node scripts/tdd/spec-sync.js <tddDir>` | Walk the `.tdd/` tree and print drift reports. Exit 0 even when reports exist — warn-only by design. |
+| `node scripts/tdd/spec-sync.js <tddDir>` | Walk the `.tdd/` tree and print drift reports. Exit 0 even when reports exist – warn-only by design. |
 | `node scripts/tdd/test-list.js <tddDir> <featureId>` | Regenerate per-AC views from the feature-level master test list. |
-| `bash tests/run_all.sh` (per scaffolded project) | Run every `validate_*.sh` in the project's `tests/` directory — the project's full validation suite. |
+| `bash tests/run_all.sh` (per scaffolded project) | Run every `validate_*.sh` in the project's `tests/` directory – the project's full validation suite. |
 
 ## Project-level entry points
 
-- **`/design`** — wraps Spec Author + Architect Reviewer + Test Strategist phases. Project-specific JIRA hierarchy creation lives here.
-- **`/build`** — wraps Orchestrator. Project-specific PR/merge ceremony lives here.
-- **`/ship`** — lives in `lakebase-release-workflows`. Not part of this skill.
+- **`/design`** – wraps Spec Author + Architect Reviewer + Test Strategist phases. Project-specific JIRA hierarchy creation lives here.
+- **`/build`** – wraps Orchestrator. Project-specific PR/merge ceremony lives here.
+- **`/ship`** – lives in `lakebase-release-workflows`. Not part of this skill.
 
 Substrate ships no slash commands. It ships skills + agents + scripts + CLI bins. The MCP server (`apps/mcp-server/`) exposes the tool surface for MCP-capable consumers.
 
 ## Integration with sibling skills
 
-- **[`lakebase-scm-workflows`](../lakebase-scm-workflows/README.md)** — `createFeatureBranch`, `deleteBranch`, `getSchemaDiff`, `getConnection`. Experiments and spikes are paired branches.
-- **`lakebase-release-workflows`** — Tier model (feature → staging → production), TTL, "never delete production." TDD defers to release-workflows for everything past PR merge.
-- **[`software-design-principles`](../software-design-principles/SKILL.md)** — Imported as canon by Architect Reviewer (layering + cross-cutting concerns) and Navigator (refactor heuristics).
+- **[`lakebase-scm-workflows`](../lakebase-scm-workflows/README.md)** – `createFeatureBranch`, `deleteBranch`, `getSchemaDiff`, `getConnection`. Experiments and spikes are paired branches.
+- **`lakebase-release-workflows`** – Tier model (feature → staging → production), TTL, "never delete production." TDD defers to release-workflows for everything past PR merge.
+- **[`software-design-principles`](../software-design-principles/SKILL.md)** – Imported as canon by Architect Reviewer (layering + cross-cutting concerns) and Navigator (refactor heuristics).

--- a/skills/lakebase-tdd-workflows/SKILL.md
+++ b/skills/lakebase-tdd-workflows/SKILL.md
@@ -4,7 +4,7 @@ description: "Test-driven development against paired Lakebase branches. Canonica
 user-invocable: true
 ---
 
-# lakebase-tdd-workflows — agent contract
+# lakebase-tdd-workflows – agent contract
 
 Agent-facing contract: hard rules, phase flow, agent prompt index, and concrete code patterns for the substrate primitives.
 
@@ -22,7 +22,7 @@ The contract every agent (Navigator, Driver, Orchestrator) and every human colla
 6. Never make a private method public to test it.
 7. Test count is a lagging indicator. The leading indicator is "how cheap is the next test?" Rising cost = design problem.
 8. Spike code is throwaway. Promote nothing from a spike branch into a TDD branch except notes.
-9. N=1 mode is iterative refinement. There is no promote/synthesize ceremony — the branch IS the feature.
+9. N=1 mode is iterative refinement. There is no promote/synthesize ceremony – the branch IS the feature.
 
 See [`agents/navigator.md`](agents/navigator.md) and [`agents/driver.md`](agents/driver.md) for per-role specializations.
 
@@ -30,10 +30,10 @@ See [`agents/navigator.md`](agents/navigator.md) and [`agents/driver.md`](agents
 
 | Phase | Output | HITL gate |
 |---|---|---|
-| 0 Discovery | Draft `feature.{md,json}` + `story.{md,json}` + `ac.{md,json}` per AC | **Gate 1 — Draft spec** |
-| 1 Architectural review | `layer` + `architectural_notes` populated; `architecture.md` summary | **Gate 2 — Architectural lens** |
-| 2 Test-list construction | Ordered `test-list.{md,json}` at feature level | **Gate 3 — Test list ordering** |
-| 3 Design-spec gate | Experiment plan in `selection-log.md` + `features/<F>/plan.json` | **Gate 4 — Experiment plan** |
+| 0 Discovery | Draft `feature.{md,json}` + `story.{md,json}` + `ac.{md,json}` per AC | **Gate 1 – Draft spec** |
+| 1 Architectural review | `layer` + `architectural_notes` populated; `architecture.md` summary | **Gate 2 – Architectural lens** |
+| 2 Test-list construction | Ordered `test-list.{md,json}` at feature level | **Gate 3 – Test list ordering** |
+| 3 Design-spec gate | Experiment plan in `selection-log.md` + `features/<F>/plan.json` | **Gate 4 – Experiment plan** |
 | 4 Implementation | Per-experiment cycles producing tests + code | Continuous: smells; final: promote / synthesize choice |
 
 Refuse to transition if prior-phase artifacts are missing or invalid.
@@ -42,17 +42,17 @@ Refuse to transition if prior-phase artifacts are missing or invalid.
 
 Load the per-role prompt for the phase you're in:
 
-- [`agents/architect-reviewer.md`](agents/architect-reviewer.md) — phase 1, populates `layer` and `architectural_notes`, imports `software-design-principles`.
-- [`agents/test-strategist.md`](agents/test-strategist.md) — phase 2, builds the Beck-style ordered test list.
-- [`agents/scrum-master.md`](agents/scrum-master.md) — phases 3 → 4, orchestrates the design-spec gate, spawns experiments, runs cycles, watches smells, surfaces to HITL.
-- [`agents/navigator.md`](agents/navigator.md) — phase 4 PLAN + RED + REVIEW.
-- [`agents/driver.md`](agents/driver.md) — phase 4 GREEN + REFACTOR.
+- [`agents/architect-reviewer.md`](agents/architect-reviewer.md) – phase 1, populates `layer` and `architectural_notes`, imports `software-design-principles`.
+- [`agents/test-strategist.md`](agents/test-strategist.md) – phase 2, builds the Beck-style ordered test list.
+- [`agents/scrum-master.md`](agents/scrum-master.md) – phases 3 → 4, orchestrates the design-spec gate, spawns experiments, runs cycles, watches smells, surfaces to HITL.
+- [`agents/navigator.md`](agents/navigator.md) – phase 4 PLAN + RED + REVIEW.
+- [`agents/driver.md`](agents/driver.md) – phase 4 GREEN + REFACTOR.
 
 ## References
 
-- [`references/spec-format.md`](references/spec-format.md) — full `.tdd/` directory layout + markdown ↔ JSON contract.
-- `scripts/tdd/schemas/` — JSON Schemas validated by `spec-sync.ts`.
-- [`../software-design-principles/SKILL.md`](../software-design-principles/SKILL.md) — engineering canon (SOLID, DRY, DTSTTCPW, layered architecture, cross-cutting concerns, NFRs). Required reading for Architect Reviewer and Navigator.
+- [`references/spec-format.md`](references/spec-format.md) – full `.tdd/` directory layout + markdown ↔ JSON contract.
+- `scripts/tdd/schemas/` – JSON Schemas validated by `spec-sync.ts`.
+- [`../software-design-principles/SKILL.md`](../software-design-principles/SKILL.md) – engineering canon (SOLID, DRY, DTSTTCPW, layered architecture, cross-cutting concerns, NFRs). Required reading for Architect Reviewer and Navigator.
 
 ## Operations
 
@@ -65,8 +65,8 @@ import { analyzeForGate, recordPlan, writePlan } from "@databricks-solutions/lak
 import { canCutAnotherExperiment } from "@databricks-solutions/lakebase-app-dev-kit/tdd/budget";
 
 const analysis = analyzeForGate(".tdd", "F1");
-// analysis.opinion_gaps[]  — items the analyzer flagged as opinion gaps
-// analysis.proposed_plan   — { mode: "N=1" | "N>=2", N, strategies[], budget, rationale }
+// analysis.opinion_gaps[]  – items the analyzer flagged as opinion gaps
+// analysis.proposed_plan   – { mode: "N=1" | "N>=2", N, strategies[], budget, rationale }
 
 // Surface to PO. On Gate 4 approval, persist:
 recordPlan(".tdd", analysis.proposed_plan, "kevin@example.com");
@@ -83,7 +83,7 @@ if (!ok.ok) throw new Error(`budget: ${ok.reason}`);
 import { cutExperiment, listExperiments, readOutcomes, writeOutcomes, deleteExperiment }
   from "@databricks-solutions/lakebase-app-dev-kit/tdd/experiment";
 
-// N=1 — slug matches the feature.
+// N=1 – slug matches the feature.
 const feature = await cutExperiment({
   instance: "proj-checkout",
   tddDir: ".tdd",
@@ -97,7 +97,7 @@ const feature = await cutExperiment({
 
 writeOutcomes(".tdd", "F1", "checkout", { status: "succeeded", tests_passed: 2 });
 
-// Teardown is HITL-gated. deleteBranchToo defaults to false — record survives.
+// Teardown is HITL-gated. deleteBranchToo defaults to false – record survives.
 await deleteExperiment({
   instance: "proj-checkout",
   tddDir: ".tdd",
@@ -148,7 +148,7 @@ const scope = {
 // Open a DSN against the experiment's branch DB (no mocks).
 const dsn = await openBranchDsn({ instance: "proj-checkout", branch_id: "checkout" });
 
-// RED — Navigator writes a failing test, persists the cycle artifact.
+// RED – Navigator writes a failing test, persists the cycle artifact.
 const c1 = beginCycle({
   ...scope,
   test_id: "T1",
@@ -156,10 +156,10 @@ const c1 = beginCycle({
   navigator_plan: "force the public boundary to accept a Cart payload",
 });
 
-// GREEN — Driver returns and Navigator reviews.
+// GREEN – Driver returns and Navigator reviews.
 markGreen(scope, c1.cycle_id, "added POST handler + repository write");
 
-// Optional REFACTOR — Navigator requests, Driver applies, no outer-boundary test changes.
+// Optional REFACTOR – Navigator requests, Driver applies, no outer-boundary test changes.
 markRefactored(scope, c1.cycle_id, "extracted CartRepository");
 
 // Navigator-flagged smells (Hard Rule 1, 4 violations).
@@ -187,9 +187,9 @@ import { compareExperiments }
   from "@databricks-solutions/lakebase-app-dev-kit/tdd/compare-experiments";
 
 const report = compareExperiments(".tdd", "F1");
-// report.rows[].signal       — "winning" | "stalled" | "abandoned" | "running" | "unknown"
-// report.recommendation      — "promote" | "synthesize" | "continue" | "abandon-all"
-// report.rationale           — short explanation surfaced to the PO
+// report.rows[].signal       – "winning" | "stalled" | "abandoned" | "running" | "unknown"
+// report.recommendation      – "promote" | "synthesize" | "continue" | "abandon-all"
+// report.rationale           – short explanation surfaced to the PO
 ```
 
 ### Promote (N≥2, single winner)
@@ -242,7 +242,7 @@ import { validateSpec, readFeature, writeFeature, readWorkflowState, writeWorkfl
   from "@databricks-solutions/lakebase-app-dev-kit/tdd/spec-sync";
 
 const drift = validateSpec(".tdd");
-// drift[].kind — "schema" | "pair-missing" | "narrative-empty" | "id-mismatch"
+// drift[].kind – "schema" | "pair-missing" | "narrative-empty" | "id-mismatch"
 // Warn-only; do not auto-correct narrative drift.
 ```
 
@@ -374,9 +374,9 @@ if (report.recommendation === "promote") {
 
 ## Adapters
 
-Bundled: `markdown.ts` (no-op default — the spec IS the tracking), `jira.ts` (stub). Project skills wire in the adapter they want via `.tdd/adapters/<name>.json` config.
+Bundled: `markdown.ts` (no-op default – the spec IS the tracking), `jira.ts` (stub). Project skills wire in the adapter they want via `.tdd/adapters/<name>.json` config.
 
-The `SpecAdapter` interface extends `SyncEventHooks` — implementations may opt into `onPhaseTransition`, `onCycleComplete`, `onSmellDetected` hooks for status-mirroring to external trackers. Adapter failures must degrade gracefully — the on-disk spec is the source of truth.
+The `SpecAdapter` interface extends `SyncEventHooks` – implementations may opt into `onPhaseTransition`, `onCycleComplete`, `onSmellDetected` hooks for status-mirroring to external trackers. Adapter failures must degrade gracefully – the on-disk spec is the source of truth.
 
 ## CLI bins
 
@@ -384,5 +384,5 @@ For non-agent invocation (debugging, CI introspection):
 
 | Command | Purpose |
 |---|---|
-| `node scripts/tdd/spec-sync.js <tddDir>` | Walk the `.tdd/` tree and print drift reports. Exits 0 even when reports exist — warn-only. |
+| `node scripts/tdd/spec-sync.js <tddDir>` | Walk the `.tdd/` tree and print drift reports. Exits 0 even when reports exist – warn-only. |
 | `node scripts/tdd/test-list.js <tddDir> <featureId>` | Regenerate per-AC views from the feature-level master test list. |

--- a/skills/lakebase-tdd-workflows/agents/architect-reviewer.md
+++ b/skills/lakebase-tdd-workflows/agents/architect-reviewer.md
@@ -4,9 +4,9 @@ You apply the architectural lens to a draft spec. Your job is to ensure every ac
 
 ## Inputs
 
-- `.tdd/features/<F>/feature.{md,json}` — draft feature spec (Gate 1 signed off).
-- `.tdd/features/<F>/stories/<S>/story.{md,json}` — one or more stories.
-- `.tdd/features/<F>/stories/<S>/acs/<AC>.{md,json}` — one or more acceptance criteria.
+- `.tdd/features/<F>/feature.{md,json}` – draft feature spec (Gate 1 signed off).
+- `.tdd/features/<F>/stories/<S>/story.{md,json}` – one or more stories.
+- `.tdd/features/<F>/stories/<S>/acs/<AC>.{md,json}` – one or more acceptance criteria.
 
 ## Outputs
 
@@ -17,10 +17,10 @@ You apply the architectural lens to a draft spec. Your job is to ensure every ac
 ## Canon you must import
 
 Read `skills/software-design-principles/SKILL.md` and its references before annotating. Specifically:
-- [Layered architecture](../../software-design-principles/references/layered-architecture.md) — the four-layer model + dependency direction.
-- [Cross-cutting concerns](../../software-design-principles/references/cross-cutting-concerns.md) — ownership defaults table.
-- [SOLID](../../software-design-principles/references/solid.md) — module-level rules.
-- [NFRs](../../software-design-principles/references/nfrs.md) — baseline checklist.
+- [Layered architecture](../../software-design-principles/references/layered-architecture.md) – the four-layer model + dependency direction.
+- [Cross-cutting concerns](../../software-design-principles/references/cross-cutting-concerns.md) – ownership defaults table.
+- [SOLID](../../software-design-principles/references/solid.md) – module-level rules.
+- [NFRs](../../software-design-principles/references/nfrs.md) – baseline checklist.
 
 ## Method
 
@@ -36,14 +36,14 @@ For each AC:
 
 For each feature + story:
 
-5. Walk the [NFRs checklist](../../software-design-principles/references/nfrs.md). Populate `nfrs[]` with entries that have a non-trivial answer. "N/A — reason" is allowed; "unconsidered" is not.
+5. Walk the [NFRs checklist](../../software-design-principles/references/nfrs.md). Populate `nfrs[]` with entries that have a non-trivial answer. "N/A – reason" is allowed; "unconsidered" is not.
 
 For the feature as a whole:
 
 6. Write `architecture.md`. Sections:
-   - **Architectural Concerns Mapping** — fill in the table from `software-design-principles/SKILL.md`.
-   - **Pattern proposals** — any SOLID-driven module boundaries you anticipate.
-   - **Risks** — design choices that may need revisiting (call out explicitly, not as a TODO).
+   - **Architectural Concerns Mapping** – fill in the table from `software-design-principles/SKILL.md`.
+   - **Pattern proposals** – any SOLID-driven module boundaries you anticipate.
+   - **Risks** – design choices that may need revisiting (call out explicitly, not as a TODO).
 
 ## HITL gate (Gate 2)
 
@@ -59,4 +59,4 @@ Do **not** proceed to test-list construction until the PO signs off.
 - You do **not** write tests. Test-list construction is the Test Strategist's job in phase 2 (Test-list construction).
 - You do **not** decide promote-vs-synthesize. That's the PO in phase 4 (Implementation).
 - You do **not** weaken existing assertions on the ACs. If an AC is unclear, surface it to the PO; do not silently rewrite the Then clause.
-- If a cross-cutting concern is missing an owner, that's a finding — surface it; do not invent ownership.
+- If a cross-cutting concern is missing an owner, that's a finding – surface it; do not invent ownership.

--- a/skills/lakebase-tdd-workflows/agents/driver.md
+++ b/skills/lakebase-tdd-workflows/agents/driver.md
@@ -1,6 +1,6 @@
 # Driver
 
-You receive a RED test from the Navigator and produce the minimal honest code to make it pass (GREEN). After GREEN, you REFACTOR on Navigator's request — without changing what the outer-boundary tests check.
+You receive a RED test from the Navigator and produce the minimal honest code to make it pass (GREEN). After GREEN, you REFACTOR on Navigator's request – without changing what the outer-boundary tests check.
 
 ## Inputs
 
@@ -18,16 +18,16 @@ You receive a RED test from the Navigator and produce the minimal honest code to
 ## GREEN
 
 1. Read the failing test and the Navigator's `navigator_plan`.
-2. Write the **simplest, least clever** thing that satisfies the test — see [dtsttcpw.md](../../software-design-principles/references/dtsttcpw.md).
+2. Write the **simplest, least clever** thing that satisfies the test – see [dtsttcpw.md](../../software-design-principles/references/dtsttcpw.md).
    - If a constant satisfies the test, return a constant. The next test will demand variability.
    - Do not invent abstractions in anticipation of tests you can see further in the list. The test list is your horizon; the *current* test is your increment.
    - "Minimal honest" code is allowed to be a little forward-looking when honesty requires it: don't write code that knowingly contradicts the test list, but don't pre-build the abstraction either.
-3. Run the test. If it passes — and only the failing test changed status from `pending` → `green` — call `markGreen()` with a short `driver_changes` summary.
+3. Run the test. If it passes – and only the failing test changed status from `pending` → `green` – call `markGreen()` with a short `driver_changes` summary.
 4. If the test still fails, fix the code. Never weaken the test.
 
 ## REFACTOR (only when Navigator requests it)
 
-5. Improve names, extract helpers, collapse duplication — without changing any outer-boundary test.
+5. Improve names, extract helpers, collapse duplication – without changing any outer-boundary test.
 6. If your refactor breaks an outer-boundary test, the refactor is wrong (or the test is). Surface this to Navigator; do not edit the test.
 7. Call `markRefactored()` with a one-line `refactor_notes`.
 
@@ -41,10 +41,10 @@ You receive a RED test from the Navigator and produce the minimal honest code to
 
 ## Smells you must surface (via Navigator's flagSmells)
 
-- **Cycle stall** — you've spent N cycles without a GREEN. Flag `["cycle-stall"]`. The test ordering or spec is probably wrong.
-- **Test cost spiral** — each new test is taking >2x the lines of the prior one. Flag `["test-cost-spiral"]`.
-- **Fragility ratio** — your one-line behavior change broke >3 tests. Flag `["fragility-ratio"]`; the tests are mirroring the implementation rather than testing behavior.
+- **Cycle stall** – you've spent N cycles without a GREEN. Flag `["cycle-stall"]`. The test ordering or spec is probably wrong.
+- **Test cost spiral** – each new test is taking >2x the lines of the prior one. Flag `["test-cost-spiral"]`.
+- **Fragility ratio** – your one-line behavior change broke >3 tests. Flag `["fragility-ratio"]`; the tests are mirroring the implementation rather than testing behavior.
 
 ## Composition with the Navigator
 
-You are the Driver in a strict pair. You execute Navigator's plan. You do not propose plans, write tests, or decide refactors unprompted — but you do flag when the situation surfaces a smell. The Orchestrator handles bad-smell escalation to the PO; you flag, you don't decide.
+You are the Driver in a strict pair. You execute Navigator's plan. You do not propose plans, write tests, or decide refactors unprompted – but you do flag when the situation surfaces a smell. The Orchestrator handles bad-smell escalation to the PO; you flag, you don't decide.

--- a/skills/lakebase-tdd-workflows/agents/navigator.md
+++ b/skills/lakebase-tdd-workflows/agents/navigator.md
@@ -1,11 +1,11 @@
 # Navigator
 
-You PLAN the next test, write a failing assertion (RED), and REVIEW the design after each GREEN. You never weaken an assertion to make a test pass — that's the Driver's responsibility to satisfy honestly, or yours to renegotiate via the Product Owner.
+You PLAN the next test, write a failing assertion (RED), and REVIEW the design after each GREEN. You never weaken an assertion to make a test pass – that's the Driver's responsibility to satisfy honestly, or yours to renegotiate via the Product Owner.
 
 ## Inputs
 
-- `.tdd/features/<F>/test-list.json` — the approved Beck-style ordered list (Gate 3 signed off).
-- `.tdd/cycles/<F>/<S>/<AC>/cycle-NNN.json` — prior cycle artifacts (so you can see what's already passing).
+- `.tdd/features/<F>/test-list.json` – the approved Beck-style ordered list (Gate 3 signed off).
+- `.tdd/cycles/<F>/<S>/<AC>/cycle-NNN.json` – prior cycle artifacts (so you can see what's already passing).
 - The experiment branch's source tree.
 - Connection to the experiment's Lakebase branch DB via `openBranchDsn` from `scripts/tdd/run-cycle.ts`.
 
@@ -27,12 +27,12 @@ Before writing any code:
 3. Write down `navigator_plan` in 2-3 sentences:
    - what concept the test forces into being
    - what the interface should look like after the test passes
-4. If the test requires a private helper to exist before the test can be written, that's a smell — re-order the test list with the PO instead.
+4. If the test requires a private helper to exist before the test can be written, that's a smell – re-order the test list with the PO instead.
 
 ## RED
 
 5. Write the failing test against the experiment branch's DB (via `openBranchDsn({instance, branch_id: <experiment_branch>})`).
-6. Verify the test **actually fails** — a test that passes before any production code is written is testing the wrong thing.
+6. Verify the test **actually fails** – a test that passes before any production code is written is testing the wrong thing.
 7. Call `beginCycle()` to persist the cycle artifact.
 
 ## REVIEW (after Driver returns GREEN)
@@ -47,10 +47,10 @@ Before writing any code:
 ## Smells you must flag (not silently fix)
 
 - **Driver attempts to delete or weaken a test.** Hard block. Surface to PO; never accept.
-- **Test cost spiral** — each new test is taking >2x the lines of the prior one. Flag via `flagSmells(["test-cost-spiral"])`.
-- **API coherence drift** — the same concept named differently across two consecutive PASS reviews. Flag `["api-coherence-drift"]`; request a rename refactor before the next test.
-- **Fragility ratio** — a small behavior change failed >3 tests. Flag `["fragility-ratio"]`; likely tests-mirror-implementation anti-pattern.
-- **Boundary violation** — Driver added a test against a private helper. Flag `["boundary-violation"]`; insist on an outer-boundary test or move the inner logic to its own list.
+- **Test cost spiral** – each new test is taking >2x the lines of the prior one. Flag via `flagSmells(["test-cost-spiral"])`.
+- **API coherence drift** – the same concept named differently across two consecutive PASS reviews. Flag `["api-coherence-drift"]`; request a rename refactor before the next test.
+- **Fragility ratio** – a small behavior change failed >3 tests. Flag `["fragility-ratio"]`; likely tests-mirror-implementation anti-pattern.
+- **Boundary violation** – Driver added a test against a private helper. Flag `["boundary-violation"]`; insist on an outer-boundary test or move the inner logic to its own list.
 
 ## Rules
 

--- a/skills/lakebase-tdd-workflows/agents/scrum-master.md
+++ b/skills/lakebase-tdd-workflows/agents/scrum-master.md
@@ -4,10 +4,10 @@ You facilitate. You do not decide. You run phase transitions, spawn experiments 
 
 ## Inputs
 
-- `.tdd/workflow-state.json` — current phase + locus.
-- `.tdd/features/<F>/...` — approved spec + test list.
-- `.tdd/features/<F>/plan.json` — design-spec gate output (Gate 4 signed off).
-- `scripts/tdd/*.ts` primitives — experiment / cycle / smells / compare / promote / synthesis / budget.
+- `.tdd/workflow-state.json` – current phase + locus.
+- `.tdd/features/<F>/...` – approved spec + test list.
+- `.tdd/features/<F>/plan.json` – design-spec gate output (Gate 4 signed off).
+- `scripts/tdd/*.ts` primitives – experiment / cycle / smells / compare / promote / synthesis / budget.
 
 ## Outputs
 
@@ -20,45 +20,45 @@ You facilitate. You do not decide. You run phase transitions, spawn experiments 
 
 ## Method
 
-### Phase 0 → 1 — Discovery → Architectural review
+### Phase 0 → 1 – Discovery → Architectural review
 
 1. Read `workflow-state.json`. If phase != "discovery", do not regress.
 2. Confirm draft spec artifacts exist for the active feature: `feature.{md,json}` + one or more stories with their ACs.
 3. Surface to PO: Gate 1 confirmation.
 4. On approval: transition phase → "architectural-review". Hand off to Architect Reviewer (`agents/architect-reviewer.md`).
 
-### Phase 1 → 2 — Architectural review → Test-list construction
+### Phase 1 → 2 – Architectural review → Test-list construction
 
 5. Wait for Architect Reviewer to populate `layer`, `architectural_notes`, `nfrs[]` and produce `architecture.md`.
 6. Surface to PO: Gate 2 confirmation.
 7. On approval: transition phase → "test-list-construction". Hand off to Test Strategist (`agents/test-strategist.md`).
 
-### Phase 2 → 3 — Test-list construction → Design-spec gate
+### Phase 2 → 3 – Test-list construction → Design-spec gate
 
 8. Wait for Test Strategist to produce ordered `test-list.{md,json}` + per-AC views.
 9. Surface to PO: Gate 3 confirmation.
 10. On approval: transition phase → "design-spec-gate". Run `scripts/tdd/design-spec-gate.ts analyzeForGate()`.
 
-### Phase 3 → 4 — Design-spec gate → Implementation
+### Phase 3 → 4 – Design-spec gate → Implementation
 
 11. Show PO the proposed plan (N=1 vs N≥2, strategies, budget).
 12. On Gate 4 approval: `writePlan()` + `recordPlan(approverEmail)`. Transition phase → "implementation".
 13. Spawn experiments per plan, respecting `canCutAnotherExperiment()` from `scripts/tdd/budget.ts`.
 
-### Phase 4 — Implementation loop
+### Phase 4 – Implementation loop
 
 For each experiment, per cycle:
 14. Pair Navigator + Driver per the agent contracts. They mutate cycle artifacts via `run-cycle.ts`.
 15. After each cycle, run `scripts/tdd/smells.ts.runDetectorsForScope()`. Persist hits via `writeSmellsLog()`.
 16. For any smell hit, immediately surface to PO + propose the remediation from `SMELL_CATALOG`. **Never auto-apply remediations.**
 17. Watch budget. `canCutAnotherExperiment()` returns `{ok: false}` → surface to PO; do not cut another.
-18. Watch for `cross-experiment-divergence` (N≥2) — if two experiments are solving different problems, that's an opinion-gap leak; surface and propose re-running design-spec gate.
+18. Watch for `cross-experiment-divergence` (N≥2) – if two experiments are solving different problems, that's an opinion-gap leak; surface and propose re-running design-spec gate.
 
-### Phase 4 outcomes — N=1 vs N≥2
+### Phase 4 outcomes – N=1 vs N≥2
 
 N=1:
 19. When the test list is exhausted (all items `green` or `refactored`) **or** PO declares done, transition phase → "review".
-20. There is **no** promote/synthesize ceremony in N=1 — the branch IS the feature. Surface to PO for PR creation.
+20. There is **no** promote/synthesize ceremony in N=1 – the branch IS the feature. Surface to PO for PR creation.
 
 N≥2:
 21. When experiments converge, run `compareExperiments()`. Show the report to PO.
@@ -71,7 +71,7 @@ N≥2:
 
 ## Adapter status-sync
 
-24. If an adapter is configured (per `.tdd/adapters/<name>.json`), call its `onPhaseTransition` / `onCycleComplete` / `onSmellDetected` hooks at the matching points. Adapter failures must not block the workflow — log and surface, do not throw.
+24. If an adapter is configured (per `.tdd/adapters/<name>.json`), call its `onPhaseTransition` / `onCycleComplete` / `onSmellDetected` hooks at the matching points. Adapter failures must not block the workflow – log and surface, do not throw.
 
 ## Rules
 
@@ -79,4 +79,4 @@ N≥2:
 - Every promote/synthesize call requires `hitlApproved: true` and an `approverEmail`. The scripts will throw otherwise.
 - You do not write tests. You do not write production code. You orchestrate.
 - Smells produce proposals, not auto-applied changes. PO gates every remediation.
-- Adapter failures degrade gracefully — the on-disk spec is the source of truth.
+- Adapter failures degrade gracefully – the on-disk spec is the source of truth.

--- a/skills/lakebase-tdd-workflows/agents/test-strategist.md
+++ b/skills/lakebase-tdd-workflows/agents/test-strategist.md
@@ -4,15 +4,15 @@ You convert an architecturally-annotated feature into a Beck-style ordered test 
 
 ## Inputs
 
-- `.tdd/features/<F>/feature.json` — feature with `nfrs[]` populated.
-- `.tdd/features/<F>/stories/<S>/acs/<AC>.json` — every AC has `layer`, `architectural_notes`, and `nfrs[]`.
-- `.tdd/features/<F>/architecture.md` — Architect Reviewer's layering summary.
+- `.tdd/features/<F>/feature.json` – feature with `nfrs[]` populated.
+- `.tdd/features/<F>/stories/<S>/acs/<AC>.json` – every AC has `layer`, `architectural_notes`, and `nfrs[]`.
+- `.tdd/features/<F>/architecture.md` – Architect Reviewer's layering summary.
 - (Architectural review gate 2 must be signed off.)
 
 ## Outputs
 
-- `.tdd/features/<F>/test-list.{md,json}` — Beck's master ordered list at the **feature** level.
-- For each AC: `.tdd/features/<F>/stories/<S>/test-list-per-ac.json` — generated transform by `scripts/tdd/test-list.ts`.
+- `.tdd/features/<F>/test-list.{md,json}` – Beck's master ordered list at the **feature** level.
+- For each AC: `.tdd/features/<F>/stories/<S>/test-list-per-ac.json` – generated transform by `scripts/tdd/test-list.ts`.
 - Optional: scaffolded scenario files under `.tdd/features/<F>/stories/<S>/scenarios/` as `.feature` (Gherkin) or `.test.ts` stubs.
 
 ## Method
@@ -37,7 +37,7 @@ You convert an architecturally-annotated feature into a Beck-style ordered test 
 Surface to the Product Owner:
 - The ordered master list with rationale.
 - Items skipped or deferred, with reason.
-- Any scenario that cannot be defined without writing implementation first (this is a design smell — call it out).
+- Any scenario that cannot be defined without writing implementation first (this is a design smell – call it out).
 
 Do not proceed to design-spec gate until the PO signs off.
 
@@ -45,6 +45,6 @@ Do not proceed to design-spec gate until the PO signs off.
 
 - One test per behavioral scenario. Do not bundle two assertions into "and." If two assertions are required, that's two items.
 - Test at the **outermost public boundary** that maps to the AC's `layer`. Inner-loop tests are reserved for pure logic that can't be exercised through the outer boundary.
-- The list is **immutable** once approved by the PO (Gate 3). Drift triggers the `test-list-drift` bad smell — request a PO refinement before adding items.
+- The list is **immutable** once approved by the PO (Gate 3). Drift triggers the `test-list-drift` bad smell – request a PO refinement before adding items.
 - Do **not** write code. Test items describe *what* will be tested, not *how* the production code will satisfy them.
 - Do **not** decide N=1 vs N≥2. That's the Orchestrator's job in phase 3 (Design-spec gate).

--- a/skills/lakebase-tdd-workflows/references/spec-format.md
+++ b/skills/lakebase-tdd-workflows/references/spec-format.md
@@ -69,7 +69,7 @@ The on-disk `.tdd/` layout that the lakebase-tdd-workflows substrate reads and w
 - Schema: every `.json` is validated against its schema in `scripts/tdd/schemas/`. A schema failure is a hard error reported as a `DriftReport` of kind `schema`.
 - Pair completeness: each `feature.json`, `story.json`, and `ac.json` must have a sibling `.md`. Missing narrative is reported as `pair-missing`. Empty narrative is reported as `narrative-empty` (size < 20 bytes).
 - ID consistency: the directory name must start with the `id` field from the JSON. Mismatches are reported as `id-mismatch`.
-- Drift is **warn-only**. The CLI exits 0 with reports printed. Auto-correction is intentionally not done — narrative changes are too easy to silently overwrite.
+- Drift is **warn-only**. The CLI exits 0 with reports printed. Auto-correction is intentionally not done – narrative changes are too easy to silently overwrite.
 
 ## Schemas (machine contract)
 
@@ -87,8 +87,8 @@ Schemas live at `scripts/tdd/schemas/`. The substrate consumes them via Ajv in `
 
 The on-disk format is canonical. Adapters (markdown, jira, github-issues, etc.) implement `SpecAdapter` from `scripts/tdd/adapters/types.ts` to mirror state to an external system. The `external_ref` field on every entity carries `{adapter, external_id}` once an adapter has pushed.
 
-- **`markdown.ts`** — no-op (the spec IS the tracking). Default when no adapter is configured.
-- **`jira.ts`** — stub at M1.5; full implementation deferred. When wired, will push features as Stories under an Epic, ACs as Sub-tasks, status as JIRA transitions.
+- **`markdown.ts`** – no-op (the spec IS the tracking). Default when no adapter is configured.
+- **`jira.ts`** – stub at M1.5; full implementation deferred. When wired, will push features as Stories under an Epic, ACs as Sub-tasks, status as JIRA transitions.
 
 ## Read / write helpers
 

--- a/skills/software-design-principles/SKILL.md
+++ b/skills/software-design-principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: software-design-principles
-description: "Foundational engineering canon — SOLID, DRY, DTSTTCPW, clean code, layered architecture, cross-cutting concerns, NFRs. Imported by workflow skills (lakebase-tdd-workflows, lakebase-scm-workflows, lakebase-release-workflows) and project skills that need shared engineering vocabulary. Use when: designing a new module, reviewing a PR, planning a refactor, mapping cross-cutting concerns to layers, or arguing about API shape."
+description: "Foundational engineering canon – SOLID, DRY, DTSTTCPW, clean code, layered architecture, cross-cutting concerns, NFRs. Imported by workflow skills (lakebase-tdd-workflows, lakebase-scm-workflows, lakebase-release-workflows) and project skills that need shared engineering vocabulary. Use when: designing a new module, reviewing a PR, planning a refactor, mapping cross-cutting concerns to layers, or arguing about API shape."
 ---
 
 # software-design-principles
@@ -15,7 +15,7 @@ Shared canon. Read when you need a common engineering vocabulary across roles (A
 
 ## What this skill is
 
-A reference, not an executor. It ships markdown only — no scripts. The job is to provide a consistent vocabulary and a checklist of considerations. Workflow skills cite these references; agents read them; humans read them.
+A reference, not an executor. It ships markdown only – no scripts. The job is to provide a consistent vocabulary and a checklist of considerations. Workflow skills cite these references; agents read them; humans read them.
 
 ## Architectural Concerns Mapping (mandatory before promote/merge)
 
@@ -37,15 +37,15 @@ If a row is unfilled or a concern doesn't have a clear owner, that's a design sm
 
 ## References
 
-The canon is organized into seven focused references. Each is a short, opinionated document — not a textbook.
+The canon is organized into seven focused references. Each is a short, opinionated document – not a textbook.
 
-- [SOLID](references/solid.md) — Single Responsibility, Open-Closed, Liskov Substitution, Interface Segregation, Dependency Inversion. The grammar of object-oriented design.
-- [DRY](references/dry.md) — Don't Repeat Yourself, with the rule-of-three guardrail against premature abstraction.
-- [DTSTTCPW](references/dtsttcpw.md) — Do The Simplest Thing That Could Possibly Work. The TDD-aligned counter-balance to speculative generality.
-- [Clean code](references/clean-code.md) — Naming, function shape, comment policy, error-handling boundaries. Condensed from Uncle Bob.
-- [Layered architecture](references/layered-architecture.md) — Infrastructure / service / HTTP / policy layers, dependency direction rules.
-- [Cross-cutting concerns](references/cross-cutting-concerns.md) — Which layer owns auth, authz, capability resolution, audit, rate limiting, schema, policy config.
-- [NFRs](references/nfrs.md) — Performance, scalability, security, observability, operability, resilience. The baseline checklist.
+- [SOLID](references/solid.md) – Single Responsibility, Open-Closed, Liskov Substitution, Interface Segregation, Dependency Inversion. The grammar of object-oriented design.
+- [DRY](references/dry.md) – Don't Repeat Yourself, with the rule-of-three guardrail against premature abstraction.
+- [DTSTTCPW](references/dtsttcpw.md) – Do The Simplest Thing That Could Possibly Work. The TDD-aligned counter-balance to speculative generality.
+- [Clean code](references/clean-code.md) – Naming, function shape, comment policy, error-handling boundaries. Condensed from Uncle Bob.
+- [Layered architecture](references/layered-architecture.md) – Infrastructure / service / HTTP / policy layers, dependency direction rules.
+- [Cross-cutting concerns](references/cross-cutting-concerns.md) – Which layer owns auth, authz, capability resolution, audit, rate limiting, schema, policy config.
+- [NFRs](references/nfrs.md) – Performance, scalability, security, observability, operability, resilience. The baseline checklist.
 
 ## Hard rules
 
@@ -54,15 +54,15 @@ These rules apply across all references. Workflow skills that import this canon 
 1. **Names carry the design.** If a fresh reader can't infer the concept from the name, rename it before the next test.
 2. **Layers depend inward, never outward.** HTTP can call service. Service can call infrastructure. Infrastructure never calls service. Service never calls HTTP.
 3. **Cross-cutting concerns have one owner.** Two modules with overlapping audit logic is a smell. One owns it; the others delegate.
-4. **DRY after three.** Two similar implementations is a coincidence. Three is a pattern — extract.
+4. **DRY after three.** Two similar implementations is a coincidence. Three is a pattern – extract.
 5. **DTSTTCPW beats speculative generality.** Add the abstraction when the third caller appears, not when you imagine it.
-6. **NFR baseline check before declaring done.** Performance / scalability / security / observability / operability / resilience — at least skim the checklist.
+6. **NFR baseline check before declaring done.** Performance / scalability / security / observability / operability / resilience – at least skim the checklist.
 7. **Public boundary tests, private implementation refactors.** A correct refactor never changes the outer-boundary tests.
 
 ## Composition with workflow skills
 
-- **`lakebase-tdd-workflows`** — Architect Reviewer imports this canon during phase 7.1 (architectural review). Navigator imports during PLAN. Driver imports during REFACTOR.
-- **`lakebase-scm-workflows`** — Branch PRs are reviewed against the layered-architecture + cross-cutting-concerns checks.
-- **`lakebase-release-workflows`** — NFR baseline checklist is the release gate.
+- **`lakebase-tdd-workflows`** – Architect Reviewer imports this canon during phase 7.1 (architectural review). Navigator imports during PLAN. Driver imports during REFACTOR.
+- **`lakebase-scm-workflows`** – Branch PRs are reviewed against the layered-architecture + cross-cutting-concerns checks.
+- **`lakebase-release-workflows`** – NFR baseline checklist is the release gate.
 
 This skill ships no slash commands and no scripts. It is consulted, not invoked.

--- a/skills/software-design-principles/references/clean-code.md
+++ b/skills/software-design-principles/references/clean-code.md
@@ -31,8 +31,8 @@ When to comment:
 - TODO / FIXME with a ticket number.
 
 When *not* to comment:
-- To explain *what* the code does — rename the function/variable instead.
-- To explain *how* the code works — extract a helper with a clear name.
+- To explain *what* the code does – rename the function/variable instead.
+- To explain *how* the code works – extract a helper with a clear name.
 - To narrate the developer's process ("first we get the user, then we check perms").
 - To restate the obvious (`// increment counter` next to `counter++`).
 - To mark removed code ("// removed X because Y"). Use git history.
@@ -45,7 +45,7 @@ A comment that would confuse a reader if removed deserves to exist. A comment wh
 - Once past the boundary, trust your own types.
 - Never silently swallow exceptions. At minimum log; ideally re-throw with context.
 - Don't `try/catch` for control flow. Exceptions are for *exceptional* conditions.
-- The "happy path" of a function should be visually obvious — error handling is the indented or guarded path.
+- The "happy path" of a function should be visually obvious – error handling is the indented or guarded path.
 
 Guard clauses beat nested ifs:
 
@@ -79,9 +79,9 @@ if (user) {
 Clean-code rules apply to tests:
 - Clear names that read like specifications (`it("rejects login when the password is wrong")`).
 - One assertion per test, ideally. If you need three, the test is doing three things.
-- No magic numbers — use named constants or fixture factories.
+- No magic numbers – use named constants or fixture factories.
 - AAA structure (Arrange / Act / Assert) is visible by indentation.
-- Test fixtures are data — repeat freely, don't over-factor.
+- Test fixtures are data – repeat freely, don't over-factor.
 
 ## The cleanest code question
 

--- a/skills/software-design-principles/references/cross-cutting-concerns.md
+++ b/skills/software-design-principles/references/cross-cutting-concerns.md
@@ -1,6 +1,6 @@
 # Cross-cutting concerns
 
-Concerns that span multiple modules — auth, audit, rate limiting, schema validation, capability resolution, policy. The design failure mode is *implementing the same concern in multiple places* and having the implementations drift.
+Concerns that span multiple modules – auth, audit, rate limiting, schema validation, capability resolution, policy. The design failure mode is *implementing the same concern in multiple places* and having the implementations drift.
 
 The rule: **each cross-cutting concern has one owner layer and one owner module.** Everything else delegates.
 
@@ -37,7 +37,7 @@ Example: audit logging
 - The HTTP layer wraps the service call.
 - The wrapper calls `audit.emit(event)` after the service call returns or throws.
 - The audit module formats and writes the event.
-- The service does not call `audit.emit()` directly — that's the wrapper's job.
+- The service does not call `audit.emit()` directly – that's the wrapper's job.
 
 This way: adding a new audit destination touches *one* module; removing audit from a route touches *one* middleware registration.
 
@@ -45,18 +45,18 @@ This way: adding a new audit destination touches *one* module; removing audit fr
 
 Before merging a new feature, walk the mapping:
 
-- [ ] Authentication — does this route need it? Where is it enforced?
-- [ ] Authorization — is the action gated? Where does the decision live?
-- [ ] Capability resolution — does the caller need a capability check?
-- [ ] Audit — should this action emit an event? At which boundary?
-- [ ] Rate limiting — does this route need a limit?
-- [ ] Schema validation — is the input validated? Where?
-- [ ] Policy config — does this feature have configuration? Where does it live?
-- [ ] Transactions — what's the atomicity boundary?
-- [ ] Caching — does this read benefit from a cache?
-- [ ] Tracing/metrics — is this operation traced?
-- [ ] Secrets — does this feature consume any?
-- [ ] Feature flags — is this feature behind a flag?
+- [ ] Authentication – does this route need it? Where is it enforced?
+- [ ] Authorization – is the action gated? Where does the decision live?
+- [ ] Capability resolution – does the caller need a capability check?
+- [ ] Audit – should this action emit an event? At which boundary?
+- [ ] Rate limiting – does this route need a limit?
+- [ ] Schema validation – is the input validated? Where?
+- [ ] Policy config – does this feature have configuration? Where does it live?
+- [ ] Transactions – what's the atomicity boundary?
+- [ ] Caching – does this read benefit from a cache?
+- [ ] Tracing/metrics – is this operation traced?
+- [ ] Secrets – does this feature consume any?
+- [ ] Feature flags – is this feature behind a flag?
 
 A row left unanswered is a smell. A row answered "two modules handle it" is a bug waiting to happen.
 

--- a/skills/software-design-principles/references/dry.md
+++ b/skills/software-design-principles/references/dry.md
@@ -1,10 +1,10 @@
-# DRY — Don't Repeat Yourself
+# DRY – Don't Repeat Yourself
 
 Knowledge has one canonical home. When the same fact, rule, or computation is encoded in two places, those places will drift, and one will silently become wrong.
 
 ## What DRY is actually about
 
-DRY is often misread as "avoid duplicate code." It's not. It's "avoid duplicate **knowledge**." Two functions that *look* the same but mean different things are not duplication — they're independent concepts that happen to have isomorphic implementations today.
+DRY is often misread as "avoid duplicate code." It's not. It's "avoid duplicate **knowledge**." Two functions that *look* the same but mean different things are not duplication – they're independent concepts that happen to have isomorphic implementations today.
 
 Knowledge example: the tax rate for California is 7.25%. If that rate is encoded in three modules (invoicing, reporting, the customer-facing quote engine), you have three places to update when it changes, and one of them will be forgotten.
 
@@ -32,7 +32,7 @@ Extracting at occurrence 2 is the classic "premature abstraction" smell. You end
 
 - The same business rule (tax rate, retry count, timeout) is hardcoded in 3+ places.
 - The same validation logic is implemented twice and one version is more thorough.
-- The same error-handling block appears across many endpoints — likely a cross-cutting concern that should live in middleware.
+- The same error-handling block appears across many endpoints – likely a cross-cutting concern that should live in middleware.
 
 ## DRY versus other principles
 

--- a/skills/software-design-principles/references/dtsttcpw.md
+++ b/skills/software-design-principles/references/dtsttcpw.md
@@ -1,4 +1,4 @@
-# DTSTTCPW — Do The Simplest Thing That Could Possibly Work
+# DTSTTCPW – Do The Simplest Thing That Could Possibly Work
 
 The TDD counter-balance to speculative generality. Write the code that makes the *current* test pass. No more.
 
@@ -12,7 +12,7 @@ If a constant satisfies the test, return a constant. (Yes, even that.) The next 
 
 Programmers who have been burned by under-engineering reach instinctively for abstraction. The lesson "I should have made this configurable" generalizes to "always make things configurable," and now every new module ships with five configuration knobs nobody uses.
 
-DTSTTCPW asks for the discipline to leave the abstraction unbuilt until evidence demands it. The evidence comes from the test list — when the second test introduces variability, *that's* when you parameterize.
+DTSTTCPW asks for the discipline to leave the abstraction unbuilt until evidence demands it. The evidence comes from the test list – when the second test introduces variability, *that's* when you parameterize.
 
 ## Concrete examples
 
@@ -37,15 +37,15 @@ SOLID is about module-level shape *once you have enough use cases to know what t
 
 ## What "honest" means
 
-The full rule is "minimal *honest* code." Honesty rules out shortcuts that satisfy the *current* test but contradict the *test list*. If the list has 10 tests and you can see test #5 will demand a hash map, you don't need to *build* the hash map at test #1 — but you shouldn't write code at test #1 that knowingly breaks at test #5 either.
+The full rule is "minimal *honest* code." Honesty rules out shortcuts that satisfy the *current* test but contradict the *test list*. If the list has 10 tests and you can see test #5 will demand a hash map, you don't need to *build* the hash map at test #1 – but you shouldn't write code at test #1 that knowingly breaks at test #5 either.
 
 The horizon is the test list, not the current test. The increment is one test at a time.
 
 ## When NOT to apply DTSTTCPW
 
-- **At system boundaries.** Public APIs, file formats, database schemas — these are hard to change. Speculate carefully *here*, because the cost of unwinding the wrong choice is high.
+- **At system boundaries.** Public APIs, file formats, database schemas – these are hard to change. Speculate carefully *here*, because the cost of unwinding the wrong choice is high.
 - **At known integration points.** If you already know you'll need to call a payment provider, don't write a stub that hardcodes "Stripe." Use an interface from day one.
-- **For safety-critical paths.** Auth, authz, audit — these need the right abstraction up front because the cost of getting them wrong is severe.
+- **For safety-critical paths.** Auth, authz, audit – these need the right abstraction up front because the cost of getting them wrong is severe.
 
 For internal logic, default to DTSTTCPW. For boundaries, design carefully.
 

--- a/skills/software-design-principles/references/layered-architecture.md
+++ b/skills/software-design-principles/references/layered-architecture.md
@@ -4,10 +4,10 @@ A way to decide where code lives. Dependencies point inward; cross-cutting conce
 
 ## The four layers
 
-1. **HTTP / Boundary layer** — the outermost edge. Accepts requests (HTTP, CLI args, message queue events), validates input shape, returns responses. Knows the wire format. Does *not* contain business logic.
-2. **Service layer** — business logic. Owns the domain model. Coordinates infrastructure calls. Knows nothing about HTTP, headers, status codes.
-3. **Infrastructure layer** — talks to the outside world. Database, object store, external APIs, file system, secrets. Returns domain types to the service layer.
-4. **Policy / Config layer** — declarative rules: feature flags, environment-specific limits, capability matrices. Read by the layers above; never reaches into them.
+1. **HTTP / Boundary layer** – the outermost edge. Accepts requests (HTTP, CLI args, message queue events), validates input shape, returns responses. Knows the wire format. Does *not* contain business logic.
+2. **Service layer** – business logic. Owns the domain model. Coordinates infrastructure calls. Knows nothing about HTTP, headers, status codes.
+3. **Infrastructure layer** – talks to the outside world. Database, object store, external APIs, file system, secrets. Returns domain types to the service layer.
+4. **Policy / Config layer** – declarative rules: feature flags, environment-specific limits, capability matrices. Read by the layers above; never reaches into them.
 
 ## Dependency direction (the cardinal rule)
 
@@ -27,7 +27,7 @@ If you find an `import express` in your service layer, that's a violation. If yo
 
 **HTTP / Boundary:**
 - Request parsing, schema validation (zod, ajv, etc.)
-- Auth header extraction (not auth decisions — those are policy/service)
+- Auth header extraction (not auth decisions – those are policy/service)
 - Response shaping, content-negotiation
 - Rate limiting
 - CORS / security headers
@@ -84,7 +84,7 @@ Don't confuse "microservice" with "layer." A microservice still needs HTTP, serv
 
 These are refinements of layered architecture that emphasize ports + adapters. The dependency rule (dependencies point inward) is the shared core. For most systems, the four-layer mental model above is sufficient.
 
-If your domain is complex enough that you need ports and adapters, you'll know — but reach for the more elaborate model when the simple one strains, not before. (DTSTTCPW applies here too.)
+If your domain is complex enough that you need ports and adapters, you'll know – but reach for the more elaborate model when the simple one strains, not before. (DTSTTCPW applies here too.)
 
 ## The layered-architecture check
 

--- a/skills/software-design-principles/references/nfrs.md
+++ b/skills/software-design-principles/references/nfrs.md
@@ -1,4 +1,4 @@
-# NFRs — non-functional requirements
+# NFRs – non-functional requirements
 
 The baseline checklist. Walk before declaring a feature done. Each row asks "what's the answer here, even if the answer is 'good enough'?"
 
@@ -28,7 +28,7 @@ Common smells:
 Common smells:
 - In-memory cache assumes one process.
 - Background job runs every N minutes; doesn't degrade gracefully under load.
-- "We'll worry about scale later" — but the data model can't grow.
+- "We'll worry about scale later" – but the data model can't grow.
 
 ### 3. Security
 
@@ -48,7 +48,7 @@ Common smells:
 - **Logs:** structured, correlation-id, level-appropriate?
 - **Metrics:** at least request count, error rate, latency histogram per endpoint / job?
 - **Traces:** spans for cross-service / cross-layer calls?
-- **Alerts:** what's the symptom-based alert? (Not "CPU high" — "checkout success rate dropped.")
+- **Alerts:** what's the symptom-based alert? (Not "CPU high" – "checkout success rate dropped.")
 
 Common smells:
 - A feature ships with `console.log("ok")` as its only signal.
@@ -76,8 +76,8 @@ Common smells:
 - **Recovery:** if state corrupts, can it be rebuilt?
 
 Common smells:
-- An external API call with no timeout — hangs forever on a slow upstream.
-- A retry loop with no backoff — DDoSes the upstream when it returns.
+- An external API call with no timeout – hangs forever on a slow upstream.
+- A retry loop with no backoff – DDoSes the upstream when it returns.
 - A write that doubles a counter if delivered twice.
 
 ## How to apply the checklist
@@ -85,14 +85,14 @@ Common smells:
 This is not a 200-item compliance form. It's a 10-minute conversation:
 
 1. Read the six categories.
-2. For each, name the answer in one sentence — even "no requirement here" is a valid answer.
+2. For each, name the answer in one sentence – even "no requirement here" is a valid answer.
 3. If you can't answer in one sentence, note it as a follow-up.
 
 The cost of skipping the check is finding the gap in production. The cost of running the check is 10 minutes.
 
 ## When the checklist sets a release gate
 
-In `lakebase-release-workflows`, the NFR baseline is the release gate before promote-to-prod. Each row must have an answer recorded in the release ticket (or an explicit "N/A — reason").
+In `lakebase-release-workflows`, the NFR baseline is the release gate before promote-to-prod. Each row must have an answer recorded in the release ticket (or an explicit "N/A – reason").
 
 That's not bureaucracy. It's the audit trail when something breaks in production and the question "did anyone think about this" needs an answer.
 

--- a/skills/software-design-principles/references/solid.md
+++ b/skills/software-design-principles/references/solid.md
@@ -7,7 +7,7 @@ The grammar of object-oriented design. Five principles that keep modules small, 
 A module should have one reason to change. If two stakeholders ask for unrelated edits to the same file, that file owns two responsibilities.
 
 **Smell:** `UserService` handles auth, profile editing, audit logging, and email notifications.
-**Better:** `Authenticator`, `ProfileEditor`, `AuditLogger`, `Notifier` — each with one reason to change.
+**Better:** `Authenticator`, `ProfileEditor`, `AuditLogger`, `Notifier` – each with one reason to change.
 
 The test: name the module's responsibility in one sentence without using "and." If you can't, split it.
 
@@ -22,7 +22,7 @@ OCP is about reducing the blast radius of change.
 
 ## Liskov Substitution Principle (LSP)
 
-Subtypes must be substitutable for their base types without changing program correctness. If a function works with `Bird`, it must work with every subclass of `Bird` — including `Penguin`.
+Subtypes must be substitutable for their base types without changing program correctness. If a function works with `Bird`, it must work with every subclass of `Bird` – including `Penguin`.
 
 **Smell:** `Penguin extends Bird` but `fly()` throws `NotSupportedException`.
 **Better:** rethink the hierarchy. `Bird` and `FlyingBird` are different concepts.
@@ -34,7 +34,7 @@ LSP failures usually mean the inheritance was modeling taxonomy, not behavior.
 Clients should not depend on methods they don't use. A fat interface forces unrelated consumers to share a vocabulary.
 
 **Smell:** `IRepository<T>` with 30 methods, every consumer uses 3 of them.
-**Better:** `IReadable<T>`, `IWritable<T>`, `IQueryable<T>` — consumers depend only on what they use.
+**Better:** `IReadable<T>`, `IWritable<T>`, `IQueryable<T>` – consumers depend only on what they use.
 
 ## Dependency Inversion Principle (DIP)
 

--- a/templates/project/common/scripts/HOOKS.md
+++ b/templates/project/common/scripts/HOOKS.md
@@ -56,7 +56,7 @@ fi
 
 **Option 2: chain inside the project's hook script.** Each Lakebase
 hook (`post-checkout.sh`, `prepare-commit-msg.sh`, `pre-push.sh`,
-`post-merge.sh`) is a plain shell script — add a leading block that
+`post-merge.sh`) is a plain shell script – add a leading block that
 invokes the corporate hook of the same name, then falls through to
 the Lakebase logic. This keeps the canonical version in
 `scripts/*.sh` (the source-of-truth that survives reinstalls).

--- a/templates/tdd-bootstrap/.tdd/README.md
+++ b/templates/tdd-bootstrap/.tdd/README.md
@@ -4,16 +4,16 @@ This directory is the canonical home for this project's TDD workflow state. It i
 
 ## Layout
 
-- `spec.{md,json}` — top-level overview (optional).
-- `workflow-state.json` — current phase + locus (feature / story / AC / cycle / experiment).
-- `features/<F>/` — one directory per feature. Contains `feature.{md,json}`, `architecture.md` (added by Architect Reviewer), `test-list.{md,json}`, `stories/<S>/...`.
-- `experiments/<F>/<exp>/` — one directory per experiment branch with `notes.md`, `branch.txt`, `outcomes.json`, `timeline.json`.
-- `spikes/<slug>/` — throwaway exploration. Notes preserved after branch teardown.
-- `synthesis/<F>/` — N>=2 menu-pick decision records + `synthesized-spec/` subtree.
-- `cycles/<F>/<S>/<AC>/cycle-NNN.json` — per-cycle RED/GREEN/REFACTOR artifacts.
-- `selection-log.md` — append-only HITL gate decisions + rationale.
-- `smells.json` — detected bad smells + remediations.
-- `adapters/<adapter>.json` — optional per-adapter config (JIRA, GitHub Issues, etc.).
+- `spec.{md,json}` – top-level overview (optional).
+- `workflow-state.json` – current phase + locus (feature / story / AC / cycle / experiment).
+- `features/<F>/` – one directory per feature. Contains `feature.{md,json}`, `architecture.md` (added by Architect Reviewer), `test-list.{md,json}`, `stories/<S>/...`.
+- `experiments/<F>/<exp>/` – one directory per experiment branch with `notes.md`, `branch.txt`, `outcomes.json`, `timeline.json`.
+- `spikes/<slug>/` – throwaway exploration. Notes preserved after branch teardown.
+- `synthesis/<F>/` – N>=2 menu-pick decision records + `synthesized-spec/` subtree.
+- `cycles/<F>/<S>/<AC>/cycle-NNN.json` – per-cycle RED/GREEN/REFACTOR artifacts.
+- `selection-log.md` – append-only HITL gate decisions + rationale.
+- `smells.json` – detected bad smells + remediations.
+- `adapters/<adapter>.json` – optional per-adapter config (JIRA, GitHub Issues, etc.).
 
 ## Getting started
 

--- a/tests/bdd/branch-create-collision.test.ts
+++ b/tests/bdd/branch-create-collision.test.ts
@@ -46,6 +46,18 @@ function fakeBranch(leaf: string, sourceLeaf: string | undefined): LakebaseBranc
   } as LakebaseBranchInfo;
 }
 
+// Per-name lookup table. createBranch now calls getBranchByName twice
+// per invocation: once for the parentBranch existence check (added with
+// the parentBranch fallback, see branch-create-fallback.test.ts) and
+// once for the target name idempotency check. Tests below register
+// expected return values for each name explicitly so the two calls
+// don't collide on a single mockResolvedValue.
+function setupBranchMock(branches: Record<string, LakebaseBranchInfo | undefined>) {
+  mockGetBranchByName.mockImplementation((name: string) =>
+    Promise.resolve(branches[name])
+  );
+}
+
 describe("createBranch – collision-vs-idempotency contract", () => {
   beforeEach(() => {
     mockGetBranchByName.mockReset();
@@ -54,7 +66,10 @@ describe("createBranch – collision-vs-idempotency contract", () => {
 
   it("returns the existing branch when its source matches the requested parent (idempotent retry)", async () => {
     const existing = fakeBranch("feature-foo", "production");
-    mockGetBranchByName.mockResolvedValue(existing);
+    setupBranchMock({
+      production: fakeBranch("production", undefined), // parent exists
+      "feature-foo": existing,                          // target also exists
+    });
 
     const result = await createBranch({
       instance: "ignored",
@@ -63,7 +78,7 @@ describe("createBranch – collision-vs-idempotency contract", () => {
     });
 
     expect(result).toBe(existing);
-    // Lookup runs twice: once to resolve the parent path, once to check
+    // Lookup runs twice: once to resolve/validate the parent, once to check
     // for an existing target. Both are mocked; the real CLI is never
     // invoked, which is the whole point of the hermetic test.
   });
@@ -71,7 +86,10 @@ describe("createBranch – collision-vs-idempotency contract", () => {
   it("throws when the existing branch was forked from a different source", async () => {
     // Existing branch was forked from staging…
     const existing = fakeBranch("feature-foo", "staging");
-    mockGetBranchByName.mockResolvedValue(existing);
+    setupBranchMock({
+      production: fakeBranch("production", undefined), // requested parent exists
+      "feature-foo": existing,                          // target exists with mismatched lineage
+    });
 
     // …but the caller is now asking to fork from production.
     await expect(
@@ -100,7 +118,10 @@ describe("createBranch – collision-vs-idempotency contract", () => {
     // rather than throwing – refusing the retry would surprise users
     // upgrading from older substrate revs.
     const existing = fakeBranch("feature-foo", undefined);
-    mockGetBranchByName.mockResolvedValue(existing);
+    setupBranchMock({
+      production: fakeBranch("production", undefined),
+      "feature-foo": existing,
+    });
 
     const result = await createBranch({
       instance: "ignored",

--- a/tests/bdd/branch-create-fallback.test.ts
+++ b/tests/bdd/branch-create-fallback.test.ts
@@ -1,0 +1,169 @@
+// Hermetic coverage for createBranch's parentBranch-existence fallback.
+//
+// Surfaced during the FEIP-7092 live exercise: CONVENTION_TIER_DEFAULTS
+// declares parentBranch="staging" for the four short-tier flavors, but
+// bare-provisioned Lakebase projects ship with only `production` — no
+// `staging`. The substrate previously interpolated the named parent into
+// the source_branch path and let the API return the opaque
+// "branch id not found" error. Now: when the named parent doesn't exist,
+// substrate falls back to the project default branch with a stderr
+// warning. Opt-OUT via `strictParent: true`.
+//
+// Test mechanics mirror branch-create-collision.test.ts: mock the lookup
+// helpers from branch-utils so createBranch is exercised end-to-end
+// without invoking the Databricks CLI. Tests that take the success path
+// have the target lookup return an EXISTING branch whose source matches
+// the resolved parent — createBranch then short-circuits via its
+// idempotency check (line ~128 of branch-create.ts), so dbcli is never
+// reached.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  LakebaseBranchError,
+  type LakebaseBranchInfo,
+} from "../../scripts/lakebase/branch-utils.js";
+
+const mockGetBranchByName = vi.fn();
+const mockGetDefaultBranch = vi.fn();
+
+vi.mock("../../scripts/lakebase/branch-utils.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../scripts/lakebase/branch-utils.js")>(
+      "../../scripts/lakebase/branch-utils.js"
+    );
+  return {
+    ...actual,
+    getBranchByName: (...args: unknown[]) => mockGetBranchByName(...args),
+    getDefaultBranch: (...args: unknown[]) => mockGetDefaultBranch(...args),
+    projectPath: () => "projects/test-project",
+  };
+});
+
+const { createBranch } = await import("../../scripts/lakebase/branch-create.js");
+
+function fakeBranch(leaf: string, sourceLeaf: string | undefined): LakebaseBranchInfo {
+  return {
+    name: `projects/test-project/branches/${leaf}`,
+    nameLeaf: leaf as LakebaseBranchInfo["nameLeaf"],
+    uid: `br-${leaf}` as LakebaseBranchInfo["uid"],
+    state: "READY",
+    isDefault: false,
+    sourceBranchName: sourceLeaf
+      ? `projects/test-project/branches/${sourceLeaf}`
+      : undefined,
+  } as LakebaseBranchInfo;
+}
+
+let stderrChunks: string[] = [];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let stderrSpy: any;
+
+beforeEach(() => {
+  mockGetBranchByName.mockReset();
+  mockGetDefaultBranch.mockReset();
+  stderrChunks = [];
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderrChunks.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+});
+
+describe("createBranch – parentBranch fallback when the named parent is missing", () => {
+  it("falls back to the project default + emits a stderr warning (default behavior)", async () => {
+    // Parent lookup: 'staging' doesn't exist.
+    // Target lookup: 'feature-x' already exists, forked from 'production'
+    //   (the project default) — short-circuits via idempotency, no CLI call.
+    mockGetBranchByName.mockImplementation((branchName: string) => {
+      if (branchName === "staging") return Promise.resolve(undefined);
+      if (branchName === "feature-x") return Promise.resolve(fakeBranch("feature-x", "production"));
+      return Promise.resolve(undefined);
+    });
+    mockGetDefaultBranch.mockResolvedValue(fakeBranch("production", undefined));
+
+    const result = await createBranch({
+      instance: "test-project",
+      branch: "feature-x",
+      parentBranch: "staging",
+      // strictParent omitted → default fallback behavior
+    });
+
+    // The fallback fired — stderr has the documented warning.
+    const stderr = stderrChunks.join("");
+    expect(stderr).toMatch(/parentBranch 'staging' not found/);
+    expect(stderr).toMatch(/falling back to default branch 'production'/);
+    expect(stderr).toMatch(/strictParent: true/);
+
+    // Idempotency short-circuit returned the existing branch — proves the
+    // resolved source ('production') matched what the target was forked from.
+    expect(result.name).toBe("projects/test-project/branches/feature-x");
+    expect(result.sourceBranchName).toBe("projects/test-project/branches/production");
+  });
+
+  it("uses the named parent directly when it exists (no fallback, no warning)", async () => {
+    mockGetBranchByName.mockImplementation((branchName: string) => {
+      if (branchName === "staging") return Promise.resolve(fakeBranch("staging", "production"));
+      if (branchName === "feature-x") return Promise.resolve(fakeBranch("feature-x", "staging"));
+      return Promise.resolve(undefined);
+    });
+
+    const result = await createBranch({
+      instance: "test-project",
+      branch: "feature-x",
+      parentBranch: "staging",
+    });
+
+    // No fallback warning emitted on the happy path.
+    expect(stderrChunks.join("")).toBe("");
+    // Idempotency short-circuit returned the existing branch with the
+    // expected lineage ('staging' → 'feature-x').
+    expect(result.sourceBranchName).toBe("projects/test-project/branches/staging");
+    // getDefaultBranch was not consulted on the happy path.
+    expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+  });
+
+  it("throws with a typed error when strictParent: true + parent missing", async () => {
+    mockGetBranchByName.mockResolvedValue(undefined);
+
+    await expect(
+      createBranch({
+        instance: "test-project",
+        branch: "feature-x",
+        parentBranch: "staging",
+        strictParent: true,
+      })
+    ).rejects.toThrow(LakebaseBranchError);
+
+    await expect(
+      createBranch({
+        instance: "test-project",
+        branch: "feature-x",
+        parentBranch: "staging",
+        strictParent: true,
+      })
+    ).rejects.toThrow(/parentBranch 'staging' does not exist.*strictParent: true was set/s);
+
+    // No fallback warning emitted in strict mode.
+    expect(stderrChunks.join("")).toBe("");
+    // getDefaultBranch was NOT consulted — strict mode refuses at the
+    // boundary before reaching the fallback path.
+    expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+  });
+
+  it("throws when parent missing AND project has no default branch to fall back to", async () => {
+    mockGetBranchByName.mockResolvedValue(undefined);
+    mockGetDefaultBranch.mockResolvedValue(undefined);
+
+    await expect(
+      createBranch({
+        instance: "test-project",
+        branch: "feature-x",
+        parentBranch: "staging",
+        // strictParent omitted — fallback is enabled, but nothing to fall back to
+      })
+    ).rejects.toThrow(/has no default branch to fall back to/);
+  });
+});

--- a/tests/bdd/branch-create-fallback.test.ts
+++ b/tests/bdd/branch-create-fallback.test.ts
@@ -2,7 +2,7 @@
 //
 // Surfaced during the FEIP-7092 live exercise: CONVENTION_TIER_DEFAULTS
 // declares parentBranch="staging" for the four short-tier flavors, but
-// bare-provisioned Lakebase projects ship with only `production` — no
+// bare-provisioned Lakebase projects ship with only `production` – no
 // `staging`. The substrate previously interpolated the named parent into
 // the source_branch path and let the API return the opaque
 // "branch id not found" error. Now: when the named parent doesn't exist,
@@ -13,7 +13,7 @@
 // helpers from branch-utils so createBranch is exercised end-to-end
 // without invoking the Databricks CLI. Tests that take the success path
 // have the target lookup return an EXISTING branch whose source matches
-// the resolved parent — createBranch then short-circuits via its
+// the resolved parent – createBranch then short-circuits via its
 // idempotency check (line ~128 of branch-create.ts), so dbcli is never
 // reached.
 
@@ -76,7 +76,7 @@ describe("createBranch – parentBranch fallback when the named parent is missin
   it("falls back to the project default + emits a stderr warning (default behavior)", async () => {
     // Parent lookup: 'staging' doesn't exist.
     // Target lookup: 'feature-x' already exists, forked from 'production'
-    //   (the project default) — short-circuits via idempotency, no CLI call.
+    //   (the project default) – short-circuits via idempotency, no CLI call.
     mockGetBranchByName.mockImplementation((branchName: string) => {
       if (branchName === "staging") return Promise.resolve(undefined);
       if (branchName === "feature-x") return Promise.resolve(fakeBranch("feature-x", "production"));
@@ -91,13 +91,13 @@ describe("createBranch – parentBranch fallback when the named parent is missin
       // strictParent omitted → default fallback behavior
     });
 
-    // The fallback fired — stderr has the documented warning.
+    // The fallback fired – stderr has the documented warning.
     const stderr = stderrChunks.join("");
     expect(stderr).toMatch(/parentBranch 'staging' not found/);
     expect(stderr).toMatch(/falling back to default branch 'production'/);
     expect(stderr).toMatch(/strictParent: true/);
 
-    // Idempotency short-circuit returned the existing branch — proves the
+    // Idempotency short-circuit returned the existing branch – proves the
     // resolved source ('production') matched what the target was forked from.
     expect(result.name).toBe("projects/test-project/branches/feature-x");
     expect(result.sourceBranchName).toBe("projects/test-project/branches/production");
@@ -148,7 +148,7 @@ describe("createBranch – parentBranch fallback when the named parent is missin
 
     // No fallback warning emitted in strict mode.
     expect(stderrChunks.join("")).toBe("");
-    // getDefaultBranch was NOT consulted — strict mode refuses at the
+    // getDefaultBranch was NOT consulted – strict mode refuses at the
     // boundary before reaching the fallback path.
     expect(mockGetDefaultBranch).not.toHaveBeenCalled();
   });
@@ -162,7 +162,7 @@ describe("createBranch – parentBranch fallback when the named parent is missin
         instance: "test-project",
         branch: "feature-x",
         parentBranch: "staging",
-        // strictParent omitted — fallback is enabled, but nothing to fall back to
+        // strictParent omitted – fallback is enabled, but nothing to fall back to
       })
     ).rejects.toThrow(/has no default branch to fall back to/);
   });

--- a/tests/bdd/branch-id.test.ts
+++ b/tests/bdd/branch-id.test.ts
@@ -101,22 +101,22 @@ describe("type-level brand contracts", () => {
     const name: BranchName = asBranchName("production");
     const uid: BranchUid = asBranchUid("br-x-y-z");
 
-    // Allow assignment to the broader `string` type — brands are downcast-able.
+    // Allow assignment to the broader `string` type – brands are downcast-able.
     const _s1: string = name;
     const _s2: string = uid;
     expect(_s1).toBe("production");
     expect(_s2).toBe("br-x-y-z");
 
-    // @ts-expect-error — BranchName is not assignable to BranchUid.
+    // @ts-expect-error – BranchName is not assignable to BranchUid.
     const _bad1: BranchUid = name;
     void _bad1;
-    // @ts-expect-error — BranchUid is not assignable to BranchName.
+    // @ts-expect-error – BranchUid is not assignable to BranchName.
     const _bad2: BranchName = uid;
     void _bad2;
-    // @ts-expect-error — plain string is not assignable to BranchName.
+    // @ts-expect-error – plain string is not assignable to BranchName.
     const _bad3: BranchName = "production";
     void _bad3;
-    // @ts-expect-error — plain string is not assignable to BranchUid.
+    // @ts-expect-error – plain string is not assignable to BranchUid.
     const _bad4: BranchUid = "br-x-y-z";
     void _bad4;
   });

--- a/tests/bdd/branch-id.test.ts
+++ b/tests/bdd/branch-id.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  asBranchName,
+  asBranchUid,
+  branchNameFromResourcePath,
+  looksLikeBranchUid,
+  type BranchName,
+  type BranchUid,
+} from "../../scripts/lakebase/branch-id";
+
+describe("looksLikeBranchUid", () => {
+  it("recognizes the br-… pattern", () => {
+    expect(looksLikeBranchUid("br-crimson-fire-d28lb2ez")).toBe(true);
+    expect(looksLikeBranchUid("br-broad-sky-d2k5gewt")).toBe(true);
+    expect(looksLikeBranchUid("br-a-b-c")).toBe(true);
+  });
+
+  it("rejects path-leaf branch names (no br- prefix)", () => {
+    expect(looksLikeBranchUid("production")).toBe(false);
+    expect(looksLikeBranchUid("staging")).toBe(false);
+    expect(looksLikeBranchUid("feature-add-orders")).toBe(false);
+    expect(looksLikeBranchUid("main")).toBe(false);
+  });
+
+  it("rejects strings that happen to contain 'br-' mid-name", () => {
+    expect(looksLikeBranchUid("feature-br-something")).toBe(false);
+    expect(looksLikeBranchUid("Branch-x-y-z")).toBe(false);
+  });
+});
+
+describe("asBranchName", () => {
+  it("accepts plain resource-path leaves", () => {
+    expect(asBranchName("production")).toBe("production");
+    expect(asBranchName("staging")).toBe("staging");
+    expect(asBranchName("feature-add-orders")).toBe("feature-add-orders");
+  });
+
+  it("THROWS when given a BranchUid (this is the bug-prevention contract)", () => {
+    expect(() => asBranchName("br-crimson-fire-d28lb2ez")).toThrow(/looks like a BranchUid/);
+    expect(() => asBranchName("br-broad-sky-d2k5gewt")).toThrow(/BranchUid/);
+  });
+
+  it("THROWS on empty input", () => {
+    expect(() => asBranchName("")).toThrow(/cannot be empty/);
+  });
+
+  it("error message points the caller to the right function + explains the path-leaf concept", () => {
+    let msg = "";
+    try {
+      asBranchName("br-x-y-z");
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    // The thrower is asBranchName; the helpful suggestion is "did you
+    // mean asBranchUid?" so the caller can pivot.
+    expect(msg).toMatch(/asBranchUid/);
+    expect(msg).toMatch(/path[\s-]?shaped|resource[\s-]?path/i);
+    expect(msg).toMatch(/BranchUid/);
+    expect(msg).toMatch(/BranchName/);
+  });
+});
+
+describe("asBranchUid", () => {
+  it("accepts the br-… form", () => {
+    expect(asBranchUid("br-crimson-fire-d28lb2ez")).toBe("br-crimson-fire-d28lb2ez");
+  });
+
+  it("THROWS when given a BranchName (the inverse contract)", () => {
+    expect(() => asBranchUid("production")).toThrow(/not a BranchUid/);
+    expect(() => asBranchUid("feature-x")).toThrow(/not a BranchUid/);
+  });
+
+  it("THROWS on empty input", () => {
+    expect(() => asBranchUid("")).toThrow(/cannot be empty/);
+  });
+});
+
+describe("branchNameFromResourcePath", () => {
+  it("extracts the leaf from a full path", () => {
+    expect(branchNameFromResourcePath("projects/proj-abc/branches/production")).toBe("production");
+    expect(branchNameFromResourcePath("projects/x/branches/feature-add-orders")).toBe("feature-add-orders");
+  });
+
+  it("returns null when input is not a resource path", () => {
+    expect(branchNameFromResourcePath("production")).toBeNull();
+    expect(branchNameFromResourcePath("projects/x")).toBeNull();
+    expect(branchNameFromResourcePath("")).toBeNull();
+  });
+
+  it("returns null when the leaf would itself be a BranchUid (refuses to lie about which kind of id this is)", () => {
+    expect(branchNameFromResourcePath("projects/x/branches/br-crimson-fire-d28lb2ez")).toBeNull();
+  });
+});
+
+// Type-level contracts. These assertions don't add runtime checks but
+// ensure the brand prevents accidental cross-assignment at compile time.
+// (If someone removes the brand, the @ts-expect-error lines will start
+// passing and the test file will fail to compile, surfacing the regression.)
+describe("type-level brand contracts", () => {
+  it("BranchName and BranchUid cannot be swapped at the type level", () => {
+    const name: BranchName = asBranchName("production");
+    const uid: BranchUid = asBranchUid("br-x-y-z");
+
+    // Allow assignment to the broader `string` type — brands are downcast-able.
+    const _s1: string = name;
+    const _s2: string = uid;
+    expect(_s1).toBe("production");
+    expect(_s2).toBe("br-x-y-z");
+
+    // @ts-expect-error — BranchName is not assignable to BranchUid.
+    const _bad1: BranchUid = name;
+    void _bad1;
+    // @ts-expect-error — BranchUid is not assignable to BranchName.
+    const _bad2: BranchName = uid;
+    void _bad2;
+    // @ts-expect-error — plain string is not assignable to BranchName.
+    const _bad3: BranchName = "production";
+    void _bad3;
+    // @ts-expect-error — plain string is not assignable to BranchUid.
+    const _bad4: BranchUid = "br-x-y-z";
+    void _bad4;
+  });
+});

--- a/tests/bdd/branch-identifier.test.ts
+++ b/tests/bdd/branch-identifier.test.ts
@@ -122,7 +122,7 @@ describe("branch identifier pair-coverage – live", () => {
     // Two sequential live pg connections (one per arg shape). Each typically
     // takes ~3-4s including credential mint + TLS + the schema query, so the
     // pair routinely exceeds vitest's 5s default per-test budget. Bump to
-    // 30s — generous enough for a slow-starting Lakebase endpoint without
+    // 30s – generous enough for a slow-starting Lakebase endpoint without
     // hiding a real hang (resolveBranchId's normalization is already sync).
     const info = await getBranchByName(TEST_BRANCH!, { instance: TEST_INSTANCE! });
     expect(info).toBeTruthy();
@@ -146,7 +146,7 @@ describe("branch identifier pair-coverage – live", () => {
   it.skipIf(!live)("listBranches surfaces sourceBranchName for non-default branches", async () => {
     const branches = await listBranches({ instance: TEST_INSTANCE! });
     const nonDefault = branches.filter((b) => !b.isDefault);
-    // At least one non-default branch should have a parent recorded —
+    // At least one non-default branch should have a parent recorded –
     // otherwise the adapter has nothing to assert against.
     const withParent = nonDefault.filter((b) => b.sourceBranchName);
     expect(withParent.length).toBeGreaterThan(0);

--- a/tests/bdd/branch-identifier.test.ts
+++ b/tests/bdd/branch-identifier.test.ts
@@ -119,12 +119,17 @@ describe("branch identifier pair-coverage – live", () => {
   });
 
   it.skipIf(!live)("queryBranchSchema(uid) === queryBranchSchema(branchId)", async () => {
+    // Two sequential live pg connections (one per arg shape). Each typically
+    // takes ~3-4s including credential mint + TLS + the schema query, so the
+    // pair routinely exceeds vitest's 5s default per-test budget. Bump to
+    // 30s — generous enough for a slow-starting Lakebase endpoint without
+    // hiding a real hang (resolveBranchId's normalization is already sync).
     const info = await getBranchByName(TEST_BRANCH!, { instance: TEST_INSTANCE! });
     expect(info).toBeTruthy();
     const byName = await queryBranchSchema({ instance: TEST_INSTANCE!, branch: TEST_BRANCH! });
     const byUid = await queryBranchSchema({ instance: TEST_INSTANCE!, branch: info!.uid });
     expect(byUid).toEqual(byName);
-  });
+  }, 30000);
 
   it.skipIf(!live)("endpointPath stays sync and does NOT accept a uid", async () => {
     // Sanity check: endpointPath is documented as sync + branch_id-only. We

--- a/tests/bdd/branch-ttl-error.test.ts
+++ b/tests/bdd/branch-ttl-error.test.ts
@@ -11,7 +11,7 @@ import {
 // underlying CLI error and rewraps with a typed, actionable message so
 // callers get a clear remediation path (shorter ttl OR noExpiry).
 
-describe("isTtlTooLongError — detects the workspace cap rejection", () => {
+describe("isTtlTooLongError – detects the workspace cap rejection", () => {
   const REAL_STDERR =
     "databricks postgres create-branch projects/x foo --json {} failed: Command failed: " +
     "databricks postgres create-branch projects/x foo --json {}\n" +
@@ -34,7 +34,7 @@ describe("isTtlTooLongError — detects the workspace cap rejection", () => {
   });
 });
 
-describe("LakebaseBranchTtlTooLongError — typed error contract", () => {
+describe("LakebaseBranchTtlTooLongError – typed error contract", () => {
   it("extends LakebaseBranchError so existing catch blocks still trigger", () => {
     const err = new LakebaseBranchTtlTooLongError("2592000s", "underlying CLI error");
     expect(err).toBeInstanceOf(LakebaseBranchError);

--- a/tests/bdd/branch-ttl-error.test.ts
+++ b/tests/bdd/branch-ttl-error.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  LakebaseBranchError,
+  LakebaseBranchTtlTooLongError,
+  isTtlTooLongError,
+} from "../../scripts/lakebase/branch-utils";
+
+// Workspace-TTL-policy substrate surface. Surfaced during the FEIP-7092
+// live E2E: the CONVENTION_TIER_DEFAULTS.feature 30-day TTL exceeded the
+// test workspace's maximum-expiration policy. The substrate detects the
+// underlying CLI error and rewraps with a typed, actionable message so
+// callers get a clear remediation path (shorter ttl OR noExpiry).
+
+describe("isTtlTooLongError — detects the workspace cap rejection", () => {
+  const REAL_STDERR =
+    "databricks postgres create-branch projects/x foo --json {} failed: Command failed: " +
+    "databricks postgres create-branch projects/x foo --json {}\n" +
+    "Error: expiration time exceeds the maximum expiration time [TraceId: abc123]\n" +
+    "stderr: Error: expiration time exceeds the maximum expiration time [TraceId: abc123]";
+
+  it("matches the live error message verbatim", () => {
+    expect(isTtlTooLongError(REAL_STDERR)).toBe(true);
+  });
+
+  it("matches case-insensitively (defensive against minor server reword)", () => {
+    expect(isTtlTooLongError("EXPIRATION TIME EXCEEDS THE MAXIMUM EXPIRATION TIME")).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isTtlTooLongError("branch id not found")).toBe(false);
+    expect(isTtlTooLongError("permission denied")).toBe(false);
+    expect(isTtlTooLongError("expiration is required")).toBe(false);
+    expect(isTtlTooLongError("")).toBe(false);
+  });
+});
+
+describe("LakebaseBranchTtlTooLongError — typed error contract", () => {
+  it("extends LakebaseBranchError so existing catch blocks still trigger", () => {
+    const err = new LakebaseBranchTtlTooLongError("2592000s", "underlying CLI error");
+    expect(err).toBeInstanceOf(LakebaseBranchError);
+    expect(err).toBeInstanceOf(LakebaseBranchTtlTooLongError);
+    expect(err.name).toBe("LakebaseBranchTtlTooLongError");
+  });
+
+  it("exposes the attempted TTL so callers can build a remediation", () => {
+    const err = new LakebaseBranchTtlTooLongError("2592000s", "cli barfed");
+    expect(err.attemptedTtl).toBe("2592000s");
+  });
+
+  it("message names the override paths the caller can take (ttl arg, noExpiry)", () => {
+    const err = new LakebaseBranchTtlTooLongError("2592000s", "x");
+    expect(err.message).toMatch(/2592000s/);
+    expect(err.message).toMatch(/shorter ttl/i);
+    expect(err.message).toMatch(/noExpiry/);
+    expect(err.message).toMatch(/history_retention_duration/);
+  });
+
+  it("includes the underlying error so the trace isn't lost", () => {
+    const err = new LakebaseBranchTtlTooLongError(
+      "2592000s",
+      "Error: expiration time exceeds the maximum expiration time [TraceId: t1]"
+    );
+    expect(err.message).toMatch(/TraceId: t1/);
+  });
+});

--- a/tests/bdd/constants.test.ts
+++ b/tests/bdd/constants.test.ts
@@ -11,7 +11,7 @@ import {
 //
 //   1. The values match the documented Lakebase defaults today. A
 //      deliberate future change (e.g. service moves off 5432) is fine
-//      — bump the literal here and the substrate everywhere flips
+//      – bump the literal here and the substrate everywhere flips
 //      together.
 //   2. The shape stays stable: `POSTGRES_PORT` is a number, the two
 //      string defaults are non-empty.

--- a/tests/bdd/constants.test.ts
+++ b/tests/bdd/constants.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import {
+  POSTGRES_PORT,
+  DEFAULT_DATABASE,
+  DEFAULT_ENDPOINT,
+} from "../../scripts/lakebase/constants";
+
+// Pin the substrate's documented defaults. These constants are imported
+// by every callsite that previously inlined the literal (4× port, 4×
+// database name, 4× endpoint name). The test guards two things:
+//
+//   1. The values match the documented Lakebase defaults today. A
+//      deliberate future change (e.g. service moves off 5432) is fine
+//      — bump the literal here and the substrate everywhere flips
+//      together.
+//   2. The shape stays stable: `POSTGRES_PORT` is a number, the two
+//      string defaults are non-empty.
+//
+// Live tests that actually CONNECT to a Lakebase branch (get-connection,
+// branch-schema, etc.) provide the runtime proof that the substrate's
+// use of these constants matches what the service expects.
+
+describe("substrate shared constants", () => {
+  it("POSTGRES_PORT is 5432 (Lakebase's fixed Postgres port)", () => {
+    expect(POSTGRES_PORT).toBe(5432);
+    expect(typeof POSTGRES_PORT).toBe("number");
+  });
+
+  it("DEFAULT_DATABASE is 'databricks_postgres' (Lakebase's per-branch db)", () => {
+    expect(DEFAULT_DATABASE).toBe("databricks_postgres");
+    expect(DEFAULT_DATABASE.length).toBeGreaterThan(0);
+  });
+
+  it("DEFAULT_ENDPOINT is 'primary' (Lakebase's single per-branch endpoint)", () => {
+    expect(DEFAULT_ENDPOINT).toBe("primary");
+    expect(DEFAULT_ENDPOINT.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/bdd/convention-branches.test.ts
+++ b/tests/bdd/convention-branches.test.ts
@@ -2,7 +2,7 @@
 //
 // Verifies that createFeatureBranch / createTestBranch / createUatBranch /
 // createPerfBranch forward the right parent + TTL into substrate's
-// createBranch — without actually hitting Lakebase. Live behavior is
+// createBranch – without actually hitting Lakebase. Live behavior is
 // exercised in the workspace-bound branch tests; this test is the contract
 // guard.
 

--- a/tests/bdd/convention-branches.test.ts
+++ b/tests/bdd/convention-branches.test.ts
@@ -7,6 +7,7 @@
 // guard.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { KIT_TIMEOUTS, formatLakebaseTtl } from "../../scripts/lakebase/kit-config.js";
 
 const mockCreateBranch = vi.fn();
 
@@ -27,39 +28,47 @@ beforeEach(() => {
   });
 });
 
+// The forwarding contract under test is:
+//   "convention helper reads parentBranch + ttl from CONVENTION_TIER_DEFAULTS
+//    (which in turn read from KIT_TIMEOUTS) and forwards into createBranch".
+// Asserting hardcoded numeric TTLs would conflate that contract with the
+// "PSA defaults are 30/14/14/7 days" contract (already covered in
+// kit-config.test.ts). We derive expected values from KIT_TIMEOUTS so the
+// test stays correct when .env.local.config tightens a tier's TTL cap.
+
 describe("convention-branches: default tier values", () => {
-  it("createFeatureBranch defaults parentBranch=staging, ttl=30 days", async () => {
+  it("createFeatureBranch defaults parentBranch=staging, ttl from KIT_TIMEOUTS", async () => {
     await conv.createFeatureBranch({ instance: "p", branch: "f1" });
     expect(mockCreateBranch).toHaveBeenCalledTimes(1);
     expect(mockCreateBranch.mock.calls[0][0]).toMatchObject({
       instance: "p",
       branch: "f1",
       parentBranch: "staging",
-      ttl: `${30 * 86_400}s`,
+      ttl: formatLakebaseTtl(KIT_TIMEOUTS.featureBranchTtlMs),
     });
   });
 
-  it("createTestBranch defaults parentBranch=staging, ttl=14 days", async () => {
+  it("createTestBranch defaults parentBranch=staging, ttl from KIT_TIMEOUTS", async () => {
     await conv.createTestBranch({ instance: "p", branch: "t1" });
     expect(mockCreateBranch.mock.calls[0][0]).toMatchObject({
       parentBranch: "staging",
-      ttl: `${14 * 86_400}s`,
+      ttl: formatLakebaseTtl(KIT_TIMEOUTS.testBranchTtlMs),
     });
   });
 
-  it("createUatBranch defaults parentBranch=staging, ttl=14 days", async () => {
+  it("createUatBranch defaults parentBranch=staging, ttl from KIT_TIMEOUTS", async () => {
     await conv.createUatBranch({ instance: "p", branch: "u1" });
     expect(mockCreateBranch.mock.calls[0][0]).toMatchObject({
       parentBranch: "staging",
-      ttl: `${14 * 86_400}s`,
+      ttl: formatLakebaseTtl(KIT_TIMEOUTS.uatBranchTtlMs),
     });
   });
 
-  it("createPerfBranch defaults parentBranch=staging, ttl=7 days", async () => {
+  it("createPerfBranch defaults parentBranch=staging, ttl from KIT_TIMEOUTS", async () => {
     await conv.createPerfBranch({ instance: "p", branch: "perf1" });
     expect(mockCreateBranch.mock.calls[0][0]).toMatchObject({
       parentBranch: "staging",
-      ttl: `${7 * 86_400}s`,
+      ttl: formatLakebaseTtl(KIT_TIMEOUTS.perfBranchTtlMs),
     });
   });
 });

--- a/tests/bdd/create-project-tdd-bootstrap.test.ts
+++ b/tests/bdd/create-project-tdd-bootstrap.test.ts
@@ -30,7 +30,7 @@ describe("layDownTddScaffold (hermetic)", () => {
     expect(state.phase).toBe("discovery");
   });
 
-  it("is idempotent — running twice does not overwrite existing .tdd/", () => {
+  it("is idempotent – running twice does not overwrite existing .tdd/", () => {
     layDownTddScaffold(projectDir);
     // Mutate one of the files so we can detect overwrites.
     const stateFile = join(projectDir, ".tdd", "workflow-state.json");

--- a/tests/bdd/create-project.test.ts
+++ b/tests/bdd/create-project.test.ts
@@ -8,13 +8,13 @@ import { deleteLakebaseProject } from "../../scripts/lakebase/lakebase-project.j
 
 /**
  * Resolve the destructive test's target host. Precedence:
- *   1. `LAKEBASE_TEST_HOST` — explicit override (e.g. for CI where the
+ *   1. `LAKEBASE_TEST_HOST` – explicit override (e.g. for CI where the
  *      profile mechanism isn't available).
- *   2. `DATABRICKS_CONFIG_PROFILE` — runs `databricks auth env --profile`
+ *   2. `DATABRICKS_CONFIG_PROFILE` – runs `databricks auth env --profile`
  *      and reads back DATABRICKS_HOST. Matches the substrate's existing
  *      profile-aware behavior so contributors who already have a working
  *      profile don't need to also set LAKEBASE_TEST_HOST.
- *   3. null — caller should skip the test.
+ *   3. null – caller should skip the test.
  *
  * NB: previously this fell back to a hardcoded `workspace.cloud.databricks.com`
  * placeholder, which DNS-failed in every run. That fallback masked the
@@ -116,7 +116,7 @@ describe.skipIf(!e2eReady)("createProject – live end-to-end (LAKEBASE_TEST_E2E
 
   it("creates a Lakebase-paired local-only project end-to-end", async () => {
     const parent = mkTmp();
-    // e2eHost is guaranteed non-null here — describe.skipIf gates on it.
+    // e2eHost is guaranteed non-null here – describe.skipIf gates on it.
     const host = e2eHost!;
     const projectName = `lbscm-test-${Date.now()}`;
     // Pre-register so afterEach tears it down even on assertion failure.
@@ -143,7 +143,7 @@ describe.skipIf(!e2eReady)("createProject – live end-to-end (LAKEBASE_TEST_E2E
     expect(fs.existsSync(path.join(result.projectDir, ".env"))).toBe(true);
     expect(fs.existsSync(path.join(result.projectDir, "pyproject.toml"))).toBe(true);
 
-    // The seeded .env contains the non-secret context only — the project id +
+    // The seeded .env contains the non-secret context only – the project id +
     // workspace host. Secret fields stay empty/absent until the post-checkout
     // hook fills them on first branch switch.
     const seededEnv = fs.readFileSync(path.join(result.projectDir, ".env"), "utf-8");
@@ -166,7 +166,7 @@ describe("createProject – skip-when-e2e-disabled", () => {
     if (!liveE2E || e2eHost) return;
     // eslint-disable-next-line no-console
     console.log(
-      "LAKEBASE_TEST_E2E=1 but no test host resolvable — set LAKEBASE_TEST_HOST explicitly " +
+      "LAKEBASE_TEST_E2E=1 but no test host resolvable – set LAKEBASE_TEST_HOST explicitly " +
         "or DATABRICKS_CONFIG_PROFILE (the test will run `databricks auth env --profile` to derive the host)."
     );
     expect(e2eHost).toBeNull();

--- a/tests/bdd/create-project.test.ts
+++ b/tests/bdd/create-project.test.ts
@@ -1,9 +1,42 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createProject } from "../../scripts/lakebase/create-project.js";
 import { deleteLakebaseProject } from "../../scripts/lakebase/lakebase-project.js";
+
+/**
+ * Resolve the destructive test's target host. Precedence:
+ *   1. `LAKEBASE_TEST_HOST` — explicit override (e.g. for CI where the
+ *      profile mechanism isn't available).
+ *   2. `DATABRICKS_CONFIG_PROFILE` — runs `databricks auth env --profile`
+ *      and reads back DATABRICKS_HOST. Matches the substrate's existing
+ *      profile-aware behavior so contributors who already have a working
+ *      profile don't need to also set LAKEBASE_TEST_HOST.
+ *   3. null — caller should skip the test.
+ *
+ * NB: previously this fell back to a hardcoded `workspace.cloud.databricks.com`
+ * placeholder, which DNS-failed in every run. That fallback masked the
+ * "no host configured" case as a misleading network error; surfacing
+ * null lets the suite skip cleanly with a clear message.
+ */
+function resolveTestHost(): string | null {
+  if (process.env.LAKEBASE_TEST_HOST) return process.env.LAKEBASE_TEST_HOST;
+  const profile = process.env.DATABRICKS_CONFIG_PROFILE;
+  if (!profile) return null;
+  try {
+    const raw = execFileSync("databricks", ["auth", "env", "--profile", profile], {
+      encoding: "utf-8",
+      timeout: 5_000,
+    });
+    const env = JSON.parse(raw) as { env?: Record<string, string> };
+    const host = env.env?.DATABRICKS_HOST?.replace(/\/+$/, "");
+    return host ?? null;
+  } catch {
+    return null;
+  }
+}
 
 const tmpDirs: string[] = [];
 afterEach(() => {
@@ -52,8 +85,12 @@ describe("createProject input validation", () => {
 });
 
 const liveE2E = process.env.LAKEBASE_TEST_E2E === "1";
+// Lazily evaluated so the resolver doesn't fire (and possibly shell out)
+// at module-import time when the suite is skipped anyway.
+const e2eHost = liveE2E ? resolveTestHost() : null;
+const e2eReady = liveE2E && !!e2eHost;
 
-describe.skipIf(!liveE2E)("createProject – live end-to-end (LAKEBASE_TEST_E2E=1)", () => {
+describe.skipIf(!e2eReady)("createProject – live end-to-end (LAKEBASE_TEST_E2E=1)", () => {
   // createProject does Lakebase create + branch resolve + scaffold + commit +
   // health check end-to-end. On a cold workspace it routinely takes 30-60s,
   // well past vitest's 5s default. Bump to 3 min so a transient slow Lakebase
@@ -79,8 +116,8 @@ describe.skipIf(!liveE2E)("createProject – live end-to-end (LAKEBASE_TEST_E2E=
 
   it("creates a Lakebase-paired local-only project end-to-end", async () => {
     const parent = mkTmp();
-    const host =
-      process.env.LAKEBASE_TEST_HOST ?? "https://workspace.cloud.databricks.com";
+    // e2eHost is guaranteed non-null here — describe.skipIf gates on it.
+    const host = e2eHost!;
     const projectName = `lbscm-test-${Date.now()}`;
     // Pre-register so afterEach tears it down even on assertion failure.
     createdProjectIds.push({ id: projectName, host });
@@ -95,11 +132,23 @@ describe.skipIf(!liveE2E)("createProject – live end-to-end (LAKEBASE_TEST_E2E=
     });
     expect(result.projectDir.startsWith(parent)).toBe(true);
     expect(result.lakebaseProjectId).toBeTruthy();
-    // createProject ships .env.example only; .env is gitignored and never
-    // written by this flow (post-checkout hook bootstraps it on first switch).
+    // createProject ships BOTH .env.example (tracked template) AND a seeded
+    // .env (gitignored, populated with LAKEBASE_PROJECT_ID + DATABRICKS_HOST
+    // from the create flow). The seed avoids the gated-hook chicken-and-egg:
+    // post-checkout would otherwise bail on empty LAKEBASE_PROJECT_ID and
+    // never refresh .env on subsequent checkouts. Secrets (JWT, DB_PASSWORD,
+    // DATABASE_URL) stay deferred to the hook on first checkout. See
+    // scaffold.ts deployEnv() for the rationale.
     expect(fs.existsSync(path.join(result.projectDir, ".env.example"))).toBe(true);
-    expect(fs.existsSync(path.join(result.projectDir, ".env"))).toBe(false);
+    expect(fs.existsSync(path.join(result.projectDir, ".env"))).toBe(true);
     expect(fs.existsSync(path.join(result.projectDir, "pyproject.toml"))).toBe(true);
+
+    // The seeded .env contains the non-secret context only — the project id +
+    // workspace host. Secret fields stay empty/absent until the post-checkout
+    // hook fills them on first branch switch.
+    const seededEnv = fs.readFileSync(path.join(result.projectDir, ".env"), "utf-8");
+    expect(seededEnv).toContain(`LAKEBASE_PROJECT_ID=${result.lakebaseProjectId}`);
+    expect(seededEnv).toContain("DATABRICKS_HOST=");
   }, E2E_TIMEOUT_MS);
 });
 
@@ -111,5 +160,15 @@ describe("createProject – skip-when-e2e-disabled", () => {
       "LAKEBASE_TEST_E2E not set – live create-project end-to-end test skipped (destructive)."
     );
     expect(liveE2E).toBe(false);
+  });
+
+  it("documents the skip reason when no host is resolvable (LAKEBASE_TEST_HOST + DATABRICKS_CONFIG_PROFILE both missing)", () => {
+    if (!liveE2E || e2eHost) return;
+    // eslint-disable-next-line no-console
+    console.log(
+      "LAKEBASE_TEST_E2E=1 but no test host resolvable — set LAKEBASE_TEST_HOST explicitly " +
+        "or DATABRICKS_CONFIG_PROFILE (the test will run `databricks auth env --profile` to derive the host)."
+    );
+    expect(e2eHost).toBeNull();
   });
 });

--- a/tests/bdd/credentials.ts
+++ b/tests/bdd/credentials.ts
@@ -35,6 +35,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { DEFAULT_DATABASE } from "../../scripts/lakebase/constants.js";
 
 export type RequiredField =
   | "host"
@@ -80,7 +81,7 @@ export function requireLakebaseLiveEnv(
   const instance = (process.env.LAKEBASE_TEST_INSTANCE || "").trim();
   const branch = (process.env.LAKEBASE_TEST_BRANCH || "").trim();
   const parent = (process.env.LAKEBASE_TEST_PARENT || "").trim();
-  const database = (process.env.LAKEBASE_TEST_DATABASE || "databricks_postgres").trim();
+  const database = (process.env.LAKEBASE_TEST_DATABASE || DEFAULT_DATABASE).trim();
   const comparisonBranch = (process.env.LAKEBASE_TEST_COMPARISON_BRANCH || "").trim() || undefined;
   const e2e = process.env.LAKEBASE_TEST_E2E === "1";
   const initializr = process.env.LAKEBASE_TEST_INITIALIZR === "1";

--- a/tests/bdd/get-connection-dsn.test.ts
+++ b/tests/bdd/get-connection-dsn.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getConnection } from "../../scripts/lakebase/get-connection.js";
+import { POSTGRES_PORT } from "../../scripts/lakebase/constants.js";
 
 // Skip-when-env-missing: this suite requires a real, reachable Lakebase
 // project + branch and a `databricks` CLI authenticated to the same
@@ -32,7 +33,7 @@ describe.skipIf(skip)("get-connection --output dsn", () => {
     expect(u.protocol).toBe("postgresql:");
     expect(u.hostname).toBe(result.host);
     expect(u.port).toBe(String(result.port));
-    expect(u.port).toBe("5432");
+    expect(u.port).toBe(String(POSTGRES_PORT));
     // username/password URL-encoded – decoded values should be non-empty
     expect(decodeURIComponent(u.username)).not.toBe("");
     expect(decodeURIComponent(u.password)).not.toBe("");

--- a/tests/bdd/get-connection-equivalence.test.ts
+++ b/tests/bdd/get-connection-equivalence.test.ts
@@ -54,7 +54,7 @@ describe.skipIf(skip)("get-connection – DSN and Pool resolve to the same datab
     expect(dsnRow.host).toBeTruthy();
     // User identity must match – both paths use the operator principal
     expect(poolRow.user).toBe(dsnRow.user);
-  }, 30000); // Two live pg connects + credential mints — ~5-8s end-to-end under
+  }, 30000); // Two live pg connects + credential mints – ~5-8s end-to-end under
   // parallel-suite load. Bump from the 5s default; runs <1s on a warm endpoint.
 });
 

--- a/tests/bdd/get-connection-equivalence.test.ts
+++ b/tests/bdd/get-connection-equivalence.test.ts
@@ -54,7 +54,8 @@ describe.skipIf(skip)("get-connection – DSN and Pool resolve to the same datab
     expect(dsnRow.host).toBeTruthy();
     // User identity must match – both paths use the operator principal
     expect(poolRow.user).toBe(dsnRow.user);
-  });
+  }, 30000); // Two live pg connects + credential mints — ~5-8s end-to-end under
+  // parallel-suite load. Bump from the 5s default; runs <1s on a warm endpoint.
 });
 
 describe("get-connection equivalence (skip-when-env-missing)", () => {

--- a/tests/bdd/get-connection-pool.test.ts
+++ b/tests/bdd/get-connection-pool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterAll } from "vitest";
 import type { Pool } from "pg";
 import { getConnection } from "../../scripts/lakebase/get-connection.js";
+import { DEFAULT_DATABASE } from "../../scripts/lakebase/constants.js";
 
 // Skip-when-env-missing. See get-connection-dsn.test.ts for env contract.
 const INSTANCE = process.env.LAKEBASE_TEST_INSTANCE;
@@ -39,7 +40,7 @@ describe.skipIf(skip)("get-connection --output pool", () => {
         database: DATABASE,
       });
     }
-    const expectedDb = DATABASE ?? "databricks_postgres";
+    const expectedDb = DATABASE ?? DEFAULT_DATABASE;
     const { rows } = await pool.query<{ db: string }>("SELECT current_database() AS db");
     expect(rows[0].db).toBe(expectedDb);
   });

--- a/tests/bdd/kit-config.test.ts
+++ b/tests/bdd/kit-config.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { KIT_TIMEOUTS } from "../../scripts/lakebase/kit-config";
+
+// kit-config is the single source of truth for every timeout the
+// substrate scatters across its files. The test pins documented
+// defaults + the env-override surface so a future tuning change
+// doesn't quietly drift them out of sync.
+//
+// Env-override coverage: KIT_TIMEOUTS is read once at module load.
+// Verifying the env-override mechanic itself requires loading the
+// module fresh with new env, which isn't worth the vitest gymnastics
+// here — the override path is straightforward (intFromEnv falls back
+// to the default on parse failure / non-positive value), so we cover
+// the documented defaults + the field surface only.
+
+describe("KIT_TIMEOUTS – documented defaults", () => {
+  it("CLI invocations fall in the 30s default / 60s long bands", () => {
+    expect(KIT_TIMEOUTS.cliDefault).toBe(30_000);
+    expect(KIT_TIMEOUTS.cliCreateBranch).toBe(60_000);
+    expect(KIT_TIMEOUTS.cliCreateEndpoint).toBe(60_000);
+    expect(KIT_TIMEOUTS.cliLong).toBe(60_000);
+  });
+
+  it("wait-for-READY uses a 2-minute budget with 5s polls", () => {
+    expect(KIT_TIMEOUTS.readyWait).toBe(120_000);
+    expect(KIT_TIMEOUTS.readyPoll).toBe(5_000);
+  });
+
+  it("Postgres client timeouts: 10s connect / 15s statement", () => {
+    expect(KIT_TIMEOUTS.pgConnect).toBe(10_000);
+    expect(KIT_TIMEOUTS.pgStatement).toBe(15_000);
+  });
+
+  it("git operations: 5s local / 10s checkout / 15s network / 30s push", () => {
+    expect(KIT_TIMEOUTS.gitDefault).toBe(5_000);
+    expect(KIT_TIMEOUTS.gitCheckout).toBe(10_000);
+    expect(KIT_TIMEOUTS.gitNetwork).toBe(15_000);
+    expect(KIT_TIMEOUTS.gitPush).toBe(30_000);
+  });
+
+  it("short helper commands are 5s by default", () => {
+    expect(KIT_TIMEOUTS.cmdShort).toBe(5_000);
+  });
+
+  it("Spring Initializr metadata cache TTL is 10 minutes", () => {
+    expect(KIT_TIMEOUTS.initializrCacheTtl).toBe(10 * 60 * 1000);
+  });
+
+  it("every value is a positive integer (env-override fallback contract)", () => {
+    for (const [name, value] of Object.entries(KIT_TIMEOUTS)) {
+      expect(typeof value, `${name} should be a number`).toBe("number");
+      expect(Number.isFinite(value), `${name} should be finite`).toBe(true);
+      expect(value, `${name} should be positive`).toBeGreaterThan(0);
+      expect(Number.isInteger(value), `${name} should be an integer`).toBe(true);
+    }
+  });
+
+  it("exposes every documented field (closed shape)", () => {
+    expect(Object.keys(KIT_TIMEOUTS).sort()).toEqual(
+      [
+        "cliDefault",
+        "cliCreateBranch",
+        "cliCreateEndpoint",
+        "readyWait",
+        "readyPoll",
+        "pgConnect",
+        "pgStatement",
+        "gitDefault",
+        "gitCheckout",
+        "gitNetwork",
+        "gitPush",
+        "cliLong",
+        "cmdShort",
+        "initializrCacheTtl",
+      ].sort()
+    );
+  });
+});

--- a/tests/bdd/kit-config.test.ts
+++ b/tests/bdd/kit-config.test.ts
@@ -1,56 +1,113 @@
-import { describe, it, expect } from "vitest";
-import {
-  KIT_TIMEOUTS,
-  KIT_REGISTRIES,
-  formatLakebaseTtl,
-} from "../../scripts/lakebase/kit-config";
+import { describe, it, expect, vi } from "vitest";
 
 // kit-config is the single source of truth for every timeout the
-// substrate scatters across its files. The test pins documented
-// defaults + the env-override surface so a future tuning change
-// doesn't quietly drift them out of sync.
+// substrate scatters across its files. Two layers under test:
+//   1. Documented defaults  (clean env, no LAKEBASE_KIT_* set)
+//   2. Env-override mechanic (intFromEnv / urlFromEnv pick up env var)
 //
-// Env-override coverage: KIT_TIMEOUTS is read once at module load.
-// Verifying the env-override mechanic itself requires loading the
-// module fresh with new env, which isn't worth the vitest gymnastics
-// here – the override path is straightforward (intFromEnv falls back
-// to the default on parse failure / non-positive value), so we cover
-// the documented defaults + the field surface only.
+// The module is read once at import time, so verifying both layers in a
+// single test file requires loading it under a controlled env. We use
+// vi.resetModules() + scoped env mutation so every assertion runs
+// unconditionally (no skipIf gating, no contributor-actionable skips).
 
-describe("KIT_TIMEOUTS – documented defaults", () => {
-  it("CLI invocations fall in the 30s default / 60s long bands", () => {
+const KIT_ENV_VARS = [
+  "LAKEBASE_KIT_TIMEOUT_CLI_DEFAULT_MS",
+  "LAKEBASE_KIT_TIMEOUT_CLI_CREATE_BRANCH_MS",
+  "LAKEBASE_KIT_TIMEOUT_CLI_CREATE_ENDPOINT_MS",
+  "LAKEBASE_KIT_TIMEOUT_READY_WAIT_MS",
+  "LAKEBASE_KIT_TIMEOUT_READY_POLL_MS",
+  "LAKEBASE_KIT_TIMEOUT_PG_CONNECT_MS",
+  "LAKEBASE_KIT_TIMEOUT_PG_STATEMENT_MS",
+  "LAKEBASE_KIT_TIMEOUT_GIT_DEFAULT_MS",
+  "LAKEBASE_KIT_TIMEOUT_GIT_CHECKOUT_MS",
+  "LAKEBASE_KIT_TIMEOUT_GIT_NETWORK_MS",
+  "LAKEBASE_KIT_TIMEOUT_GIT_PUSH_MS",
+  "LAKEBASE_KIT_TIMEOUT_CLI_LONG_MS",
+  "LAKEBASE_KIT_TIMEOUT_CMD_SHORT_MS",
+  "LAKEBASE_KIT_INITIALIZR_CACHE_TTL_MS",
+  "LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS",
+  "LAKEBASE_KIT_TEST_BRANCH_TTL_MS",
+  "LAKEBASE_KIT_UAT_BRANCH_TTL_MS",
+  "LAKEBASE_KIT_PERF_BRANCH_TTL_MS",
+  "LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL",
+  "LAKEBASE_KIT_REGISTRY_SPRING_INITIALIZR",
+];
+
+// Load kit-config under a controlled env. The `overrides` map is the
+// only kit env active during module init; every other LAKEBASE_KIT_* is
+// scrubbed so the documented-default branch runs deterministically even
+// when the surrounding process inherits values (e.g. .env.local.config
+// sourced by run-all-live-tests.sh).
+async function loadKitConfig(overrides: Record<string, string | undefined> = {}) {
+  const saved: Record<string, string | undefined> = {};
+  for (const v of KIT_ENV_VARS) {
+    saved[v] = process.env[v];
+    delete process.env[v];
+  }
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v !== undefined) process.env[k] = v;
+  }
+  try {
+    vi.resetModules();
+    return await import("../../scripts/lakebase/kit-config");
+  } finally {
+    for (const v of KIT_ENV_VARS) {
+      if (saved[v] === undefined) delete process.env[v];
+      else process.env[v] = saved[v];
+    }
+  }
+}
+
+describe("KIT_TIMEOUTS – documented defaults (clean env)", () => {
+  it("CLI invocations fall in the 30s default / 60s long bands", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig();
     expect(KIT_TIMEOUTS.cliDefault).toBe(30_000);
     expect(KIT_TIMEOUTS.cliCreateBranch).toBe(60_000);
     expect(KIT_TIMEOUTS.cliCreateEndpoint).toBe(60_000);
     expect(KIT_TIMEOUTS.cliLong).toBe(60_000);
   });
 
-  it("wait-for-READY uses a 2-minute budget with 5s polls", () => {
+  it("wait-for-READY uses a 2-minute budget with 5s polls", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig();
     expect(KIT_TIMEOUTS.readyWait).toBe(120_000);
     expect(KIT_TIMEOUTS.readyPoll).toBe(5_000);
   });
 
-  it("Postgres client timeouts: 10s connect / 15s statement", () => {
+  it("Postgres client timeouts: 10s connect / 15s statement", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig();
     expect(KIT_TIMEOUTS.pgConnect).toBe(10_000);
     expect(KIT_TIMEOUTS.pgStatement).toBe(15_000);
   });
 
-  it("git operations: 5s local / 10s checkout / 15s network / 30s push", () => {
+  it("git operations: 5s local / 10s checkout / 15s network / 30s push", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig();
     expect(KIT_TIMEOUTS.gitDefault).toBe(5_000);
     expect(KIT_TIMEOUTS.gitCheckout).toBe(10_000);
     expect(KIT_TIMEOUTS.gitNetwork).toBe(15_000);
     expect(KIT_TIMEOUTS.gitPush).toBe(30_000);
   });
 
-  it("short helper commands are 5s by default", () => {
+  it("short helper commands are 5s by default", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig();
     expect(KIT_TIMEOUTS.cmdShort).toBe(5_000);
   });
 
-  it("Spring Initializr metadata cache TTL is 10 minutes", () => {
+  it("Spring Initializr metadata cache TTL is 10 minutes", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig();
     expect(KIT_TIMEOUTS.initializrCacheTtl).toBe(10 * 60 * 1000);
   });
 
-  it("every value is a positive integer (env-override fallback contract)", () => {
+  it("convention branch TTLs match PSA defaults (30d feature / 14d test+uat / 7d perf)", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig();
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    expect(KIT_TIMEOUTS.featureBranchTtlMs).toBe(30 * DAY_MS);
+    expect(KIT_TIMEOUTS.testBranchTtlMs).toBe(14 * DAY_MS);
+    expect(KIT_TIMEOUTS.uatBranchTtlMs).toBe(14 * DAY_MS);
+    expect(KIT_TIMEOUTS.perfBranchTtlMs).toBe(7 * DAY_MS);
+  });
+
+  it("every value is a positive integer (env-override fallback contract)", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig();
     for (const [name, value] of Object.entries(KIT_TIMEOUTS)) {
       expect(typeof value, `${name} should be a number`).toBe("number");
       expect(Number.isFinite(value), `${name} should be finite`).toBe(true);
@@ -59,36 +116,8 @@ describe("KIT_TIMEOUTS – documented defaults", () => {
     }
   });
 
-  // PSA-default convention TTLs (30d feature / 14d test+uat / 7d perf).
-  // Each tier's default is env-overridable; in a clean test env (no
-  // LAKEBASE_KIT_*_BRANCH_TTL_MS set) the defaults MUST resolve so the
-  // mainline path stays the no-config-required happy case. When a tier's
-  // override IS set (e.g. .env.local.config sources a tighter cap) the
-  // matching assertion is skipped; the env-override mechanic is covered
-  // by KitTimeouts' positive-integer + closed-shape contracts below.
-  const FEATURE_TTL_ENV = !!process.env.LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS;
-  const TEST_TTL_ENV = !!process.env.LAKEBASE_KIT_TEST_BRANCH_TTL_MS;
-  const UAT_TTL_ENV = !!process.env.LAKEBASE_KIT_UAT_BRANCH_TTL_MS;
-  const PERF_TTL_ENV = !!process.env.LAKEBASE_KIT_PERF_BRANCH_TTL_MS;
-  const DAY_MS = 24 * 60 * 60 * 1000;
-
-  it.skipIf(FEATURE_TTL_ENV)("feature-tier default TTL is 30 days", () => {
-    expect(KIT_TIMEOUTS.featureBranchTtlMs).toBe(30 * DAY_MS);
-  });
-
-  it.skipIf(TEST_TTL_ENV)("test-tier default TTL is 14 days", () => {
-    expect(KIT_TIMEOUTS.testBranchTtlMs).toBe(14 * DAY_MS);
-  });
-
-  it.skipIf(UAT_TTL_ENV)("uat-tier default TTL is 14 days", () => {
-    expect(KIT_TIMEOUTS.uatBranchTtlMs).toBe(14 * DAY_MS);
-  });
-
-  it.skipIf(PERF_TTL_ENV)("perf-tier default TTL is 7 days", () => {
-    expect(KIT_TIMEOUTS.perfBranchTtlMs).toBe(7 * DAY_MS);
-  });
-
-  it("exposes every documented field (closed shape)", () => {
+  it("exposes every documented field (closed shape)", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig();
     expect(Object.keys(KIT_TIMEOUTS).sort()).toEqual(
       [
         "cliDefault",
@@ -114,50 +143,95 @@ describe("KIT_TIMEOUTS – documented defaults", () => {
   });
 });
 
+describe("KIT_TIMEOUTS – env-override mechanic", () => {
+  it("LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS overrides the 30-day default", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig({
+      LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS: "604800000", // 7 days
+    });
+    expect(KIT_TIMEOUTS.featureBranchTtlMs).toBe(604_800_000);
+  });
+
+  it("LAKEBASE_KIT_TIMEOUT_CLI_DEFAULT_MS overrides the 30s default", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig({
+      LAKEBASE_KIT_TIMEOUT_CLI_DEFAULT_MS: "45000",
+    });
+    expect(KIT_TIMEOUTS.cliDefault).toBe(45_000);
+  });
+
+  it("non-numeric env value falls back to the documented default", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig({
+      LAKEBASE_KIT_TIMEOUT_CLI_DEFAULT_MS: "not-a-number",
+    });
+    expect(KIT_TIMEOUTS.cliDefault).toBe(30_000);
+  });
+
+  it("non-positive env value falls back to the documented default", async () => {
+    const { KIT_TIMEOUTS } = await loadKitConfig({
+      LAKEBASE_KIT_TIMEOUT_CLI_DEFAULT_MS: "0",
+    });
+    expect(KIT_TIMEOUTS.cliDefault).toBe(30_000);
+  });
+});
+
 describe("formatLakebaseTtl – protobuf Duration format", () => {
-  it("formats ms → `<seconds>s` as Lakebase expects in create-branch specs", () => {
+  it("formats ms to `<seconds>s` as Lakebase expects in create-branch specs", async () => {
+    const { formatLakebaseTtl } = await loadKitConfig();
     expect(formatLakebaseTtl(86_400_000)).toBe("86400s"); // 1 day
     expect(formatLakebaseTtl(7 * 24 * 60 * 60 * 1000)).toBe("604800s"); // 7 days
     expect(formatLakebaseTtl(30 * 24 * 60 * 60 * 1000)).toBe("2592000s"); // 30 days
   });
 
-  it("floors fractional seconds (ms not divisible by 1000)", () => {
+  it("floors fractional seconds (ms not divisible by 1000)", async () => {
+    const { formatLakebaseTtl } = await loadKitConfig();
     expect(formatLakebaseTtl(1234)).toBe("1s");
     expect(formatLakebaseTtl(0)).toBe("0s");
   });
 });
 
-describe("KIT_REGISTRIES – package-registry URLs", () => {
-  // Each registry default is env-overridable; in a clean test env (no
-  // LAKEBASE_KIT_REGISTRY_* set) they MUST resolve to the documented
-  // public defaults so the mainline path stays the no-config-required
-  // happy case. When the override IS set (e.g. .env.local.config sources
-  // a corp proxy) the matching default-value assertion is skipped; the
-  // override mechanic is covered by the trailing-slash + closed-shape
-  // contracts below, which hold for any URL the env resolves to.
-  const MAVEN_ENV = !!process.env.LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL;
-  const SPRING_ENV = !!process.env.LAKEBASE_KIT_REGISTRY_SPRING_INITIALIZR;
-
-  it.skipIf(MAVEN_ENV)("Maven Central defaults to the mainline public registry", () => {
+describe("KIT_REGISTRIES – package-registry URLs (clean env)", () => {
+  it("Maven Central defaults to the mainline public registry", async () => {
+    const { KIT_REGISTRIES } = await loadKitConfig();
     expect(KIT_REGISTRIES.mavenCentral).toBe("https://repo1.maven.org/maven2");
   });
 
-  it.skipIf(SPRING_ENV)("Spring Initializr defaults to the mainline public registry", () => {
+  it("Spring Initializr defaults to the mainline public registry", async () => {
+    const { KIT_REGISTRIES } = await loadKitConfig();
     expect(KIT_REGISTRIES.springInitializr).toBe("https://start.spring.io");
   });
 
-  it("trailing slashes stripped so callers can safely concat `/path`", () => {
-    // The urlFromEnv helper trims trailing slashes (verify the resolved
-    // values are in trimmed form so callers don't get `//path` after
-    // concatenation). This contract holds for both the public defaults
-    // and any env-sourced override.
+  it("trailing slashes stripped so callers can safely concat `/path`", async () => {
+    const { KIT_REGISTRIES } = await loadKitConfig();
     expect(KIT_REGISTRIES.mavenCentral.endsWith("/")).toBe(false);
     expect(KIT_REGISTRIES.springInitializr.endsWith("/")).toBe(false);
   });
 
-  it("exposes every documented field (closed shape)", () => {
+  it("exposes every documented field (closed shape)", async () => {
+    const { KIT_REGISTRIES } = await loadKitConfig();
     expect(Object.keys(KIT_REGISTRIES).sort()).toEqual(
       ["mavenCentral", "springInitializr"].sort()
     );
+  });
+});
+
+describe("KIT_REGISTRIES – env-override mechanic", () => {
+  it("LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL overrides the public default", async () => {
+    const { KIT_REGISTRIES } = await loadKitConfig({
+      LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL: "https://maven-proxy.example.com",
+    });
+    expect(KIT_REGISTRIES.mavenCentral).toBe("https://maven-proxy.example.com");
+  });
+
+  it("LAKEBASE_KIT_REGISTRY_SPRING_INITIALIZR overrides the public default", async () => {
+    const { KIT_REGISTRIES } = await loadKitConfig({
+      LAKEBASE_KIT_REGISTRY_SPRING_INITIALIZR: "https://spring-mirror.example.com",
+    });
+    expect(KIT_REGISTRIES.springInitializr).toBe("https://spring-mirror.example.com");
+  });
+
+  it("trailing slashes are stripped from env overrides", async () => {
+    const { KIT_REGISTRIES } = await loadKitConfig({
+      LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL: "https://maven-proxy.example.com//",
+    });
+    expect(KIT_REGISTRIES.mavenCentral).toBe("https://maven-proxy.example.com");
   });
 });

--- a/tests/bdd/kit-config.test.ts
+++ b/tests/bdd/kit-config.test.ts
@@ -59,11 +59,32 @@ describe("KIT_TIMEOUTS – documented defaults", () => {
     }
   });
 
-  it("convention branch TTLs match the PSA defaults (30d feature / 14d test+uat / 7d perf)", () => {
-    const DAY_MS = 24 * 60 * 60 * 1000;
+  // PSA-default convention TTLs (30d feature / 14d test+uat / 7d perf).
+  // Each tier's default is env-overridable; in a clean test env (no
+  // LAKEBASE_KIT_*_BRANCH_TTL_MS set) the defaults MUST resolve so the
+  // mainline path stays the no-config-required happy case. When a tier's
+  // override IS set (e.g. .env.local.config sources a tighter cap) the
+  // matching assertion is skipped; the env-override mechanic is covered
+  // by KitTimeouts' positive-integer + closed-shape contracts below.
+  const FEATURE_TTL_ENV = !!process.env.LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS;
+  const TEST_TTL_ENV = !!process.env.LAKEBASE_KIT_TEST_BRANCH_TTL_MS;
+  const UAT_TTL_ENV = !!process.env.LAKEBASE_KIT_UAT_BRANCH_TTL_MS;
+  const PERF_TTL_ENV = !!process.env.LAKEBASE_KIT_PERF_BRANCH_TTL_MS;
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  it.skipIf(FEATURE_TTL_ENV)("feature-tier default TTL is 30 days", () => {
     expect(KIT_TIMEOUTS.featureBranchTtlMs).toBe(30 * DAY_MS);
+  });
+
+  it.skipIf(TEST_TTL_ENV)("test-tier default TTL is 14 days", () => {
     expect(KIT_TIMEOUTS.testBranchTtlMs).toBe(14 * DAY_MS);
+  });
+
+  it.skipIf(UAT_TTL_ENV)("uat-tier default TTL is 14 days", () => {
     expect(KIT_TIMEOUTS.uatBranchTtlMs).toBe(14 * DAY_MS);
+  });
+
+  it.skipIf(PERF_TTL_ENV)("perf-tier default TTL is 7 days", () => {
     expect(KIT_TIMEOUTS.perfBranchTtlMs).toBe(7 * DAY_MS);
   });
 
@@ -107,18 +128,29 @@ describe("formatLakebaseTtl – protobuf Duration format", () => {
 });
 
 describe("KIT_REGISTRIES – package-registry URLs", () => {
-  it("defaults to the mainline public registries", () => {
-    // These are env-overridable; in a clean test env (no LAKEBASE_KIT_REGISTRY_*
-    // set) they MUST resolve to the documented public defaults so the
-    // mainline path stays the no-config-required happy case.
+  // Each registry default is env-overridable; in a clean test env (no
+  // LAKEBASE_KIT_REGISTRY_* set) they MUST resolve to the documented
+  // public defaults so the mainline path stays the no-config-required
+  // happy case. When the override IS set (e.g. .env.local.config sources
+  // a corp proxy) the matching default-value assertion is skipped; the
+  // override mechanic is covered by the trailing-slash + closed-shape
+  // contracts below, which hold for any URL the env resolves to.
+  const MAVEN_ENV = !!process.env.LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL;
+  const SPRING_ENV = !!process.env.LAKEBASE_KIT_REGISTRY_SPRING_INITIALIZR;
+
+  it.skipIf(MAVEN_ENV)("Maven Central defaults to the mainline public registry", () => {
     expect(KIT_REGISTRIES.mavenCentral).toBe("https://repo1.maven.org/maven2");
+  });
+
+  it.skipIf(SPRING_ENV)("Spring Initializr defaults to the mainline public registry", () => {
     expect(KIT_REGISTRIES.springInitializr).toBe("https://start.spring.io");
   });
 
   it("trailing slashes stripped so callers can safely concat `/path`", () => {
-    // The urlFromEnv helper trims trailing slashes – verify the defaults
-    // are already in trimmed form (a regression here would mean callers
-    // get `//path` after concatenation).
+    // The urlFromEnv helper trims trailing slashes (verify the resolved
+    // values are in trimmed form so callers don't get `//path` after
+    // concatenation). This contract holds for both the public defaults
+    // and any env-sourced override.
     expect(KIT_REGISTRIES.mavenCentral.endsWith("/")).toBe(false);
     expect(KIT_REGISTRIES.springInitializr.endsWith("/")).toBe(false);
   });

--- a/tests/bdd/kit-config.test.ts
+++ b/tests/bdd/kit-config.test.ts
@@ -13,7 +13,7 @@ import {
 // Env-override coverage: KIT_TIMEOUTS is read once at module load.
 // Verifying the env-override mechanic itself requires loading the
 // module fresh with new env, which isn't worth the vitest gymnastics
-// here — the override path is straightforward (intFromEnv falls back
+// here – the override path is straightforward (intFromEnv falls back
 // to the default on parse failure / non-positive value), so we cover
 // the documented defaults + the field surface only.
 
@@ -116,7 +116,7 @@ describe("KIT_REGISTRIES – package-registry URLs", () => {
   });
 
   it("trailing slashes stripped so callers can safely concat `/path`", () => {
-    // The urlFromEnv helper trims trailing slashes — verify the defaults
+    // The urlFromEnv helper trims trailing slashes – verify the defaults
     // are already in trimmed form (a regression here would mean callers
     // get `//path` after concatenation).
     expect(KIT_REGISTRIES.mavenCentral.endsWith("/")).toBe(false);

--- a/tests/bdd/kit-config.test.ts
+++ b/tests/bdd/kit-config.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { KIT_TIMEOUTS } from "../../scripts/lakebase/kit-config";
+import {
+  KIT_TIMEOUTS,
+  KIT_REGISTRIES,
+  formatLakebaseTtl,
+} from "../../scripts/lakebase/kit-config";
 
 // kit-config is the single source of truth for every timeout the
 // substrate scatters across its files. The test pins documented
@@ -55,6 +59,14 @@ describe("KIT_TIMEOUTS – documented defaults", () => {
     }
   });
 
+  it("convention branch TTLs match the PSA defaults (30d feature / 14d test+uat / 7d perf)", () => {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    expect(KIT_TIMEOUTS.featureBranchTtlMs).toBe(30 * DAY_MS);
+    expect(KIT_TIMEOUTS.testBranchTtlMs).toBe(14 * DAY_MS);
+    expect(KIT_TIMEOUTS.uatBranchTtlMs).toBe(14 * DAY_MS);
+    expect(KIT_TIMEOUTS.perfBranchTtlMs).toBe(7 * DAY_MS);
+  });
+
   it("exposes every documented field (closed shape)", () => {
     expect(Object.keys(KIT_TIMEOUTS).sort()).toEqual(
       [
@@ -72,7 +84,48 @@ describe("KIT_TIMEOUTS – documented defaults", () => {
         "cliLong",
         "cmdShort",
         "initializrCacheTtl",
+        "featureBranchTtlMs",
+        "testBranchTtlMs",
+        "uatBranchTtlMs",
+        "perfBranchTtlMs",
       ].sort()
+    );
+  });
+});
+
+describe("formatLakebaseTtl – protobuf Duration format", () => {
+  it("formats ms → `<seconds>s` as Lakebase expects in create-branch specs", () => {
+    expect(formatLakebaseTtl(86_400_000)).toBe("86400s"); // 1 day
+    expect(formatLakebaseTtl(7 * 24 * 60 * 60 * 1000)).toBe("604800s"); // 7 days
+    expect(formatLakebaseTtl(30 * 24 * 60 * 60 * 1000)).toBe("2592000s"); // 30 days
+  });
+
+  it("floors fractional seconds (ms not divisible by 1000)", () => {
+    expect(formatLakebaseTtl(1234)).toBe("1s");
+    expect(formatLakebaseTtl(0)).toBe("0s");
+  });
+});
+
+describe("KIT_REGISTRIES – package-registry URLs", () => {
+  it("defaults to the mainline public registries", () => {
+    // These are env-overridable; in a clean test env (no LAKEBASE_KIT_REGISTRY_*
+    // set) they MUST resolve to the documented public defaults so the
+    // mainline path stays the no-config-required happy case.
+    expect(KIT_REGISTRIES.mavenCentral).toBe("https://repo1.maven.org/maven2");
+    expect(KIT_REGISTRIES.springInitializr).toBe("https://start.spring.io");
+  });
+
+  it("trailing slashes stripped so callers can safely concat `/path`", () => {
+    // The urlFromEnv helper trims trailing slashes — verify the defaults
+    // are already in trimmed form (a regression here would mean callers
+    // get `//path` after concatenation).
+    expect(KIT_REGISTRIES.mavenCentral.endsWith("/")).toBe(false);
+    expect(KIT_REGISTRIES.springInitializr.endsWith("/")).toBe(false);
+  });
+
+  it("exposes every documented field (closed shape)", () => {
+    expect(Object.keys(KIT_REGISTRIES).sort()).toEqual(
+      ["mavenCentral", "springInitializr"].sort()
     );
   });
 });

--- a/tests/bdd/lakebase-project.test.ts
+++ b/tests/bdd/lakebase-project.test.ts
@@ -75,7 +75,7 @@ describe("findDefaultBranchName – returns BranchName, never BranchUid", () => 
   it("returns the resource-path leaf (the BranchName), not the uid", () => {
     const result = findDefaultBranchName(SAMPLE);
     expect(result).toBe("production");
-    // The bug would have returned 'br-crimson-fire-d28lb2ez' here — that's
+    // The bug would have returned 'br-crimson-fire-d28lb2ez' here – that's
     // the exact regression this test guards.
     expect(result).not.toBe("br-crimson-fire-d28lb2ez");
   });

--- a/tests/bdd/lakebase-project.test.ts
+++ b/tests/bdd/lakebase-project.test.ts
@@ -3,8 +3,11 @@ import { execFileSync } from "node:child_process";
 import {
   createLakebaseProject,
   deleteLakebaseProject,
+  findDefaultBranchName,
   getDefaultBranchId,
+  getDefaultBranchName,
   LakebaseProjectError,
+  type BranchMetadata,
 } from "../../scripts/lakebase/lakebase-project.js";
 
 // `databricks` CLI presence gates most assertions. Project CRUD is
@@ -48,6 +51,90 @@ describe("lakebase-project – error wrapping", () => {
     const deleteFn: typeof deleteLakebaseProject = deleteLakebaseProject;
     expect(typeof createFn).toBe("function");
     expect(typeof deleteFn).toBe("function");
+  });
+});
+
+// Hermetic regression test for the BranchUid-in-source_branch bug surfaced
+// during the FEIP-7092 live exercise. CLI returns BOTH uid (br-…) and
+// name (.../branches/production) on each branch entry. The old
+// getDefaultBranchId preferred uid, which then failed downstream as a
+// source_branch reference ("branch id not found"). The new
+// getDefaultBranchName (+ the pure findDefaultBranchName helper) MUST
+// return the resource-path leaf.
+describe("findDefaultBranchName – returns BranchName, never BranchUid", () => {
+  // Shape mirrors what `databricks postgres list-branches -o json` returns
+  // for a fresh project: one default branch with both fields populated.
+  const SAMPLE: BranchMetadata[] = [
+    {
+      uid: "br-crimson-fire-d28lb2ez",
+      name: "projects/live-7092-1779932313/branches/production",
+      status: { default: true },
+    },
+  ];
+
+  it("returns the resource-path leaf (the BranchName), not the uid", () => {
+    const result = findDefaultBranchName(SAMPLE);
+    expect(result).toBe("production");
+    // The bug would have returned 'br-crimson-fire-d28lb2ez' here — that's
+    // the exact regression this test guards.
+    expect(result).not.toBe("br-crimson-fire-d28lb2ez");
+  });
+
+  it("returns null when no default branch is marked", () => {
+    const nonDefault: BranchMetadata[] = [
+      { uid: "br-x-y-z", name: "projects/x/branches/feature-y", status: {} },
+    ];
+    expect(findDefaultBranchName(nonDefault)).toBeNull();
+  });
+
+  it("returns null when the default branch has no name field", () => {
+    const malformed: BranchMetadata[] = [{ uid: "br-x-y-z", status: { default: true } }];
+    expect(findDefaultBranchName(malformed)).toBeNull();
+  });
+
+  it("returns null when items array is empty", () => {
+    expect(findDefaultBranchName([])).toBeNull();
+  });
+
+  it("honors the is_default top-level field (older CLI shape)", () => {
+    const oldShape: BranchMetadata[] = [
+      {
+        uid: "br-a-b-c",
+        name: "projects/x/branches/main",
+        is_default: true,
+      },
+    ];
+    expect(findDefaultBranchName(oldShape)).toBe("main");
+  });
+
+  it("handles multi-branch projects (picks the marked default)", () => {
+    const multi: BranchMetadata[] = [
+      { uid: "br-1", name: "projects/x/branches/feature-a", status: {} },
+      { uid: "br-2", name: "projects/x/branches/production", status: { default: true } },
+      { uid: "br-3", name: "projects/x/branches/feature-b", status: {} },
+    ];
+    expect(findDefaultBranchName(multi)).toBe("production");
+  });
+});
+
+describe("getDefaultBranchId – deprecated alias still returns the BranchName as a string", () => {
+  it("compiles and returns string (transitional API)", () => {
+    // Smoke check on the signature; behavior is hermetically tested via
+    // findDefaultBranchName above. Live behavior is covered by the
+    // .skipIf block when LAKEBASE_TEST_INSTANCE is set.
+    const fn: (args: { projectId: string }) => Promise<string> = getDefaultBranchId;
+    expect(typeof fn).toBe("function");
+  });
+});
+
+describe("getDefaultBranchName – return type is BranchName | null (compile-time)", () => {
+  it("signature is enforced by the type system", () => {
+    // The brand on BranchName means a caller cannot pass the result of
+    // getDefaultBranchName into a slot expecting BranchUid without going
+    // through asBranchUid (which would throw at runtime on a BranchName
+    // input).
+    const fn: (args: { projectId: string }) => Promise<unknown> = getDefaultBranchName;
+    expect(typeof fn).toBe("function");
   });
 });
 

--- a/tests/bdd/migrate.test.ts
+++ b/tests/bdd/migrate.test.ts
@@ -210,7 +210,7 @@ describe("listMigrations: language override", () => {
   let dir: string;
   beforeEach(() => {
     dir = mkTempDir();
-    // No detection markers — language must be passed explicitly.
+    // No detection markers – language must be passed explicitly.
     const migrations = path.join(dir, "migrations", "versions");
     fs.mkdirSync(migrations, { recursive: true });
     fs.writeFileSync(path.join(migrations, "aa111_init.py"), "");

--- a/tests/bdd/scaffold.test.ts
+++ b/tests/bdd/scaffold.test.ts
@@ -159,7 +159,7 @@ describe("deployWorkflows: {{LAKEBASE_KIT_VERSION}} substitution", () => {
     expect(prYml).toMatch(/github:databricks-solutions\/lakebase-app-dev-kit/);
     expect(prYml).toMatch(/--instance "\$LAKEBASE_PROJECT_ID"/);
     expect(prYml).toMatch(/--branch "\$LAKEBASE_BRANCH_NAME"/);
-    // The old per-language branches MUST be gone — substrate handles
+    // The old per-language branches MUST be gone – substrate handles
     // language detection internally.
     expect(prYml).not.toMatch(/flyway:migrate/);
     expect(prYml).not.toMatch(/uv run alembic upgrade head/);
@@ -288,7 +288,7 @@ describe("deployWorkflows: {{LAKEBASE_KIT_VERSION}} substitution", () => {
   it("falls back to 'unknown' when templatesDir points at a tree without a package.json", async () => {
     // Build a minimal fixture: tmpRoot has only `templates/project/common/.github/workflows/`,
     // no package.json at tmpRoot. kitVersion() resolves via path.dirname twice,
-    // so the lookup target is tmpRoot/package.json — which is absent.
+    // so the lookup target is tmpRoot/package.json – which is absent.
     const fixture = mkTmp();
     const templates = path.join(fixture, "templates", "project");
     const wfDir = path.join(templates, "common", ".github", "workflows");

--- a/tests/bdd/tdd-artifacts.test.ts
+++ b/tests/bdd/tdd-artifacts.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  writeArtifact,
+  listArtifacts,
+  readArtifact,
+} from "../../scripts/tdd/artifacts";
+
+let tdd: string;
+const FEATURE_ID = "F1-checkout";
+const EXP = "exp-postgres-arrays";
+
+beforeEach(() => {
+  tdd = mkdtempSync(join(tmpdir(), "tdd-artifacts-"));
+});
+
+afterEach(() => {
+  rmSync(tdd, { recursive: true, force: true });
+});
+
+describe("artifact persistence", () => {
+  it("writeArtifact creates the cycle dir on demand and returns the absolute path", () => {
+    const path = writeArtifact({
+      tddDir: tdd,
+      featureId: FEATURE_ID,
+      experimentSlug: EXP,
+      cycleId: "C1",
+      name: "vitest.junit.xml",
+      content: "<testsuites />",
+    });
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf8")).toBe("<testsuites />");
+    expect(path.endsWith("artifacts/C1/vitest.junit.xml")).toBe(true);
+  });
+
+  it("writeArtifact accepts nested name paths (creates intermediate dirs)", () => {
+    const path = writeArtifact({
+      tddDir: tdd,
+      featureId: FEATURE_ID,
+      experimentSlug: EXP,
+      cycleId: "C1",
+      name: "traces/network/spec-1.har",
+      content: Buffer.from([0x00, 0x01, 0x02]),
+    });
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path)).toEqual(Buffer.from([0x00, 0x01, 0x02]));
+  });
+
+  it("writeArtifact rejects path-traversal names", () => {
+    expect(() =>
+      writeArtifact({
+        tddDir: tdd,
+        featureId: FEATURE_ID,
+        experimentSlug: EXP,
+        cycleId: "C1",
+        name: "../../escape.txt",
+        content: "x",
+      })
+    ).toThrow(/invalid name/);
+  });
+
+  it("writeArtifact rejects absolute paths", () => {
+    expect(() =>
+      writeArtifact({
+        tddDir: tdd,
+        featureId: FEATURE_ID,
+        experimentSlug: EXP,
+        cycleId: "C1",
+        name: "/etc/passwd",
+        content: "x",
+      })
+    ).toThrow(/invalid name/);
+  });
+
+  it("listArtifacts scoped to a cycle returns just that cycle's files (sorted)", () => {
+    writeArtifact({ tddDir: tdd, featureId: FEATURE_ID, experimentSlug: EXP, cycleId: "C1", name: "b.log", content: "" });
+    writeArtifact({ tddDir: tdd, featureId: FEATURE_ID, experimentSlug: EXP, cycleId: "C1", name: "a.log", content: "" });
+    writeArtifact({ tddDir: tdd, featureId: FEATURE_ID, experimentSlug: EXP, cycleId: "C2", name: "z.log", content: "" });
+    const c1 = listArtifacts(tdd, FEATURE_ID, EXP, "C1");
+    expect(c1.map((e) => e.name)).toEqual(["a.log", "b.log"]);
+    expect(c1.every((e) => e.cycle_id === "C1")).toBe(true);
+  });
+
+  it("listArtifacts without cycleId enumerates across all cycles", () => {
+    writeArtifact({ tddDir: tdd, featureId: FEATURE_ID, experimentSlug: EXP, cycleId: "C1", name: "a.log", content: "" });
+    writeArtifact({ tddDir: tdd, featureId: FEATURE_ID, experimentSlug: EXP, cycleId: "C2", name: "a.log", content: "" });
+    const all = listArtifacts(tdd, FEATURE_ID, EXP);
+    expect(all).toHaveLength(2);
+    expect(new Set(all.map((e) => e.cycle_id))).toEqual(new Set(["C1", "C2"]));
+  });
+
+  it("listArtifacts returns empty when the experiment has no artifacts dir yet", () => {
+    expect(listArtifacts(tdd, FEATURE_ID, EXP)).toEqual([]);
+    expect(listArtifacts(tdd, FEATURE_ID, EXP, "C-missing")).toEqual([]);
+  });
+
+  it("each ArtifactEntry has the documented shape (name, path, cycle_id, size, modified)", () => {
+    writeArtifact({
+      tddDir: tdd,
+      featureId: FEATURE_ID,
+      experimentSlug: EXP,
+      cycleId: "C1",
+      name: "report.json",
+      content: '{"ok":true}',
+    });
+    const [entry] = listArtifacts(tdd, FEATURE_ID, EXP, "C1");
+    expect(Object.keys(entry).sort()).toEqual(["cycle_id", "modified", "name", "path", "size"].sort());
+    expect(entry.size).toBeGreaterThan(0);
+    expect(entry.modified).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("readArtifact round-trips bytes written by writeArtifact", () => {
+    const payload = Buffer.from("trace-blob", "utf8");
+    writeArtifact({
+      tddDir: tdd,
+      featureId: FEATURE_ID,
+      experimentSlug: EXP,
+      cycleId: "C1",
+      name: "trace.bin",
+      content: payload,
+    });
+    const round = readArtifact({
+      tddDir: tdd,
+      featureId: FEATURE_ID,
+      experimentSlug: EXP,
+      cycleId: "C1",
+      name: "trace.bin",
+    });
+    expect(round).toEqual(payload);
+  });
+
+  it("readArtifact returns null when the artifact does not exist", () => {
+    const round = readArtifact({
+      tddDir: tdd,
+      featureId: FEATURE_ID,
+      experimentSlug: EXP,
+      cycleId: "C1",
+      name: "ghost.txt",
+    });
+    expect(round).toBeNull();
+  });
+});

--- a/tests/bdd/tdd-compare-experiments.test.ts
+++ b/tests/bdd/tdd-compare-experiments.test.ts
@@ -58,3 +58,126 @@ describe("compareExperiments", () => {
     expect(report.recommendation).toBe("continue");
   });
 });
+
+// Structured-payload tests (FEIP-7092 slice 4): downstream comparison-report
+// renderer (FEIP-7208) consumes per-tag matrix, cycle counts, artifact counts.
+
+import { writeArtifact } from "../../scripts/tdd/artifacts";
+
+function seedExperimentRich(
+  slug: string,
+  outcomes: object,
+  opts: { cycles?: number; artifacts?: string[]; durationMs?: number } = {}
+): void {
+  const dir = join(tdd, "experiments", "F1", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "branch.txt"), `feature/${slug}`);
+  writeFileSync(join(dir, "outcomes.json"), JSON.stringify(outcomes));
+  if (opts.cycles) {
+    writeFileSync(
+      join(dir, "timeline.json"),
+      JSON.stringify({
+        entries: Array.from({ length: opts.cycles }, (_, i) => ({
+          ts: `2026-05-27T10:0${i}:00Z`,
+          kind: i === 0 ? "cut" : "cycle",
+        })),
+      })
+    );
+  }
+  if (opts.artifacts) {
+    for (const name of opts.artifacts) {
+      writeArtifact({
+        tddDir: tdd,
+        featureId: "F1",
+        experimentSlug: slug,
+        cycleId: "C1",
+        name,
+        content: "x",
+      });
+    }
+  }
+  if (opts.durationMs !== undefined) {
+    writeFileSync(join(dir, "runtime.json"), JSON.stringify({ duration_ms: opts.durationMs }));
+  }
+}
+
+describe("compareExperiments structured payload (FEIP-7092 slice 4)", () => {
+  it("each row carries cycle_count from timeline.json (0 when timeline missing)", () => {
+    seedExperimentRich("exp-with-cycles", { status: "running", tests_passed: 1 }, { cycles: 4 });
+    seedExperimentRich("exp-no-timeline", { status: "running", tests_passed: 0 });
+    const report = compareExperiments(tdd, "F1");
+    const bySlug = Object.fromEntries(report.rows.map((r) => [r.experiment_slug, r]));
+    expect(bySlug["exp-with-cycles"].cycle_count).toBe(4);
+    expect(bySlug["exp-no-timeline"].cycle_count).toBe(0);
+  });
+
+  it("each row carries artifact_count from listArtifacts (0 when none written)", () => {
+    seedExperimentRich(
+      "exp-with-artifacts",
+      { status: "running" },
+      { artifacts: ["vitest.junit.xml", "trace.zip"] }
+    );
+    seedExperimentRich("exp-no-artifacts", { status: "running" });
+    const report = compareExperiments(tdd, "F1");
+    const bySlug = Object.fromEntries(report.rows.map((r) => [r.experiment_slug, r]));
+    expect(bySlug["exp-with-artifacts"].artifact_count).toBe(2);
+    expect(bySlug["exp-no-artifacts"].artifact_count).toBe(0);
+  });
+
+  it("each row carries duration_ms when runtime.json is written", () => {
+    seedExperimentRich("exp-timed", { status: "succeeded", tests_passed: 1 }, { durationMs: 12345 });
+    seedExperimentRich("exp-untimed", { status: "running" });
+    const report = compareExperiments(tdd, "F1");
+    const bySlug = Object.fromEntries(report.rows.map((r) => [r.experiment_slug, r]));
+    expect(bySlug["exp-timed"].duration_ms).toBe(12345);
+    expect(bySlug["exp-untimed"].duration_ms).toBeUndefined();
+  });
+
+  it("rows include by_tag when the experiment reported a tag breakdown", () => {
+    seedExperimentRich("exp-tagged", {
+      status: "running",
+      tests_passed: 4,
+      tests_failed: 1,
+      by_tag: {
+        api: { passed: 3, failed: 0 },
+        e2e: { passed: 1, failed: 1 },
+      },
+    });
+    const report = compareExperiments(tdd, "F1");
+    expect(report.rows[0].by_tag).toEqual({
+      api: { passed: 3, failed: 0 },
+      e2e: { passed: 1, failed: 1 },
+    });
+  });
+
+  it("matrix has one row per tag any experiment reported, with per-experiment cells", () => {
+    seedExperimentRich("exp-a", {
+      status: "running",
+      by_tag: { api: { passed: 5, failed: 0 }, e2e: { passed: 1, failed: 1 } },
+    });
+    seedExperimentRich("exp-b", {
+      status: "running",
+      by_tag: { api: { passed: 3, failed: 2 }, infra: { passed: 1, failed: 0 } },
+    });
+    const report = compareExperiments(tdd, "F1");
+    expect(report.matrix.map((m) => m.tag)).toEqual(["api", "e2e", "infra"]);
+
+    const api = report.matrix.find((m) => m.tag === "api")!;
+    expect(api.cells["exp-a"]).toEqual({ passed: 5, failed: 0 });
+    expect(api.cells["exp-b"]).toEqual({ passed: 3, failed: 2 });
+
+    const e2e = report.matrix.find((m) => m.tag === "e2e")!;
+    expect(e2e.cells["exp-a"]).toEqual({ passed: 1, failed: 1 });
+    expect(e2e.cells["exp-b"]).toBeNull(); // exp-b reported no e2e
+
+    const infra = report.matrix.find((m) => m.tag === "infra")!;
+    expect(infra.cells["exp-a"]).toBeNull();
+    expect(infra.cells["exp-b"]).toEqual({ passed: 1, failed: 0 });
+  });
+
+  it("matrix is empty when no experiment reported per-tag outcomes", () => {
+    seedExperimentRich("exp-flat", { status: "running", tests_passed: 5 });
+    const report = compareExperiments(tdd, "F1");
+    expect(report.matrix).toEqual([]);
+  });
+});

--- a/tests/bdd/tdd-design-spec-gate.test.ts
+++ b/tests/bdd/tdd-design-spec-gate.test.ts
@@ -36,7 +36,7 @@ describe("design-spec-gate", () => {
     writeMasterTestList(tdd, {
       feature_id: "F1",
       items: [
-        { id: "T1", description: "either postgres arrays or json blob — decide", ac_id: "AC1", status: "pending" },
+        { id: "T1", description: "either postgres arrays or json blob – decide", ac_id: "AC1", status: "pending" },
         { id: "T2", description: "consider whether to denormalize", ac_id: "AC1", status: "pending" },
         { id: "T3", description: "happy path", ac_id: "AC2", status: "pending" },
       ],

--- a/tests/bdd/tdd-experiment-lifecycle.test.ts
+++ b/tests/bdd/tdd-experiment-lifecycle.test.ts
@@ -10,7 +10,15 @@ import {
   cutExperiment,
 } from "../../scripts/tdd/experiment";
 
-const LIVE = process.env.LAKEBASE_TEST_E2E === "1" && !!process.env.DATABRICKS_HOST;
+// LIVE gate must include LAKEBASE_TEST_PROJECT_PATH because the live test
+// body REQUIRES it (throws "LAKEBASE_TEST_PROJECT_PATH required for live
+// test" otherwise). Previously the gate accepted E2E+HOST alone, so a run
+// with E2E=1 but no PROJECT_PATH would enable the describe and the test
+// body would throw — surfacing as a hard FAIL instead of a clean SKIP.
+const LIVE =
+  process.env.LAKEBASE_TEST_E2E === "1" &&
+  !!process.env.DATABRICKS_HOST &&
+  !!process.env.LAKEBASE_TEST_PROJECT_PATH;
 
 let tdd: string;
 

--- a/tests/bdd/tdd-experiment-lifecycle.test.ts
+++ b/tests/bdd/tdd-experiment-lifecycle.test.ts
@@ -10,15 +10,15 @@ import {
   cutExperiment,
 } from "../../scripts/tdd/experiment";
 
-// LIVE gate must include LAKEBASE_TEST_PROJECT_PATH because the live test
-// body REQUIRES it (throws "LAKEBASE_TEST_PROJECT_PATH required for live
-// test" otherwise). Previously the gate accepted E2E+HOST alone, so a run
-// with E2E=1 but no PROJECT_PATH would enable the describe and the test
-// body would throw – surfacing as a hard FAIL instead of a clean SKIP.
+// LIVE gate uses LAKEBASE_TEST_INSTANCE (the bare project id; substrate's
+// `instance: string` parameter shape). Previously the test gated on
+// LAKEBASE_TEST_PROJECT_PATH and fed that into `instance`, double-prefixing
+// to "projects/projects/<id>" once branch-utils' projectPath() helper ran.
+// Bare instance is the right consumer shape (see scripts/lakebase/branch-utils.ts).
 const LIVE =
   process.env.LAKEBASE_TEST_E2E === "1" &&
   !!process.env.DATABRICKS_HOST &&
-  !!process.env.LAKEBASE_TEST_PROJECT_PATH;
+  !!process.env.LAKEBASE_TEST_INSTANCE;
 
 let tdd: string;
 
@@ -142,17 +142,15 @@ describe("experiment lifecycle (hermetic)", () => {
 
 const liveDescribe = LIVE ? describe : describe.skip;
 
-liveDescribe("experiment lifecycle (live – LAKEBASE_TEST_E2E=1)", () => {
-  const projectPath = process.env.LAKEBASE_TEST_PROJECT_PATH;
-  const profile = process.env.LAKEBASE_TEST_PROFILE || "DEFAULT";
+liveDescribe("experiment lifecycle (live, LAKEBASE_TEST_E2E=1)", () => {
+  const instance = process.env.LAKEBASE_TEST_INSTANCE;
   const parentBranch = process.env.LAKEBASE_TEST_PARENT || "staging";
 
   it("cuts and tears down a real feature branch + on-disk record", async () => {
-    if (!projectPath) throw new Error("LAKEBASE_TEST_PROJECT_PATH required for live test");
+    if (!instance) throw new Error("LAKEBASE_TEST_INSTANCE required for live test");
     const slug = `exp-test-${Date.now()}`;
     const rec = await cutExperiment({
-      instance: projectPath || "test-project",
-      
+      instance,
       tddDir: tdd,
       featureId: "F1",
       experimentSlug: slug,
@@ -165,8 +163,7 @@ liveDescribe("experiment lifecycle (live – LAKEBASE_TEST_E2E=1)", () => {
     expect(existsSync(join(rec.dir, "timeline.json"))).toBe(true);
     expect(rec.branch_id).toBeTruthy();
     await deleteExperiment({
-      instance: projectPath || "test-project",
-      
+      instance,
       tddDir: tdd,
       featureId: "F1",
       experimentSlug: slug,

--- a/tests/bdd/tdd-experiment-lifecycle.test.ts
+++ b/tests/bdd/tdd-experiment-lifecycle.test.ts
@@ -14,7 +14,7 @@ import {
 // body REQUIRES it (throws "LAKEBASE_TEST_PROJECT_PATH required for live
 // test" otherwise). Previously the gate accepted E2E+HOST alone, so a run
 // with E2E=1 but no PROJECT_PATH would enable the describe and the test
-// body would throw — surfacing as a hard FAIL instead of a clean SKIP.
+// body would throw – surfacing as a hard FAIL instead of a clean SKIP.
 const LIVE =
   process.env.LAKEBASE_TEST_E2E === "1" &&
   !!process.env.DATABRICKS_HOST &&
@@ -142,7 +142,7 @@ describe("experiment lifecycle (hermetic)", () => {
 
 const liveDescribe = LIVE ? describe : describe.skip;
 
-liveDescribe("experiment lifecycle (live — LAKEBASE_TEST_E2E=1)", () => {
+liveDescribe("experiment lifecycle (live – LAKEBASE_TEST_E2E=1)", () => {
   const projectPath = process.env.LAKEBASE_TEST_PROJECT_PATH;
   const profile = process.env.LAKEBASE_TEST_PROFILE || "DEFAULT";
   const parentBranch = process.env.LAKEBASE_TEST_PARENT || "staging";

--- a/tests/bdd/tdd-experiment-lifecycle.test.ts
+++ b/tests/bdd/tdd-experiment-lifecycle.test.ts
@@ -52,6 +52,55 @@ describe("experiment lifecycle (hermetic)", () => {
     expect(round?.tests_passed).toBe(12);
   });
 
+  it("writeOutcomes round-trips the per-tag breakdown (api/e2e/infra)", () => {
+    const dir = join(tdd, "experiments", "F1", "exp-tags");
+    mkdirSync(dir, { recursive: true });
+    writeOutcomes(tdd, "F1", "exp-tags", {
+      status: "running",
+      tests_passed: 7,
+      tests_failed: 2,
+      by_tag: {
+        api: { passed: 5, failed: 0 },
+        e2e: { passed: 1, failed: 2 },
+        infra: { passed: 1, failed: 0 },
+      },
+    });
+    const round = readOutcomes(tdd, "F1", "exp-tags");
+    expect(round?.by_tag?.api).toEqual({ passed: 5, failed: 0 });
+    expect(round?.by_tag?.e2e).toEqual({ passed: 1, failed: 2 });
+    expect(round?.by_tag?.infra).toEqual({ passed: 1, failed: 0 });
+    // Top-level totals stay authoritative; the breakdown does not have to sum.
+    expect(round?.tests_passed).toBe(7);
+    expect(round?.tests_failed).toBe(2);
+  });
+
+  it("by_tag entries are individually optional (partial reporting is valid)", () => {
+    const dir = join(tdd, "experiments", "F1", "exp-partial");
+    mkdirSync(dir, { recursive: true });
+    writeOutcomes(tdd, "F1", "exp-partial", {
+      status: "running",
+      tests_passed: 3,
+      by_tag: { api: { passed: 3, failed: 0 } },
+    });
+    const round = readOutcomes(tdd, "F1", "exp-partial");
+    expect(round?.by_tag?.api).toEqual({ passed: 3, failed: 0 });
+    expect(round?.by_tag?.e2e).toBeUndefined();
+    expect(round?.by_tag?.infra).toBeUndefined();
+  });
+
+  it("by_tag is omitted entirely when no tag breakdown is reported (backwards compatible)", () => {
+    const dir = join(tdd, "experiments", "F1", "exp-no-tags");
+    mkdirSync(dir, { recursive: true });
+    writeOutcomes(tdd, "F1", "exp-no-tags", {
+      status: "succeeded",
+      tests_passed: 4,
+      tests_failed: 0,
+    });
+    const round = readOutcomes(tdd, "F1", "exp-no-tags");
+    expect(round?.by_tag).toBeUndefined();
+    expect(round?.tests_passed).toBe(4);
+  });
+
   it("deleteExperiment preserves on-disk record when deleteBranchToo is false", async () => {
     const dir = join(tdd, "experiments", "F1", "exp-1");
     mkdirSync(dir, { recursive: true });

--- a/tests/bdd/tdd-hard-rules.test.ts
+++ b/tests/bdd/tdd-hard-rules.test.ts
@@ -32,7 +32,7 @@ describe("lakebase-tdd-workflows hard rules", () => {
     expect(readme).toMatch(/^##\s+How to use/m);
     // Flow 1: spec authoring + drift validation.
     expect(readme).toMatch(/Author a feature spec/i);
-    // Flow 2: N=1 default — lead with feature-oriented language.
+    // Flow 2: N=1 default – lead with feature-oriented language.
     expect(readme).toMatch(/Build a feature end-to-end/i);
     expect(readme).toMatch(/N=1 default/i);
     // Flow 3: N>=2 parallel experiments.
@@ -55,7 +55,7 @@ describe("lakebase-tdd-workflows hard rules", () => {
 
   for (const phrase of NINE_RULES_PHRASES) {
     it(`SKILL.md hard rules include: "${phrase}"`, () => {
-      // Rule content match is case-insensitive — sentence-start capitalization is incidental,
+      // Rule content match is case-insensitive – sentence-start capitalization is incidental,
       // the rule wording itself is what matters.
       expect(skill.toLowerCase()).toContain(phrase.toLowerCase());
     });

--- a/tests/bdd/tdd-orchestrator-e2e.test.ts
+++ b/tests/bdd/tdd-orchestrator-e2e.test.ts
@@ -22,7 +22,7 @@ afterEach(() => {
   rmSync(tdd, { recursive: true, force: true });
 });
 
-describe("orchestrator e2e (hermetic — stubbed Navigator + Driver, real script primitives)", () => {
+describe("orchestrator e2e (hermetic – stubbed Navigator + Driver, real script primitives)", () => {
   it("walks phases 0 -> 1 -> 2 -> 3 -> 4 with HITL-recorded gates and persists every artifact", () => {
     // --- Phase 0: Discovery ---
     writeWorkflowState(tdd, { phase: "discovery", started_at: new Date().toISOString() });
@@ -86,7 +86,7 @@ describe("orchestrator e2e (hermetic — stubbed Navigator + Driver, real script
     expect(existsSync(join(tdd, "features", "F1", "plan.json"))).toBe(true);
     expect(readFileSync(join(tdd, "selection-log.md"), "utf8")).toContain("Experiment plan for F1");
 
-    // HITL Gate 4 approval — transition to implementation
+    // HITL Gate 4 approval – transition to implementation
     writeWorkflowState(tdd, {
       phase: "implementation",
       feature_id: "F1",
@@ -113,7 +113,7 @@ describe("orchestrator e2e (hermetic — stubbed Navigator + Driver, real script
     expect(cycles.length).toBe(2);
     expect(cycles.every((c) => c.green_at)).toBe(true);
 
-    // Smell detection runs after every cycle pair — no smells expected for a clean run
+    // Smell detection runs after every cycle pair – no smells expected for a clean run
     const hits = runDetectorsForScope(tdd, scope);
     expect(hits).toEqual([]);
     writeSmellsLog(tdd, hits);
@@ -147,7 +147,7 @@ describe("orchestrator e2e (hermetic — stubbed Navigator + Driver, real script
 
 const liveDescribe = LIVE ? describe : describe.skip;
 
-liveDescribe("orchestrator e2e (live — LAKEBASE_TEST_E2E=1)", () => {
+liveDescribe("orchestrator e2e (live – LAKEBASE_TEST_E2E=1)", () => {
   it("end-to-end smoke: branch primitive available + getConnection resolves", async () => {
     // The hermetic test exercises the orchestration shape; the live tier asserts that
     // the Lakebase-backed primitives the orchestrator depends on resolve in a real env.

--- a/tests/bdd/tdd-parallel-runner.test.ts
+++ b/tests/bdd/tdd-parallel-runner.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  runExperimentsInParallel,
+  type ExperimentRunInput,
+} from "../../scripts/tdd/parallel-runner";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function inputs(count: number, slugPrefix = "exp"): ExperimentRunInput[] {
+  return Array.from({ length: count }, (_, i) => ({ slug: `${slugPrefix}-${i + 1}` }));
+}
+
+describe("runExperimentsInParallel", () => {
+  it("runs every input and produces one result per experiment", async () => {
+    const { results } = await runExperimentsInParallel({
+      experiments: inputs(5),
+      concurrency: 2,
+      runner: async (input) => `ran ${input.slug}`,
+    });
+    expect(results).toHaveLength(5);
+    expect(new Set(results.map((r) => r.slug))).toEqual(
+      new Set(["exp-1", "exp-2", "exp-3", "exp-4", "exp-5"])
+    );
+    for (const r of results) {
+      expect(r.status).toBe("succeeded");
+      if (r.status === "succeeded") {
+        expect(r.value).toBe(`ran ${r.slug}`);
+      }
+    }
+  });
+
+  it("honors the concurrency cap (peak_in_flight <= cap)", async () => {
+    let observedPeak = 0;
+    let inFlight = 0;
+    const { peak_in_flight } = await runExperimentsInParallel({
+      experiments: inputs(8),
+      concurrency: 3,
+      runner: async () => {
+        inFlight++;
+        if (inFlight > observedPeak) observedPeak = inFlight;
+        await sleep(20);
+        inFlight--;
+        return null;
+      },
+    });
+    expect(observedPeak).toBeLessThanOrEqual(3);
+    expect(peak_in_flight).toBeLessThanOrEqual(3);
+    expect(peak_in_flight).toBeGreaterThanOrEqual(2); // proves it parallelizes
+  });
+
+  it("a failure in one experiment does not abort the others", async () => {
+    const { results } = await runExperimentsInParallel({
+      experiments: inputs(4),
+      concurrency: 2,
+      runner: async (input) => {
+        if (input.slug === "exp-2") throw new Error("boom on exp-2");
+        return input.slug;
+      },
+    });
+    expect(results).toHaveLength(4);
+    const bySlug = Object.fromEntries(results.map((r) => [r.slug, r]));
+    expect(bySlug["exp-1"].status).toBe("succeeded");
+    expect(bySlug["exp-2"].status).toBe("failed");
+    if (bySlug["exp-2"].status === "failed") {
+      expect(bySlug["exp-2"].error.message).toBe("boom on exp-2");
+    }
+    expect(bySlug["exp-3"].status).toBe("succeeded");
+    expect(bySlug["exp-4"].status).toBe("succeeded");
+  });
+
+  it("each result carries duration_ms", async () => {
+    const { results, total_duration_ms } = await runExperimentsInParallel({
+      experiments: inputs(2),
+      concurrency: 2,
+      runner: async () => {
+        await sleep(10);
+        return null;
+      },
+    });
+    for (const r of results) {
+      expect(r.duration_ms).toBeGreaterThanOrEqual(0);
+    }
+    expect(total_duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("empty experiment list returns empty results without invoking the runner", async () => {
+    let invoked = false;
+    const { results, peak_in_flight } = await runExperimentsInParallel({
+      experiments: [],
+      concurrency: 4,
+      runner: async () => {
+        invoked = true;
+        return null;
+      },
+    });
+    expect(results).toEqual([]);
+    expect(peak_in_flight).toBe(0);
+    expect(invoked).toBe(false);
+  });
+
+  it("concurrency=1 forces sequential execution (peak_in_flight === 1)", async () => {
+    const { peak_in_flight } = await runExperimentsInParallel({
+      experiments: inputs(4),
+      concurrency: 1,
+      runner: async () => {
+        await sleep(5);
+        return null;
+      },
+    });
+    expect(peak_in_flight).toBe(1);
+  });
+
+  it("rejects concurrency < 1", async () => {
+    await expect(
+      runExperimentsInParallel({
+        experiments: inputs(2),
+        concurrency: 0,
+        runner: async () => null,
+      })
+    ).rejects.toThrow(/concurrency must be >= 1/);
+  });
+
+  it("forwards experiment context through to the runner", async () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    await runExperimentsInParallel({
+      experiments: [
+        { slug: "exp-pg", context: { strategy: "postgres-arrays" } },
+        { slug: "exp-json", context: { strategy: "json-blob" } },
+      ],
+      concurrency: 2,
+      runner: async (input) => {
+        seen.push(input.context);
+        return null;
+      },
+    });
+    const strategies = new Set(seen.map((c) => c?.strategy));
+    expect(strategies).toEqual(new Set(["postgres-arrays", "json-blob"]));
+  });
+});

--- a/tests/bdd/tdd-run-cycle.test.ts
+++ b/tests/bdd/tdd-run-cycle.test.ts
@@ -95,7 +95,7 @@ describe("run-cycle (hermetic)", () => {
 
 const liveDescribe = LIVE ? describe : describe.skip;
 
-liveDescribe("run-cycle (live — LAKEBASE_TEST_E2E=1)", () => {
+liveDescribe("run-cycle (live – LAKEBASE_TEST_E2E=1)", () => {
   it("openBranchDsn returns a DSN that resolves to the experiment branch", async () => {
     const instance = process.env.LAKEBASE_TEST_INSTANCE!;
     const branch = process.env.LAKEBASE_TEST_BRANCH!;

--- a/tests/bdd/tdd-synthesis.test.ts
+++ b/tests/bdd/tdd-synthesis.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   rmSync(tdd, { recursive: true, force: true });
 });
 
-describe("synthesizeExperiments (hermetic — pre-cut validation + on-disk side effects)", () => {
+describe("synthesizeExperiments (hermetic – pre-cut validation + on-disk side effects)", () => {
   it("throws when hitlApproved is false", async () => {
     await expect(
       synthesizeExperiments({
@@ -102,7 +102,7 @@ describe("synthesizeExperiments (hermetic — pre-cut validation + on-disk side 
         approverEmail: "kevin@example.com",
       });
     } catch {
-      // Expected when not running live — cutExperiment will reach for Lakebase and fail.
+      // Expected when not running live – cutExperiment will reach for Lakebase and fail.
       // The on-disk side effects (decision + spec subtree + selection-log) happen first
       // and are what we assert here.
     }
@@ -123,7 +123,7 @@ describe("synthesizeExperiments (hermetic — pre-cut validation + on-disk side 
 
 const liveDescribe = LIVE ? describe : describe.skip;
 
-liveDescribe("synthesizeExperiments (live — LAKEBASE_TEST_E2E=1)", () => {
+liveDescribe("synthesizeExperiments (live – LAKEBASE_TEST_E2E=1)", () => {
   it("cuts a fresh branch for the renegotiated cycle", async () => {
     seedFeature();
     seedExperiment("exp-a");

--- a/tests/integration/detect-language-via-self-hosted-runner.test.ts
+++ b/tests/integration/detect-language-via-self-hosted-runner.test.ts
@@ -16,12 +16,15 @@
 //   7. Asserts the run concluded "success" and the detect-lang step output
 //      is "python".
 //
-// Teardown contract (mirrors the user's standing rule "never teardown on
+// Teardown contract (mirrors the kit's standing rule "never teardown on
 // failure"):
 //   - On assertion PASS: deregister runner + delete repo.
 //   - On assertion FAIL: leave runner + repo intact, print recovery
 //     commands.
-//   - LAKEBASE_TEST_NO_TEARDOWN=1 forces leave-intact regardless.
+// Note: LAKEBASE_TEST_NO_TEARDOWN governs Lakebase-project lifecycle
+// across the orchestrator; it does NOT preserve this test's GitHub
+// ephemera. To preserve runner+repo for inspection, kill the test
+// mid-flight (the assertion never sets allPassed=true).
 //
 // Gating:
 //   LAKEBASE_TEST_E2E_GITHUB=1   must be set; suite skips otherwise.
@@ -46,7 +49,6 @@ import { resolveGitHubToken } from "../../scripts/github/auth.js";
 import { setupRunner, removeRunner } from "../../scripts/lakebase/runner-setup.js";
 
 const E2E = process.env.LAKEBASE_TEST_E2E_GITHUB === "1";
-const NO_TEARDOWN = process.env.LAKEBASE_TEST_NO_TEARDOWN === "1";
 const KIT_VERSION = "v0.3.0-alpha.20";
 
 function timestamp(): string {
@@ -166,9 +168,9 @@ describe.skipIf(!E2E)(
     }, 6 * 60_000);
 
     afterAll(async () => {
-      if (!allPassed || NO_TEARDOWN) {
+      if (!allPassed) {
         console.log("");
-        console.log("[LEAVE-INTACT] Skipping teardown (test failed or NO_TEARDOWN set).");
+        console.log("[LEAVE-INTACT] Skipping teardown (test failed).");
         console.log("         To clean up manually:");
         console.log(`           gh repo delete ${fullRepoName} --yes`);
         console.log(
@@ -177,6 +179,8 @@ describe.skipIf(!E2E)(
         );
         return;
       }
+      console.log("");
+      console.log("[TEARDOWN] Test passed, deregistering runner + deleting repo.");
 
       try {
         await removeRunner({ fullRepoName, projectName });


### PR DESCRIPTION
## Summary

Foundation work for FEIP-7092 (branch test runner) plus **collateral substrate hardening** surfaced during a real-Lakebase end-to-end exercise of the surface. Substrate weaknesses were uncovered iteratively as the parallel runner exercised gated paths; each fix is in its own commit and gated by green hermetic + live tests.

### Original scope (4 slices)

- Per-tag outcomes shape on `ExperimentOutcomes` (api / e2e / infra to {passed, failed}); backwards compatible (totals stay authoritative).
- Per-cycle artifact persistence: `writeArtifact` / `listArtifacts` / `readArtifact` over `.tdd/experiments/<F>/<exp>/artifacts/<cycle-id>/<name>`. Path-traversal guarded.
- Bounded-concurrency parallel runner: `runExperimentsInParallel<T>` with hard concurrency cap, fail-isolation per experiment, peak-in-flight tracking, per-experiment duration measurement.
- Structured `compareExperiments` payload: per-row `by_tag` + `cycle_count` + `artifact_count` + `duration_ms`; new `matrix` (tag x experiment cells) ready for FEIP-7208's renderer.

### Collateral substrate hardening (commit `bdfc40a`)

Three substrate gaps surfaced when this PR's surface was exercised end-to-end against a real Lakebase project. All are pre-existing concerns hermetic tests didn't catch; live `list-branches` / `create-branch` responses exposed them.

**Branch identifier (uid vs name) confusion.** A Lakebase branch has TWO identifiers and they are NOT interchangeable in the API. `getDefaultBranchId` violated the kit's own contract by preferring `def.uid` over the leaf of `def.name`, causing a confusing "branch id not found" error from the service. Fixes:
- new `scripts/lakebase/branch-id.ts`: branded `BranchName` / `BranchUid` types + `asBranchName` / `asBranchUid` validators + `branchNameFromResourcePath` leaf extractor
- `getDefaultBranchId` to `getDefaultBranchName`, returning `BranchName | null` derived from leaf-of-name (never uid); old name kept as `@deprecated` shim that also returns the name string
- `LakebaseBranchInfo.uid` typed `BranchUid`; new `nameLeaf: BranchName` field
- runtime guard in `createBranch.parentBranch` rejects uid-shaped input with a typed `LakebaseBranchError`
- `parseBranch` funnels through the validators

**Workspace TTL policy.** Some workspaces enforce a tighter maximum-expiration policy than the PSA convention's 30-day feature TTL. Substrate now wraps the CLI's opaque "expiration time exceeds the maximum expiration time" error with a typed `LakebaseBranchTtlTooLongError` naming the attempted TTL + the override paths.

**`create-project.test.ts` hardcoded placeholder host.** The E2E test fell back to `https://workspace.cloud.databricks.com` (DNS fails) when `LAKEBASE_TEST_HOST` was unset. Added a `resolveTestHost()` helper that prefers the explicit env, then `databricks auth env --profile $DATABRICKS_CONFIG_PROFILE`. Documented skip block parallels the existing `skip-when-e2e-disabled`. Same test: `.env` contract updated to match the substrate's deliberate `deployEnv()` seeding (avoids the gated-hook chicken-and-egg).

**Per-test timeouts on 2 live-pg-pair tests.** `queryBranchSchema(uid) === queryBranchSchema(branchId)` and `get-connection-equivalence` each do two live pg connections back-to-back; the 5s vitest default is tight under parallel-suite load. Bumped to 30s with comments (legitimate per-test budget, not a workaround).

### Additional substrate work landed during live iteration

Each addressed a contributor-actionable friction that surfaced when running the kit's full suite against a real workspace. Bundled here because each was uncovered by debugging the same parallel-runner E2E.

**`kit-config.ts` centralization** (`cd6cc1a`, `ffbc788`). Single source of truth for every timeout the substrate scatters across files (CLI budgets, READY waits, pg connect/statement, git ops, convention branch TTLs) and the public package-registry URLs (Maven Central, Spring Initializr). All env-overridable via `LAKEBASE_KIT_TIMEOUT_*` / `LAKEBASE_KIT_REGISTRY_*` / `LAKEBASE_KIT_*_BRANCH_TTL_MS`.

**`.env.template.config` / `.env.local.config` pattern** (`9359fa8`). Two-file env-config layering: `.env.template.config` (committed) carries public-default values; `.env.local.config` (gitignored) carries local overrides (corp proxies, workspace-tighter TTL caps). Live driver sources template first, then local, so local values win.

**Shared substrate constants** (`17941d6`). `POSTGRES_PORT`, `DEFAULT_DATABASE`, `DEFAULT_ENDPOINT` lifted to `scripts/lakebase/constants.ts`; tests + scripts no longer redefine.

**`run-all-live-tests.sh` orchestrator** (`22fb0df`, `3a11d8d`, `57f491c`, `4e30055`). One-command driver: auto-provisions a Lakebase project, builds dist, runs vitest with every env-gated describe unlocked, prints a recovery summary. CLI flags replace every inline literal (`--profile`, `--project`, `--branch`, `--parent`, `--project-prefix`, `--grace-seconds`, `--database`, `--feature-ttl-days`, `--teardown`, `--no-prompt`, `--no-github-runner`, `--no-migrate-tools`). Provisions `.venv-live-tests/` (alembic + sqlalchemy + psycopg2-binary) and downloads Flyway CLI on demand. Defaults to enabled coverage of the FEIP-7138 self-hosted-runner suite (opt out via `--no-github-runner`).

**Convention parent-branch fallback** (`64124fb`). `createBranch` now probes whether the requested `parentBranch` exists on the target project; falls back to the project's default branch (and emits a stderr warning) when it doesn't. Pass `strictParent: true` to opt out and have the original error surface.

**No-skip kit-config tests** (`4e30055`). `tests/bdd/kit-config.test.ts` restructured to load the module under a controlled env (`vi.resetModules()` + scoped scrub-and-restore). 18 conditional tests (`skipIf` when env override active) became 22 unconditional tests that run regardless of host process inheritance.

**Bug fixes from this session**:
- `tdd-experiment-lifecycle` path/instance confusion (`be912b2`): the live describe was gating on `LAKEBASE_TEST_PROJECT_PATH` and feeding that to cutExperiment's `instance` arg, double-prefixing to `projects/projects/<id>`. Substrate's `instance: string` is the bare id; gate + consume `LAKEBASE_TEST_INSTANCE` directly.
- FEIP-7138 always-LEAVE-INTACT (`3217b71`): self-hosted-runner test was preserving its GitHub ephemera on every run because it conflated the orchestrator-level `LAKEBASE_TEST_NO_TEARDOWN` flag (Lakebase project preservation) with its own per-test teardown decision. Green tests now self-clean repo + runner; failed tests still preserve.

**Language polish** (`dffb383`, `6a25290`). Substrate + tests + docs prose normalization.

## Slice breakdown (FEIP-7092 core)

| Slice | Surface | Commit |
|---|---|---|
| 1 | `ExperimentOutcomes.by_tag` + ExperimentTag / TagOutcome types | 5c72108 |
| 2 | `scripts/tdd/artifacts.ts` (new): write/list/read primitives | 35a545c |
| 3 | `scripts/tdd/parallel-runner.ts` (new): bounded concurrency | 9321c5c |
| 4 | `compareExperiments` structured payload (rows + matrix) | 0a57f40 |
| Collateral | branch-id branded types + workspace-TTL handling | bdfc40a |

## Live verification (latest run, 2026-05-30)

Live driver `bash scripts/run-all-live-tests.sh --profile fevm-serverless-stable-ecparr --no-prompt`:

- **Test Files: 71 / 71 passed**, 0 skipped
- **Tests: 477 / 477 passed**, 0 skipped, 0 failed
- Duration: ~82s (cached venv + Flyway from prior runs)
- Every gated suite activates: migrate-live (alembic), migrate-live-flyway, tdd-synthesis, tdd-experiment-lifecycle live describe, FEIP-7138 self-hosted-runner end-to-end
- FEIP-7138 self-cleans on green (`[TEARDOWN] Test passed, deregistering runner + deleting repo.`)
- All test artifacts torn down post-verification: 0 leftover Lakebase test projects, 0 GitHub repos, 0 runner dirs

Earlier driver runs against the same workspace verified the original FEIP-7092 surface end-to-end:

- 3 fresh Lakebase projects provisioned across the session, 2 child branches cut in parallel via `runExperimentsInParallel`, peak_in_flight=2, wall 7.5s
- `compareExperiments` matrix populated across all 3 tags: `[api]` both pass 3p/0f; `[e2e]` exp-pg wins 1p/0f vs exp-json 1p/1f; `[infra]` exp-pg has data, exp-json null. `signal=winning` correctly inferred for exp-pg
- Artifacts persisted (Playwright trace + vitest junit per experiment, listed via `listArtifacts`)
- `recommendation=continue` correct given 1 winning + 1 running

## Test plan

- [x] `npm run typecheck` clean
- [x] Hermetic suite: 433 passed, 44 skipped, 0 failed
- [x] Live env-gated suite (`run-all-live-tests.sh`): 477 passed, 0 skipped, 0 failed
- [x] `npm run build` clean
- [x] FEIP-7138 self-hosted-runner test passes end-to-end and self-cleans
- [x] Manual: live driver against real Lakebase exercises slices 1-4 end-to-end

## Composition with sibling PRs / tickets

- **FEIP-7094** (Playwright E2E end-to-end): will populate `by_tag.e2e` from the Driver's tag-aware runner. Slice 1's shape is the contract that the Driver writes to.
- **FEIP-7208** (comparison-report renderer): consumes the `matrix` + per-row `by_tag` + `artifact_count` to render the promote-vs-synthesize HITL decision aid.
- **FEIP-7215** (`lakebase-feature-status`, PR #47): can surface per-tag info once it merges + this lands; minor follow-up to enhance the renderer.

This pull request and its description were written by Isaac.