### PR TITLE
feat: resolveDatabricksHost substrate primitive (FEIP-7130 follow-up)

### DIFF
--- a/scripts/lakebase/databricks-host.ts
+++ b/scripts/lakebase/databricks-host.ts
@@ -1,0 +1,65 @@
+// Resolve the workspace host URL for a Databricks CLI profile.
+//
+// The CLI's older `databricks auth env --profile <p>` was deprecated in
+// v1.1.0 in favor of `databricks auth describe --profile <p> -o json`.
+// substrate's resolveDatabricksHost uses the new shape; consumers that
+// previously shelled out to `auth env` should switch to this primitive
+// to keep working on the upgraded CLI.
+//
+// Returns the host without trailing slash (e.g. `https://fevm-...cloud.databricks.com`).
+// Returns undefined for unknown profiles or parse failures; throws only
+// on infrastructure failures (CLI not on PATH, timeout). The CLI may
+// prefix the JSON output with warning / auth-error lines (e.g. when the
+// token cache is invalidated by a CLI upgrade); we tolerate that by
+// trimming to the first `{` before parsing.
+
+import { exec } from "../util/exec.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
+
+export interface ResolveDatabricksHostArgs {
+  /** Databricks CLI profile from ~/.databrickscfg. */
+  profile: string;
+  /** Override the per-call timeout. Default: KIT_TIMEOUTS.cliDefault. */
+  timeoutMs?: number;
+}
+
+/**
+ * Resolve the workspace host URL for the named profile via
+ * `databricks auth describe -o json`. Returns the host string without
+ * trailing slash, or undefined when the profile is unknown or the
+ * response is unparseable.
+ */
+export async function resolveDatabricksHost(
+  args: ResolveDatabricksHostArgs
+): Promise<string | undefined> {
+  const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
+  const out = await exec(
+    `databricks auth describe --profile "${escapeShellArg(args.profile)}" -o json`,
+    { timeout: timeoutMs }
+  );
+  return parseHostFromAuthDescribe(out);
+}
+
+/**
+ * Exposed for unit testing. Trims a non-JSON preamble (some CLI
+ * builds prefix a warning or auth-error line before the JSON payload),
+ * parses the JSON, and extracts `details.host`.
+ */
+export function parseHostFromAuthDescribe(out: string): string | undefined {
+  const start = out.indexOf("{");
+  if (start < 0) return undefined;
+  try {
+    const parsed = JSON.parse(out.slice(start)) as Record<string, unknown>;
+    const details = parsed.details;
+    if (!details || typeof details !== "object") return undefined;
+    const host = (details as Record<string, unknown>).host;
+    if (typeof host !== "string") return undefined;
+    return host.replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function escapeShellArg(s: string): string {
+  return s.replace(/"/g, '\\"');
+}

--- a/scripts/lakebase/index.ts
+++ b/scripts/lakebase/index.ts
@@ -9,6 +9,7 @@ export * from "./branch-create.js";
 export * from "./branch-delete.js";
 export * from "./convention-branches.js";
 export * from "./cut-backup.js";
+export * from "./databricks-host.js";
 export * from "./deploy-app-endpoint.js";
 export * from "./deploy-app-yaml.js";
 export * from "./deploy-credentials.js";

--- a/tests/bdd/databricks-host.test.ts
+++ b/tests/bdd/databricks-host.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  parseHostFromAuthDescribe,
+  resolveDatabricksHost,
+} from "../../scripts/lakebase/databricks-host";
+
+function hasCli(): boolean {
+  try {
+    execFileSync("databricks", ["--version"], { stdio: "ignore", timeout: 3_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const CLI_AVAILABLE = hasCli();
+const PROFILE = process.env.LAKEBASE_TEST_PROFILE;
+const RUN_LIVE = CLI_AVAILABLE && !!PROFILE;
+
+describe("parseHostFromAuthDescribe: pure parser", () => {
+  it("extracts host from a clean JSON payload", () => {
+    const input = JSON.stringify({
+      details: { host: "https://example.cloud.databricks.com" },
+    });
+    expect(parseHostFromAuthDescribe(input)).toBe("https://example.cloud.databricks.com");
+  });
+
+  it("strips a trailing slash", () => {
+    const input = JSON.stringify({
+      details: { host: "https://example.cloud.databricks.com/" },
+    });
+    expect(parseHostFromAuthDescribe(input)).toBe("https://example.cloud.databricks.com");
+  });
+
+  it("strips multiple trailing slashes", () => {
+    const input = JSON.stringify({
+      details: { host: "https://example.cloud.databricks.com///" },
+    });
+    expect(parseHostFromAuthDescribe(input)).toBe("https://example.cloud.databricks.com");
+  });
+
+  it("tolerates non-JSON preamble before the payload", () => {
+    // CLI builds may prefix a warning or auth-error line when the
+    // token cache is invalidated by a CLI upgrade; we trim to the
+    // first `{` and parse from there.
+    const input =
+      "Warning: 'databricks auth env' is deprecated and will be removed.\n" +
+      "Error: ignored\n" +
+      JSON.stringify({ details: { host: "https://example.cloud.databricks.com" } });
+    expect(parseHostFromAuthDescribe(input)).toBe("https://example.cloud.databricks.com");
+  });
+
+  it("returns undefined when no JSON is present", () => {
+    expect(parseHostFromAuthDescribe("error: no profile found")).toBeUndefined();
+    expect(parseHostFromAuthDescribe("")).toBeUndefined();
+  });
+
+  it("returns undefined when details.host is missing", () => {
+    expect(parseHostFromAuthDescribe(JSON.stringify({}))).toBeUndefined();
+    expect(parseHostFromAuthDescribe(JSON.stringify({ details: {} }))).toBeUndefined();
+    expect(
+      parseHostFromAuthDescribe(JSON.stringify({ details: { host: 42 } }))
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when JSON is malformed", () => {
+    expect(parseHostFromAuthDescribe("{ not really json")).toBeUndefined();
+  });
+});
+
+describe("resolveDatabricksHost: error contract", () => {
+  it("rejects when CLI is missing entirely", async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = "/nonexistent-bin";
+    try {
+      await expect(
+        resolveDatabricksHost({
+          profile: "any",
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow(/ENOENT|spawn|not found|failed/i);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  }, 10_000);
+});
+
+describe("resolveDatabricksHost: live", () => {
+  it.skipIf(!RUN_LIVE)("returns the host for a valid profile", async () => {
+    const host = await resolveDatabricksHost({ profile: PROFILE! });
+    expect(host).toBeTruthy();
+    expect(host!.startsWith("https://")).toBe(true);
+    expect(host!.endsWith("/")).toBe(false);
+  }, 30_000);
+
+  it("documents the skip reason when CLI or profile is missing", () => {
+    if (!CLI_AVAILABLE) {
+      console.log("databricks CLI not on PATH; live resolveDatabricksHost skipped.");
+    } else if (!PROFILE) {
+      console.log("LAKEBASE_TEST_PROFILE not set; live resolveDatabricksHost skipped.");
+    }
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Lifts the workspace-host resolution to substrate. Surfaced as a P1 follow-up to FEIP-7130 because the extension's existing `DeployService.resolveWorkspaceHost` still uses `databricks auth env`, which is deprecated in CLI v1.1.0 and now returns an error instead of the host JSON.

## What's added

`scripts/lakebase/databricks-host.ts` exports:

- **`resolveDatabricksHost({ profile, timeoutMs? }) => Promise<string | undefined>`**: wraps `databricks auth describe -o json` and parses `details.host`. Returns the host without trailing slash, or undefined for unknown profiles / malformed output. Throws only on infrastructure failures (CLI not on PATH).
- **`parseHostFromAuthDescribe(out) => string | undefined`**: exposed for unit testing. Tolerates a non-JSON preamble (some CLI builds prefix a warning or auth-error line before the JSON payload) by trimming to the first `{` before parsing.

## Why now

Discovered during FEIP-7130 slice 6's live verification: CLI v1.1.0 marks `auth env` deprecated and returns an error message when the token cache is invalidated by a CLI upgrade. `auth describe` is the canonical replacement and works even when auth state is broken (it reads the host string from ~/.databrickscfg directly).

The extension consumer migration ships as a separate follow-up PR (extension's `DeployService.resolveWorkspaceHost` becomes a one-line proxy over the substrate primitive).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Hermetic suite: 486 passed (+9 new tests), 60 skipped, 0 failed
- [x] Tests cover clean parse, trailing-slash strip, preamble tolerance, missing-fields, malformed-JSON, CLI-missing reject, live profile lookup

This pull request and its description were written by Isaac.