### PR TITLE
feat: ensureLakebaseSecretAuth substrate primitive (P3 follow-up)

### DIFF
--- a/scripts/lakebase/index.ts
+++ b/scripts/lakebase/index.ts
@@ -32,6 +32,7 @@ export * from "./runner-setup.js";
 export * from "./scaffold-language.js";
 export * from "./scaffold.js";
 export * from "./schema-diff.js";
+export * from "./secret-auth.js";
 export * from "./spring-initializr.js";
 export * from "./uc-resources.js";
 export {

--- a/scripts/lakebase/secret-auth.ts
+++ b/scripts/lakebase/secret-auth.ts
@@ -1,0 +1,141 @@
+// Secret-based authentication setup for Databricks Apps that connect
+// to Lakebase from workspaces where service principal auth doesn't
+// work directly (e.g. non-FEVM workspaces).
+//
+// The pattern: create a secret scope, mint a long-lived PAT on behalf
+// of the deploying user, store the PAT in the scope, and grant the
+// app's service principal READ access. The app's code then reads the
+// PAT from the secret at runtime and uses it as the Lakebase password.
+//
+// Lifted from the lakebase-scm-extension's bespoke
+// DeployService.ensureLakebaseSecretAuth.
+
+import { exec } from "../util/exec.js";
+import { KIT_TIMEOUTS } from "./kit-config.js";
+
+const NINETY_DAYS_SECONDS = 90 * 24 * 60 * 60;
+
+export interface EnsureLakebaseSecretAuthArgs {
+  /** Databricks CLI profile (the deploying user's identity). */
+  profile: string;
+  /** Secret scope name to create / use. Idempotent: existing scopes
+   *  are kept. */
+  scopeName: string;
+  /** Secret key name within the scope. The minted PAT is stored here. */
+  keyName: string;
+  /** Service principal client id to grant READ on the scope. When
+   *  undefined, the scope + secret are created but no ACL is set. */
+  servicePrincipalClientId?: string;
+  /** Description placed on the minted PAT. Useful for token-list audits. */
+  tokenComment?: string;
+  /** PAT lifetime in seconds. Default: 90 days. */
+  tokenLifetimeSeconds?: number;
+  timeoutMs?: number;
+}
+
+export interface EnsureLakebaseSecretAuthResult {
+  /** Scope name (passed through). */
+  scope: string;
+  /** Key name (passed through). */
+  key: string;
+  /** True iff this call created the scope (false if it pre-existed). */
+  scopeCreated: boolean;
+  /** True iff a new PAT was minted + stored. */
+  patStored: boolean;
+  /** True iff the SP ACL was granted (false when servicePrincipalClientId
+   *  was undefined or the grant failed). */
+  aclGranted: boolean;
+}
+
+/**
+ * Ensure a secret scope + key are configured for Lakebase auth.
+ *
+ * Order:
+ *   1. Create secret scope (idempotent: tolerates SCOPE_ALREADY_EXISTS)
+ *   2. Mint a long-lived PAT
+ *   3. Store the PAT in `<scope>/<key>`
+ *   4. Grant the SP READ on the scope (only when servicePrincipalClientId provided)
+ *
+ * Each call mints a NEW PAT regardless of whether the secret already
+ * holds one; the platform's secret put is destructive (overwrite). For
+ * the lakebase-scm-extension's deploy flow, this matches the desired
+ * behavior (fresh PAT per deploy, tokens rotate at the configured
+ * lifetime).
+ *
+ * Promise rejects on infrastructure failures (CLI not on PATH, timeout,
+ * token mint refusal). The ACL grant is best-effort: failure is
+ * reflected in `aclGranted: false` rather than throwing, so callers can
+ * surface the warning without failing the deploy.
+ */
+export async function ensureLakebaseSecretAuth(
+  args: EnsureLakebaseSecretAuthArgs
+): Promise<EnsureLakebaseSecretAuthResult> {
+  const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
+  const tokenLifetimeSeconds = args.tokenLifetimeSeconds ?? NINETY_DAYS_SECONDS;
+  const tokenComment = args.tokenComment ?? `Lakebase auth (scope=${args.scopeName})`;
+  const { profile, scopeName, keyName, servicePrincipalClientId } = args;
+
+  // 1. Scope
+  let scopeCreated = false;
+  try {
+    await exec(
+      `databricks secrets create-scope "${escapeShellArg(scopeName)}" --profile "${escapeShellArg(profile)}"`,
+      { timeout: timeoutMs }
+    );
+    scopeCreated = true;
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (!isAlreadyExistsError(msg)) throw err;
+  }
+
+  // 2. Mint PAT
+  const tokenJson = await exec(
+    `databricks tokens create --comment "${escapeShellArg(tokenComment)}" --lifetime-seconds ${tokenLifetimeSeconds} -o json --profile "${escapeShellArg(profile)}"`,
+    { timeout: timeoutMs }
+  );
+  const tokenStart = tokenJson.indexOf("{");
+  if (tokenStart < 0) {
+    throw new Error(`databricks tokens create returned no JSON: ${tokenJson.slice(0, 200)}`);
+  }
+  const parsed = JSON.parse(tokenJson.slice(tokenStart)) as Record<string, unknown>;
+  const pat = parsed.token_value;
+  if (typeof pat !== "string" || !pat) {
+    throw new Error("databricks tokens create returned no token_value");
+  }
+
+  // 3. Store the PAT
+  await exec(
+    `databricks secrets put-secret "${escapeShellArg(scopeName)}" "${escapeShellArg(keyName)}" --string-value "${escapeShellArg(pat)}" --profile "${escapeShellArg(profile)}"`,
+    { timeout: timeoutMs }
+  );
+
+  // 4. ACL (best-effort)
+  let aclGranted = false;
+  if (servicePrincipalClientId) {
+    try {
+      await exec(
+        `databricks secrets put-acl "${escapeShellArg(scopeName)}" "${escapeShellArg(servicePrincipalClientId)}" READ --profile "${escapeShellArg(profile)}"`,
+        { timeout: timeoutMs }
+      );
+      aclGranted = true;
+    } catch {
+      // Best-effort; surface via result rather than throwing.
+    }
+  }
+
+  return {
+    scope: scopeName,
+    key: keyName,
+    scopeCreated,
+    patStored: true,
+    aclGranted,
+  };
+}
+
+function isAlreadyExistsError(msg: string): boolean {
+  return /already exists|SCOPE_ALREADY_EXISTS|RESOURCE_ALREADY_EXISTS/i.test(msg);
+}
+
+function escapeShellArg(s: string): string {
+  return s.replace(/"/g, '\\"');
+}

--- a/tests/bdd/secret-auth.test.ts
+++ b/tests/bdd/secret-auth.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { ensureLakebaseSecretAuth } from "../../scripts/lakebase/secret-auth";
+
+function hasCli(): boolean {
+  try {
+    execFileSync("databricks", ["--version"], { stdio: "ignore", timeout: 3_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const CLI_AVAILABLE = hasCli();
+const PROFILE = process.env.LAKEBASE_TEST_PROFILE;
+const RUN_LIVE = CLI_AVAILABLE && !!PROFILE;
+
+describe("ensureLakebaseSecretAuth: infra-error contract", () => {
+  it("rejects when CLI is missing entirely", async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = "/nonexistent-bin";
+    try {
+      await expect(
+        ensureLakebaseSecretAuth({
+          profile: "any",
+          scopeName: "any",
+          keyName: "any",
+          timeoutMs: 5_000,
+        })
+      ).rejects.toThrow(/ENOENT|spawn|failed|not found/i);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  }, 10_000);
+
+  it.skipIf(!RUN_LIVE)("rejects when the profile is invalid", async () => {
+    await expect(
+      ensureLakebaseSecretAuth({
+        profile: "kit-test-nonexistent-profile-1234567890",
+        scopeName: `kit-test-scope-${Date.now()}`,
+        keyName: "test-key",
+        timeoutMs: 15_000,
+      })
+    ).rejects.toThrow();
+  }, 30_000);
+});
+
+describe("ensureLakebaseSecretAuth: skip-when-env-missing", () => {
+  it("documents the skip reason", () => {
+    if (!CLI_AVAILABLE) {
+      console.log("databricks CLI not on PATH; live secret-auth tests skipped.");
+    } else if (!PROFILE) {
+      console.log("LAKEBASE_TEST_PROFILE not set; live secret-auth tests skipped.");
+    }
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Lifts the secret-based Lakebase auth setup pattern into substrate. Pairs with the matching extension PR that replaces ~50 lines of bespoke logic with a one-line proxy.

P3 of the post-FEIP-7130 extension extraction backlog.

## Surface

`scripts/lakebase/secret-auth.ts` exports `ensureLakebaseSecretAuth({ profile, scopeName, keyName, servicePrincipalClientId?, tokenComment?, tokenLifetimeSeconds?, timeoutMs? }) => { scope, key, scopeCreated, patStored, aclGranted }`.

Order (matches the extension's existing flow):
1. Create secret scope (idempotent, tolerates SCOPE_ALREADY_EXISTS)
2. Mint a long-lived PAT (default 90 days)
3. Store the PAT in `<scope>/<key>` (destructive put)
4. Grant the SP READ on the scope, best-effort

Failures in step 4 reflect in `aclGranted: false` rather than throwing, so callers can surface a warning without failing the deploy. Steps 1-3 throw on platform errors.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Hermetic suite: 494 passed (+2 from new tests), 63 skipped, 0 failed
- [x] `secret-auth.test.ts`: 3 tests covering CLI-missing reject, invalid-profile reject, skip-when-env-missing documentation

This pull request and its description were written by Isaac.