### PR TITLE
feat: Unity Catalog substrate primitives (P2 follow-up)

### DIFF
--- a/scripts/lakebase/index.ts
+++ b/scripts/lakebase/index.ts
@@ -33,6 +33,7 @@ export * from "./scaffold-language.js";
 export * from "./scaffold.js";
 export * from "./schema-diff.js";
 export * from "./spring-initializr.js";
+export * from "./uc-resources.js";
 export {
   applyMigrations,
   rollbackMigration,

--- a/scripts/lakebase/uc-resources.ts
+++ b/scripts/lakebase/uc-resources.ts
@@ -1,0 +1,239 @@
+// Unity Catalog resource management primitives.
+//
+// Lifted from the lakebase-scm-extension's bespoke DeployService UC
+// methods. Substrate wraps the Databricks Unity Catalog REST APIs
+// (`/api/2.1/unity-catalog/{catalogs,schemas,volumes,permissions}`)
+// behind a clean, callable surface so consumers don't shell out to
+// `databricks api get|post|patch` directly.
+//
+// Each primitive returns a structured result; the create primitives
+// are idempotent (existence check + conditional create), and the
+// permission grant matches the platform's standard CHANGES shape.
+
+import { exec } from "../util/exec.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
+
+const DEFAULT_CREATE_COMMENT = "Created by lakebase-app-dev-kit";
+
+export interface CatalogExistsArgs {
+  profile: string;
+  catalog: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Check whether a Unity Catalog catalog exists. Returns true on 200,
+ * false on 404 / RESOURCE_DOES_NOT_EXIST. Throws only on
+ * infrastructure failures (CLI not on PATH, timeout).
+ */
+export async function catalogExists(args: CatalogExistsArgs): Promise<boolean> {
+  const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
+  try {
+    await exec(
+      `databricks api get /api/2.1/unity-catalog/catalogs/${escapeShellArg(args.catalog)} --profile "${escapeShellArg(args.profile)}"`,
+      { timeout: timeoutMs }
+    );
+    return true;
+  } catch (err) {
+    if (isUcMissingError((err as Error).message)) return false;
+    throw err;
+  }
+}
+
+export interface TryCreateCatalogArgs {
+  profile: string;
+  catalog: string;
+  comment?: string;
+  timeoutMs?: number;
+}
+
+export interface TryCreateCatalogResult {
+  /** True iff the create POST returned successfully. False when the
+   *  workspace blocks programmatic catalog creation (Default Storage
+   *  workspaces, missing permissions, etc.); the caller can fall back
+   *  to an interactive flow. */
+  created: boolean;
+  /** Error message when create failed (for diagnostic surfacing). */
+  error?: string;
+}
+
+/**
+ * Try to create a Unity Catalog catalog. Returns `{ created: false,
+ * error }` (not a throw) on any failure path so the caller can decide
+ * whether to fall back to interactive creation or escalate.
+ */
+export async function tryCreateCatalog(args: TryCreateCatalogArgs): Promise<TryCreateCatalogResult> {
+  const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
+  const comment = args.comment ?? DEFAULT_CREATE_COMMENT;
+  const payload = JSON.stringify({ name: args.catalog, comment });
+  try {
+    await exec(
+      `databricks api post /api/2.1/unity-catalog/catalogs --profile "${escapeShellArg(args.profile)}" --json '${escapeSingleQuoted(payload)}'`,
+      { timeout: timeoutMs }
+    );
+    return { created: true };
+  } catch (err) {
+    return { created: false, error: (err as Error).message };
+  }
+}
+
+export interface EnsureSchemaAndVolumeArgs {
+  profile: string;
+  catalog: string;
+  schema: string;
+  volume: string;
+  /** Comment applied to newly created schema + volume. Ignored when
+   *  the resources already exist. */
+  comment?: string;
+  /** Volume type. Default: `MANAGED`. */
+  volumeType?: "MANAGED" | "EXTERNAL";
+  timeoutMs?: number;
+}
+
+export interface EnsureSchemaAndVolumeResult {
+  /** True iff this call created the schema (false if it pre-existed). */
+  schemaCreated: boolean;
+  /** True iff this call created the volume. */
+  volumeCreated: boolean;
+}
+
+/**
+ * Ensure a Unity Catalog schema + volume exist under the named catalog.
+ * Idempotent: existing schema/volume are left untouched. The catalog
+ * itself must exist (use `catalogExists` + `tryCreateCatalog` first).
+ */
+export async function ensureSchemaAndVolume(
+  args: EnsureSchemaAndVolumeArgs
+): Promise<EnsureSchemaAndVolumeResult> {
+  const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
+  const comment = args.comment ?? DEFAULT_CREATE_COMMENT;
+  const volumeType = args.volumeType ?? "MANAGED";
+  const { profile, catalog, schema, volume } = args;
+
+  // Schema
+  let schemaCreated = false;
+  let exists = await ucResourceExists(`/api/2.1/unity-catalog/schemas/${catalog}.${schema}`, profile, timeoutMs);
+  if (!exists) {
+    const payload = JSON.stringify({ name: schema, catalog_name: catalog, comment });
+    await exec(
+      `databricks api post /api/2.1/unity-catalog/schemas --profile "${escapeShellArg(profile)}" --json '${escapeSingleQuoted(payload)}'`,
+      { timeout: timeoutMs }
+    );
+    schemaCreated = true;
+  }
+
+  // Volume
+  let volumeCreated = false;
+  exists = await ucResourceExists(
+    `/api/2.1/unity-catalog/volumes/${catalog}.${schema}.${volume}`,
+    profile,
+    timeoutMs
+  );
+  if (!exists) {
+    const payload = JSON.stringify({
+      catalog_name: catalog,
+      schema_name: schema,
+      name: volume,
+      volume_type: volumeType,
+      comment,
+    });
+    await exec(
+      `databricks api post /api/2.1/unity-catalog/volumes --profile "${escapeShellArg(profile)}" --json '${escapeSingleQuoted(payload)}'`,
+      { timeout: timeoutMs }
+    );
+    volumeCreated = true;
+  }
+
+  return { schemaCreated, volumeCreated };
+}
+
+export type UcCatalogPermission =
+  | "USE_CATALOG"
+  | "USE_SCHEMA"
+  | "READ_VOLUME"
+  | "WRITE_VOLUME"
+  | "CREATE_SCHEMA"
+  | "CREATE_TABLE"
+  | "MODIFY"
+  | "SELECT"
+  | "ALL_PRIVILEGES";
+
+export interface GrantUcCatalogPermissionArgs {
+  profile: string;
+  catalog: string;
+  /** Principal (SP clientId, user email, or group name). */
+  servicePrincipalName: string;
+  /** Permissions to add. Default: the "deployed-app standard" set:
+   *  USE_CATALOG + USE_SCHEMA + READ_VOLUME + WRITE_VOLUME. */
+  permissions?: UcCatalogPermission[];
+  timeoutMs?: number;
+}
+
+export interface GrantUcCatalogPermissionResult {
+  granted: boolean;
+}
+
+const DEFAULT_APP_PERMS: UcCatalogPermission[] = [
+  "USE_CATALOG",
+  "USE_SCHEMA",
+  "READ_VOLUME",
+  "WRITE_VOLUME",
+];
+
+/**
+ * Grant a principal permissions on a Unity Catalog catalog. Wraps
+ * PATCH `/api/2.1/unity-catalog/permissions/catalog/<name>` with the
+ * standard `changes: [{ principal, add: [...] }]` shape.
+ */
+export async function grantUcCatalogPermission(
+  args: GrantUcCatalogPermissionArgs
+): Promise<GrantUcCatalogPermissionResult> {
+  const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
+  const permissions = args.permissions ?? DEFAULT_APP_PERMS;
+  const payload = JSON.stringify({
+    changes: [
+      {
+        principal: args.servicePrincipalName,
+        add: permissions,
+      },
+    ],
+  });
+  await exec(
+    `databricks api patch /api/2.1/unity-catalog/permissions/catalog/${escapeShellArg(args.catalog)} --profile "${escapeShellArg(args.profile)}" --json '${escapeSingleQuoted(payload)}'`,
+    { timeout: timeoutMs }
+  );
+  return { granted: true };
+}
+
+/**
+ * Build the Catalog Explorer URL for a workspace. Pure helper, no
+ * network call. Useful for surfacing clickable links in agent / UI
+ * output after a successful deploy.
+ */
+export function catalogExplorerUrl(workspaceHost: string): string {
+  return `${workspaceHost.replace(/\/+$/, "")}/explore/data`;
+}
+
+// ─── helpers ────────────────────────────────────────────────────
+
+async function ucResourceExists(apiPath: string, profile: string, timeoutMs: number): Promise<boolean> {
+  try {
+    await exec(`databricks api get ${apiPath} --profile "${escapeShellArg(profile)}"`, { timeout: timeoutMs });
+    return true;
+  } catch (err) {
+    if (isUcMissingError((err as Error).message)) return false;
+    throw err;
+  }
+}
+
+function isUcMissingError(msg: string): boolean {
+  return /RESOURCE_DOES_NOT_EXIST|does not exist|status:? 404\b|NOT_FOUND/i.test(msg);
+}
+
+function escapeShellArg(s: string): string {
+  return s.replace(/"/g, '\\"');
+}
+
+function escapeSingleQuoted(s: string): string {
+  return s.replace(/'/g, `'\\''`);
+}

--- a/tests/bdd/uc-resources.test.ts
+++ b/tests/bdd/uc-resources.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  catalogExists,
+  tryCreateCatalog,
+  ensureSchemaAndVolume,
+  grantUcCatalogPermission,
+  catalogExplorerUrl,
+} from "../../scripts/lakebase/uc-resources";
+
+function hasCli(): boolean {
+  try {
+    execFileSync("databricks", ["--version"], { stdio: "ignore", timeout: 3_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const CLI_AVAILABLE = hasCli();
+const PROFILE = process.env.LAKEBASE_TEST_PROFILE;
+const RUN_LIVE = CLI_AVAILABLE && !!PROFILE;
+
+describe("catalogExplorerUrl: pure helper", () => {
+  it("composes the URL with the host's trailing slashes stripped", () => {
+    expect(catalogExplorerUrl("https://example.cloud.databricks.com")).toBe(
+      "https://example.cloud.databricks.com/explore/data"
+    );
+    expect(catalogExplorerUrl("https://example.cloud.databricks.com/")).toBe(
+      "https://example.cloud.databricks.com/explore/data"
+    );
+    expect(catalogExplorerUrl("https://example.cloud.databricks.com///")).toBe(
+      "https://example.cloud.databricks.com/explore/data"
+    );
+  });
+});
+
+describe("catalogExists: error contract", () => {
+  it("rejects when CLI is missing entirely", async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = "/nonexistent-bin";
+    try {
+      await expect(
+        catalogExists({ profile: "any", catalog: "any", timeoutMs: 5_000 })
+      ).rejects.toThrow(/ENOENT|spawn|failed|not found/i);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  }, 10_000);
+
+  it.skipIf(!RUN_LIVE)("returns false for a catalog that does not exist", async () => {
+    const result = await catalogExists({
+      profile: PROFILE!,
+      catalog: `kit-test-nonexistent-${Date.now()}`,
+      timeoutMs: 30_000,
+    });
+    expect(result).toBe(false);
+  }, 60_000);
+});
+
+describe("tryCreateCatalog: error contract", () => {
+  it("returns created=false (not a throw) on any failure", async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = "/nonexistent-bin";
+    try {
+      const result = await tryCreateCatalog({
+        profile: "any",
+        catalog: "kit-test-nonexistent",
+        timeoutMs: 5_000,
+      });
+      expect(result.created).toBe(false);
+      expect(result.error).toBeTruthy();
+    } finally {
+      process.env.PATH = origPath;
+    }
+  }, 10_000);
+});
+
+describe("ensureSchemaAndVolume: error contract", () => {
+  it("rejects when CLI is missing entirely", async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = "/nonexistent-bin";
+    try {
+      await expect(
+        ensureSchemaAndVolume({
+          profile: "any",
+          catalog: "any",
+          schema: "any",
+          volume: "any",
+          timeoutMs: 5_000,
+        })
+      ).rejects.toThrow(/ENOENT|spawn|failed|not found/i);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  }, 10_000);
+});
+
+describe("grantUcCatalogPermission: error contract", () => {
+  it("rejects when CLI is missing entirely", async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = "/nonexistent-bin";
+    try {
+      await expect(
+        grantUcCatalogPermission({
+          profile: "any",
+          catalog: "any",
+          servicePrincipalName: "00000000-0000-0000-0000-000000000000",
+          timeoutMs: 5_000,
+        })
+      ).rejects.toThrow(/ENOENT|spawn|failed|not found/i);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  }, 10_000);
+
+  it.skipIf(!RUN_LIVE)("rejects on a non-existent catalog", async () => {
+    await expect(
+      grantUcCatalogPermission({
+        profile: PROFILE!,
+        catalog: `kit-nonexistent-catalog-${Date.now()}`,
+        servicePrincipalName: "00000000-0000-0000-0000-000000000000",
+        timeoutMs: 30_000,
+      })
+    ).rejects.toThrow();
+  }, 60_000);
+});
+
+describe("uc-resources: skip-when-env-missing", () => {
+  it("documents the skip reason", () => {
+    if (!CLI_AVAILABLE) {
+      console.log("databricks CLI not on PATH; live UC tests skipped.");
+    } else if (!PROFILE) {
+      console.log("LAKEBASE_TEST_PROFILE not set; live UC tests skipped.");
+    }
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Lifts the extension's bespoke UC catalog / schema / volume / permission management code into substrate. Replaces ~7 `databricks api get|post|patch` shell-outs with five typed primitives.

P2 of the post-FEIP-7130 extension extraction backlog. Pairs with the matching extension migration PR (replaces ~250 lines of bespoke logic with one-line proxies).

## Primitives

`scripts/lakebase/uc-resources.ts` exports:

- **`catalogExists({ profile, catalog })`** -> boolean. Returns false on missing-catalog patterns (RESOURCE_DOES_NOT_EXIST, 404, NOT_FOUND), throws on infrastructure failures.
- **`tryCreateCatalog({ profile, catalog, comment? })`** -> `{ created, error? }`. Never throws on platform errors so callers can fall back to interactive creation when Default Storage workspaces reject the programmatic POST.
- **`ensureSchemaAndVolume({ profile, catalog, schema, volume, comment?, volumeType? })`** -> `{ schemaCreated, volumeCreated }`. Idempotent. Volume defaults to MANAGED.
- **`grantUcCatalogPermission({ profile, catalog, servicePrincipalName, permissions? })`** -> `{ granted }`. Default permissions: `USE_CATALOG + USE_SCHEMA + READ_VOLUME + WRITE_VOLUME`.
- **`catalogExplorerUrl(workspaceHost)`** -> string. Pure helper.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Hermetic suite: 492 passed (+6 from new UC tests), 62 skipped, 0 failed
- [x] `uc-resources.test.ts`: 8 tests covering CLI-missing reject, never-throw contract for tryCreate, live missing-catalog, catalog explorer URL trimming

This pull request and its description were written by Isaac.