### PR TITLE
feat(git): lift workflow-coordination git ops to substrate (FEIP-7323)

### DIFF
--- a/scripts/git/ancestry.ts
+++ b/scripts/git/ancestry.ts
@@ -1,0 +1,120 @@
+// Branch-ancestry primitives: pick the nearest parent across candidate
+// branches and resolve the merge-base SHA. Lifted from the extension's
+// resolveNearestParent / getNearestParentName / getMergeBase.
+//
+// Why this matters: PSA uses a 3-tier release flow (prod -> staging ->
+// feature). When a feature forks from staging, staging's merge-base
+// commit is more recent than main's, so picking the parent by max
+// merge-base timestamp resolves to the right branch automatically. A
+// hardcoded "main" would diff against the wrong base content.
+
+import { exec } from "../util/exec.js";
+
+export interface ResolveNearestParentArgs {
+  cwd: string;
+  /** Ref to find the parent of. Default: "HEAD". */
+  tip?: string;
+  /**
+   * Candidate parent branches in preference order. The extension passes
+   * the deduped union of [trunkBranch, "main", "master", stagingBranch,
+   * "staging"]; the substrate stays config-agnostic and trusts the
+   * caller to pre-merge VS Code / .env / repo conventions.
+   */
+  candidates: string[];
+}
+
+export interface NearestParent {
+  name: string;
+  baseSha: string;
+}
+
+export interface GetMergeBaseArgs extends ResolveNearestParentArgs {
+  /**
+   * Branches to try with `git merge-base <tip> <fallback>` if none of the
+   * candidates have a reachable merge-base. Default: ["main", "master"].
+   * Useful for legacy two-branch projects.
+   */
+  fallbacks?: string[];
+}
+
+/**
+ * Pick the candidate branch whose merge-base with `tip` has the most
+ * recent commit timestamp. Skips the tip's own branch (so a feature
+ * branch named "main" wouldn't resolve to itself). Returns undefined
+ * when no candidate exists locally / has a reachable merge-base.
+ */
+export async function resolveNearestParent(
+  args: ResolveNearestParentArgs
+): Promise<NearestParent | undefined> {
+  const { cwd } = args;
+  const tipRef = args.tip && args.tip.length > 0 ? args.tip : "HEAD";
+
+  // The "tip branch name" is what we exclude from the candidate list, so
+  // a branch can't be its own parent. When `tip` is an explicit name,
+  // use it directly; otherwise resolve HEAD's branch.
+  let tipBranchName = "";
+  if (args.tip && args.tip.length > 0) {
+    tipBranchName = args.tip;
+  } else {
+    try {
+      tipBranchName = await exec("git rev-parse --abbrev-ref HEAD", { cwd });
+    } catch {
+      // ignore: we can still try candidates with HEAD
+    }
+  }
+
+  let best: { name: string; baseSha: string; ts: number } | undefined;
+  for (const c of args.candidates) {
+    if (!c || c === tipBranchName) continue;
+    try {
+      const baseSha = await exec(`git merge-base "${tipRef}" "${c}"`, { cwd });
+      if (!baseSha) continue;
+      const tsStr = await exec(`git log -1 --format=%at "${baseSha}"`, {
+        cwd,
+      });
+      const ts = parseInt(tsStr, 10) || 0;
+      if (!best || ts > best.ts) {
+        best = { name: c, baseSha, ts };
+      }
+    } catch {
+      // candidate missing locally / unreachable - skip
+    }
+  }
+
+  return best ? { name: best.name, baseSha: best.baseSha } : undefined;
+}
+
+/**
+ * Convenience wrapper for callers that only need the parent branch name
+ * (e.g. tree labels). Returns empty string when no candidate resolves.
+ */
+export async function getNearestParentName(
+  args: ResolveNearestParentArgs
+): Promise<string> {
+  const parent = await resolveNearestParent(args);
+  return parent?.name ?? "";
+}
+
+/**
+ * Return the merge-base SHA between `tip` and its nearest parent across
+ * `candidates`. Falls back to direct merge-base against `fallbacks`
+ * (default ["main", "master"]) when no candidate resolves, so legacy
+ * two-branch projects still get a useful diff base.
+ */
+export async function getMergeBase(args: GetMergeBaseArgs): Promise<string> {
+  const parent = await resolveNearestParent(args);
+  if (parent?.baseSha) return parent.baseSha;
+
+  const { cwd } = args;
+  const tipRef = args.tip && args.tip.length > 0 ? args.tip : "HEAD";
+  const fallbacks = args.fallbacks ?? ["main", "master"];
+  for (const fb of fallbacks) {
+    try {
+      await exec(`git rev-parse --verify ${fb}`, { cwd });
+      return await exec(`git merge-base ${fb} ${tipRef}`, { cwd });
+    } catch {
+      // try next
+    }
+  }
+  return "";
+}

--- a/scripts/git/branches.ts
+++ b/scripts/git/branches.ts
@@ -1,0 +1,153 @@
+// Branch listing + existence primitives.
+//
+// Lifted from lakebase-scm-extension's GitService (listLocalBranches,
+// listRemoteBranches, hasRemoteBranch). Substrate signatures take an
+// explicit cwd; the extension's VS-Code-workspace resolution layer stays
+// in the extension. Behavior is preserved verbatim so callers can swap
+// without recalibrating downstream consumers.
+
+import { exec } from "../util/exec.js";
+
+export interface GitBranchInfo {
+  name: string;
+  isCurrent: boolean;
+  isRemote: boolean;
+  tracking?: string;
+  ahead?: number;
+  behind?: number;
+}
+
+export interface ListLocalBranchesArgs {
+  cwd: string;
+}
+
+export interface ListRemoteBranchesArgs {
+  cwd: string;
+  /** Remote name. Default: "origin". */
+  remote?: string;
+}
+
+export interface HasRemoteBranchArgs {
+  cwd: string;
+  branch: string;
+  /** Remote name. Default: "origin". */
+  remote?: string;
+}
+
+async function currentBranchName(cwd: string): Promise<string> {
+  try {
+    return await exec("git rev-parse --abbrev-ref HEAD", { cwd });
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * List local branches with tracking + ahead/behind metadata. Returns []
+ * when the directory is not a git repo. Each entry carries the upstream
+ * ref (when set) and ahead/behind counts parsed from
+ * `git branch --format`.
+ */
+export async function listLocalBranches(
+  args: ListLocalBranchesArgs
+): Promise<GitBranchInfo[]> {
+  const { cwd } = args;
+  let raw: string;
+  try {
+    raw = await exec(
+      'git branch --format="%(refname:short)|%(upstream:short)|%(upstream:track)"',
+      { cwd }
+    );
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+
+  const current = await currentBranchName(cwd);
+
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [name, tracking, trackInfo] = line.split("|");
+      let ahead = 0;
+      let behind = 0;
+      if (trackInfo) {
+        const aheadMatch = trackInfo.match(/ahead (\d+)/);
+        const behindMatch = trackInfo.match(/behind (\d+)/);
+        if (aheadMatch) ahead = parseInt(aheadMatch[1], 10);
+        if (behindMatch) behind = parseInt(behindMatch[1], 10);
+      }
+      return {
+        name,
+        isCurrent: name === current,
+        isRemote: false,
+        tracking: tracking || undefined,
+        ahead,
+        behind,
+      };
+    });
+}
+
+/**
+ * List remote branches that are NOT already checked out locally. Strips
+ * the remote prefix from the returned `name` and preserves the full
+ * `origin/<branch>` ref in `tracking`. Useful for "switch to existing
+ * remote branch" pickers that want to hide branches the caller can
+ * already reach locally.
+ */
+export async function listRemoteBranches(
+  args: ListRemoteBranchesArgs
+): Promise<GitBranchInfo[]> {
+  const { cwd, remote = "origin" } = args;
+  try {
+    const localBranches = await listLocalBranches({ cwd });
+    const localNames = new Set(localBranches.map((b) => b.name));
+
+    const raw = await exec(`git branch -r --format="%(refname:short)"`, {
+      cwd,
+    });
+    if (!raw) return [];
+
+    const remotePrefix = `${remote}/`;
+    return raw
+      .split("\n")
+      .filter(Boolean)
+      .filter((name) => !name.includes("HEAD"))
+      .map((name) => {
+        const shortName = name.startsWith(remotePrefix)
+          ? name.slice(remotePrefix.length)
+          : name;
+        return { fullName: name, shortName };
+      })
+      .filter(({ shortName }) => !localNames.has(shortName))
+      .map(({ fullName, shortName }) => ({
+        name: shortName,
+        isCurrent: false,
+        isRemote: true,
+        tracking: fullName,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * True iff `branch` exists on the given remote. Returns false when the
+ * remote is unreachable or the branch is absent. Uses `git ls-remote
+ * --heads`, which does not require a fetch.
+ */
+export async function hasRemoteBranch(
+  args: HasRemoteBranchArgs
+): Promise<boolean> {
+  const { cwd, branch, remote = "origin" } = args;
+  try {
+    const out = await exec(
+      `git ls-remote --heads "${remote}" "${branch}"`,
+      { cwd }
+    );
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/git/index.ts
+++ b/scripts/git/index.ts
@@ -4,3 +4,7 @@ export * from "./init.js";
 export * from "./clone.js";
 export * from "./commit-push.js";
 export * from "./remote.js";
+export * from "./branches.js";
+export * from "./ancestry.js";
+export * from "./status.js";
+export * from "./migrations.js";

--- a/scripts/git/migrations.ts
+++ b/scripts/git/migrations.ts
@@ -1,0 +1,58 @@
+// List migration filenames on a branch without checking it out. Lifted
+// from extension's listMigrationsOnBranch.
+//
+// This crosses the git + migration-tool boundary, but the primitive
+// itself is pure git (`ls-tree`) plus a filename filter - so it lives
+// under scripts/git/ rather than scripts/lakebase/. Higher-level
+// migration logic (alembic / flyway / knex orchestration) stays in
+// scripts/lakebase/migrate.ts.
+
+import { exec } from "../util/exec.js";
+
+const DEFAULT_PATTERN = /^V\d+.*\.sql$/i;
+
+export interface ListMigrationsOnBranchArgs {
+  cwd: string;
+  /** Branch (or any tree-ish) to inspect. */
+  branch: string;
+  /**
+   * Path within the repo containing migration files (e.g.
+   * "src/main/resources/db/migration"). Trailing slash optional.
+   */
+  migrationPath: string;
+  /**
+   * Regex applied to the basename of each file. Default: Flyway-style
+   * `V<n>...sql` (case-insensitive). Pass an explicit pattern for
+   * Alembic, Knex, or custom layouts.
+   */
+  pattern?: RegExp;
+}
+
+/**
+ * Return migration filenames (basenames only) on `branch` matching
+ * `pattern`. Sorted lexically so versioned filenames come back in
+ * apply order. Returns [] when the branch doesn't exist, the migration
+ * path is empty, or any underlying git call fails - migration
+ * comparisons across branches in the UI shouldn't crash on a fresh
+ * branch with no migrations yet.
+ */
+export async function listMigrationsOnBranch(
+  args: ListMigrationsOnBranchArgs
+): Promise<string[]> {
+  const { cwd, branch, migrationPath, pattern = DEFAULT_PATTERN } = args;
+  if (!branch || !migrationPath) return [];
+  try {
+    const raw = await exec(
+      `git ls-tree --name-only "${branch}" -- "${migrationPath}/"`,
+      { cwd }
+    );
+    if (!raw) return [];
+    return raw
+      .split("\n")
+      .map((f) => f.split("/").pop() || f)
+      .filter((f) => pattern.test(f))
+      .sort();
+  } catch {
+    return [];
+  }
+}

--- a/scripts/git/status.ts
+++ b/scripts/git/status.ts
@@ -1,0 +1,71 @@
+// Working-tree + upstream status primitives. Lifted from extension's
+// GitService (hasUpstream, getAheadBehind, isDirty). All three operate
+// on the cwd's current branch and return safe defaults when there's no
+// upstream / no repo (rather than throwing) so call sites that drive
+// status-bar items don't have to wrap every call.
+
+import { exec } from "../util/exec.js";
+
+export interface CwdOnlyArgs {
+  cwd: string;
+}
+
+export interface AheadBehind {
+  ahead: number;
+  behind: number;
+  /** The upstream ref (e.g. "origin/main"). Empty string when no upstream. */
+  upstream: string;
+}
+
+/**
+ * True iff the current branch has a remote upstream set (i.e. a
+ * tracking ref). Returns false when no upstream is configured, when the
+ * current branch is detached, or when the cwd is not a git repo.
+ */
+export async function hasUpstream(args: CwdOnlyArgs): Promise<boolean> {
+  try {
+    await exec("git rev-parse --abbrev-ref @{u}", { cwd: args.cwd });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return ahead / behind counts of HEAD relative to its upstream, along
+ * with the upstream ref. Returns zeros + empty string when no upstream
+ * exists, the cwd is not a repo, or the ref-list call fails for any
+ * other reason - callers driving UI affordances should treat this as
+ * "no remote sync state to show".
+ */
+export async function getAheadBehind(args: CwdOnlyArgs): Promise<AheadBehind> {
+  const { cwd } = args;
+  try {
+    const upstream = await exec("git rev-parse --abbrev-ref @{u}", { cwd });
+    const raw = await exec("git rev-list --left-right --count HEAD...@{u}", {
+      cwd,
+    });
+    const parts = raw.trim().split(/\s+/);
+    return {
+      ahead: parseInt(parts[0], 10) || 0,
+      behind: parseInt(parts[1], 10) || 0,
+      upstream,
+    };
+  } catch {
+    return { ahead: 0, behind: 0, upstream: "" };
+  }
+}
+
+/**
+ * True iff the working tree has staged or unstaged changes (including
+ * untracked files reported by porcelain status). Returns false on
+ * non-git cwd or when `git status` fails.
+ */
+export async function isDirty(args: CwdOnlyArgs): Promise<boolean> {
+  try {
+    const out = await exec("git status --porcelain", { cwd: args.cwd });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/tests/bdd/git-inspection.test.ts
+++ b/tests/bdd/git-inspection.test.ts
@@ -1,0 +1,428 @@
+// BDD coverage for the P5a workflow-coordination git primitives:
+// branches.ts, ancestry.ts, status.ts, migrations.ts. Each describe
+// block spins up an isolated temp git repo so tests don't depend on
+// the host's working tree.
+
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gitInit } from "../../scripts/git/init.js";
+import {
+  listLocalBranches,
+  listRemoteBranches,
+  hasRemoteBranch,
+} from "../../scripts/git/branches.js";
+import {
+  resolveNearestParent,
+  getNearestParentName,
+  getMergeBase,
+} from "../../scripts/git/ancestry.js";
+import {
+  hasUpstream,
+  getAheadBehind,
+  isDirty,
+} from "../../scripts/git/status.js";
+import { listMigrationsOnBranch } from "../../scripts/git/migrations.js";
+import { exec } from "../../scripts/util/exec.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+});
+
+function mkTmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lbscm-gi-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function configIdentity(cwd: string): Promise<void> {
+  await exec("git config user.email test@example.com", { cwd });
+  await exec("git config user.name 'Test User'", { cwd });
+}
+
+async function commitFile(
+  cwd: string,
+  name: string,
+  contents: string,
+  message: string,
+  /**
+   * Optional ISO date string. Forces author + committer date so tests
+   * that depend on merge-base timestamp ordering (resolveNearestParent's
+   * 3-tier case) don't collide at 1-second precision under fast runs.
+   */
+  date?: string
+): Promise<string> {
+  fs.writeFileSync(path.join(cwd, name), contents);
+  await exec("git add -A", { cwd });
+  const dateEnv = date
+    ? { GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date }
+    : undefined;
+  await exec(`git commit -m "${message}"`, { cwd, env: dateEnv });
+  return await exec("git rev-parse HEAD", { cwd });
+}
+
+// ---------- branches.ts ----------
+
+describe("listLocalBranches", () => {
+  it("returns [] for a non-git directory", async () => {
+    const dir = mkTmp();
+    expect(await listLocalBranches({ cwd: dir })).toEqual([]);
+  });
+
+  it("lists local branches with the current branch flagged", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "initial");
+    await exec("git checkout -b feature/x", { cwd: dir });
+
+    const branches = await listLocalBranches({ cwd: dir });
+    const names = branches.map((b) => b.name).sort();
+    expect(names).toEqual(["feature/x", "main"]);
+    expect(branches.find((b) => b.name === "feature/x")?.isCurrent).toBe(true);
+    expect(branches.find((b) => b.name === "main")?.isCurrent).toBe(false);
+    expect(branches.every((b) => b.isRemote === false)).toBe(true);
+  });
+});
+
+describe("listRemoteBranches", () => {
+  it("returns remotes not already checked out locally, stripped of prefix", async () => {
+    // Create a "remote" bare repo, and a local repo that has it as origin
+    // with two remote branches (main + feature/y) where only main is
+    // checked out locally. listRemoteBranches should surface feature/y.
+    const remoteBare = mkTmp();
+    await exec("git init --bare -b main", { cwd: remoteBare });
+
+    const seed = mkTmp();
+    await gitInit(seed);
+    await configIdentity(seed);
+    await commitFile(seed, "a.txt", "a", "seed");
+    await exec("git checkout -b feature/y", { cwd: seed });
+    await commitFile(seed, "b.txt", "b", "y change");
+    await exec("git checkout main", { cwd: seed });
+    await exec(`git remote add origin "${remoteBare}"`, { cwd: seed });
+    await exec("git push origin main", { cwd: seed });
+    await exec("git push origin feature/y", { cwd: seed });
+
+    const local = mkTmp();
+    await exec(`git clone "${remoteBare}" "${local}"`, { cwd: os.tmpdir() });
+    await configIdentity(local);
+    // local now has main checked out + origin/feature/y available
+
+    const remotes = await listRemoteBranches({ cwd: local });
+    const names = remotes.map((b) => b.name);
+    expect(names).toContain("feature/y");
+    expect(names).not.toContain("main");
+    expect(remotes.every((b) => b.isRemote === true)).toBe(true);
+    expect(remotes.find((b) => b.name === "feature/y")?.tracking).toBe(
+      "origin/feature/y"
+    );
+  });
+});
+
+describe("hasRemoteBranch", () => {
+  it("returns true for an existing remote branch, false for a missing one", async () => {
+    const remoteBare = mkTmp();
+    await exec("git init --bare -b main", { cwd: remoteBare });
+
+    const local = mkTmp();
+    await gitInit(local);
+    await configIdentity(local);
+    await commitFile(local, "a.txt", "a", "seed");
+    await exec(`git remote add origin "${remoteBare}"`, { cwd: local });
+    await exec("git push origin main", { cwd: local });
+
+    expect(await hasRemoteBranch({ cwd: local, branch: "main" })).toBe(true);
+    expect(await hasRemoteBranch({ cwd: local, branch: "nope" })).toBe(false);
+  });
+});
+
+// ---------- ancestry.ts ----------
+
+describe("resolveNearestParent", () => {
+  it("picks the candidate with the most recent merge-base timestamp (3-tier staging case)", async () => {
+    // Simulate: main -> (some commits) -> staging branched -> staging
+    // gets newer commits -> feature/z branches from staging. Expected:
+    // feature/z's parent resolves to "staging", not "main", because
+    // staging's merge-base with feature/z is more recent than main's.
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    // Force monotonically-increasing dates so merge-base timestamp
+    // ordering is deterministic regardless of how fast the test runs.
+    await commitFile(dir, "a.txt", "a", "initial on main", "2020-01-01T00:00:00Z");
+    await commitFile(dir, "b.txt", "b", "second on main", "2020-01-02T00:00:00Z");
+
+    await exec("git checkout -b staging", { cwd: dir });
+    await commitFile(dir, "c.txt", "c", "staging-only commit", "2020-01-03T00:00:00Z");
+
+    await exec("git checkout -b feature/z", { cwd: dir });
+    await commitFile(dir, "d.txt", "d", "feature commit", "2020-01-04T00:00:00Z");
+
+    const parent = await resolveNearestParent({
+      cwd: dir,
+      candidates: ["main", "staging"],
+    });
+    expect(parent?.name).toBe("staging");
+    expect(parent?.baseSha).toBeTruthy();
+  });
+
+  it("skips the tip's own branch as a candidate", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    // tip is HEAD on main; candidates includes main itself
+    const parent = await resolveNearestParent({
+      cwd: dir,
+      candidates: ["main"],
+    });
+    expect(parent).toBeUndefined();
+  });
+
+  it("returns undefined when no candidate exists locally", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    const parent = await resolveNearestParent({
+      cwd: dir,
+      candidates: ["does-not-exist", "also-missing"],
+    });
+    expect(parent).toBeUndefined();
+  });
+});
+
+describe("getNearestParentName", () => {
+  it("returns the name string (convenience wrapper)", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    await exec("git checkout -b feature/n", { cwd: dir });
+    await commitFile(dir, "b.txt", "b", "feat");
+    expect(
+      await getNearestParentName({ cwd: dir, candidates: ["main"] })
+    ).toBe("main");
+  });
+
+  it("returns empty string when no candidate resolves", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    expect(
+      await getNearestParentName({ cwd: dir, candidates: ["missing"] })
+    ).toBe("");
+  });
+});
+
+describe("getMergeBase", () => {
+  it("returns the resolved-parent merge-base SHA when a candidate matches", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    const mainSha = await commitFile(dir, "a.txt", "a", "seed");
+    await exec("git checkout -b feature/m", { cwd: dir });
+    await commitFile(dir, "b.txt", "b", "feat");
+    const mb = await getMergeBase({ cwd: dir, candidates: ["main"] });
+    expect(mb).toBe(mainSha);
+  });
+
+  it("falls back to direct merge-base against main/master when no candidate resolves", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    const mainSha = await commitFile(dir, "a.txt", "a", "seed");
+    await exec("git checkout -b feature/m", { cwd: dir });
+    await commitFile(dir, "b.txt", "b", "feat");
+    // Candidates list is empty, fallback to ["main", "master"]
+    const mb = await getMergeBase({ cwd: dir, candidates: [] });
+    expect(mb).toBe(mainSha);
+  });
+
+  it("returns empty string when no candidate and no fallback resolves", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    // rename main so neither candidate nor fallback exists
+    await exec("git branch -m main trunk", { cwd: dir });
+    const mb = await getMergeBase({
+      cwd: dir,
+      candidates: ["nope"],
+      fallbacks: ["also-missing"],
+    });
+    expect(mb).toBe("");
+  });
+});
+
+// ---------- status.ts ----------
+
+describe("hasUpstream", () => {
+  it("returns false when no upstream is set", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    expect(await hasUpstream({ cwd: dir })).toBe(false);
+  });
+
+  it("returns true after setting upstream via push -u", async () => {
+    const remoteBare = mkTmp();
+    await exec("git init --bare -b main", { cwd: remoteBare });
+    const local = mkTmp();
+    await gitInit(local);
+    await configIdentity(local);
+    await commitFile(local, "a.txt", "a", "seed");
+    await exec(`git remote add origin "${remoteBare}"`, { cwd: local });
+    await exec("git push -u origin main", { cwd: local });
+    expect(await hasUpstream({ cwd: local })).toBe(true);
+  });
+});
+
+describe("getAheadBehind", () => {
+  it("returns ahead/behind zeros + empty upstream when no upstream", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    const ab = await getAheadBehind({ cwd: dir });
+    expect(ab).toEqual({ ahead: 0, behind: 0, upstream: "" });
+  });
+
+  it("reports ahead count after a local commit on a tracked branch", async () => {
+    const remoteBare = mkTmp();
+    await exec("git init --bare -b main", { cwd: remoteBare });
+    const local = mkTmp();
+    await gitInit(local);
+    await configIdentity(local);
+    await commitFile(local, "a.txt", "a", "seed");
+    await exec(`git remote add origin "${remoteBare}"`, { cwd: local });
+    await exec("git push -u origin main", { cwd: local });
+    await commitFile(local, "b.txt", "b", "second");
+    const ab = await getAheadBehind({ cwd: local });
+    expect(ab.ahead).toBe(1);
+    expect(ab.behind).toBe(0);
+    expect(ab.upstream).toBe("origin/main");
+  });
+});
+
+describe("isDirty", () => {
+  it("returns false for a clean repo", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    expect(await isDirty({ cwd: dir })).toBe(false);
+  });
+
+  it("returns true with an unstaged modification", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    fs.writeFileSync(path.join(dir, "a.txt"), "changed");
+    expect(await isDirty({ cwd: dir })).toBe(true);
+  });
+
+  it("returns true with an untracked file", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    fs.writeFileSync(path.join(dir, "new.txt"), "x");
+    expect(await isDirty({ cwd: dir })).toBe(true);
+  });
+});
+
+// ---------- migrations.ts ----------
+
+describe("listMigrationsOnBranch", () => {
+  it("returns Flyway-style migrations sorted, basenames only", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    const migDir = path.join(dir, "db", "migration");
+    fs.mkdirSync(migDir, { recursive: true });
+    fs.writeFileSync(path.join(migDir, "V002__b.sql"), "");
+    fs.writeFileSync(path.join(migDir, "V001__a.sql"), "");
+    fs.writeFileSync(path.join(migDir, "README.md"), "");
+    await exec("git add -A", { cwd: dir });
+    await exec(`git commit -m "seed"`, { cwd: dir });
+
+    const files = await listMigrationsOnBranch({
+      cwd: dir,
+      branch: "main",
+      migrationPath: "db/migration",
+    });
+    expect(files).toEqual(["V001__a.sql", "V002__b.sql"]);
+  });
+
+  it("respects a custom pattern (Alembic-style numeric prefix)", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    const migDir = path.join(dir, "alembic", "versions");
+    fs.mkdirSync(migDir, { recursive: true });
+    fs.writeFileSync(path.join(migDir, "0001_a.py"), "");
+    fs.writeFileSync(path.join(migDir, "0002_b.py"), "");
+    fs.writeFileSync(path.join(migDir, "ignored.txt"), "");
+    await exec("git add -A", { cwd: dir });
+    await exec(`git commit -m "seed"`, { cwd: dir });
+
+    const files = await listMigrationsOnBranch({
+      cwd: dir,
+      branch: "main",
+      migrationPath: "alembic/versions",
+      pattern: /^\d{4}.*\.py$/,
+    });
+    expect(files).toEqual(["0001_a.py", "0002_b.py"]);
+  });
+
+  it("returns [] for a branch that does not exist", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    const files = await listMigrationsOnBranch({
+      cwd: dir,
+      branch: "ghost",
+      migrationPath: "db/migration",
+    });
+    expect(files).toEqual([]);
+  });
+
+  it("returns [] for empty branch / empty migrationPath inputs", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await commitFile(dir, "a.txt", "a", "seed");
+    expect(
+      await listMigrationsOnBranch({
+        cwd: dir,
+        branch: "",
+        migrationPath: "db/migration",
+      })
+    ).toEqual([]);
+    expect(
+      await listMigrationsOnBranch({
+        cwd: dir,
+        branch: "main",
+        migrationPath: "",
+      })
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

P5a of the gitService.ts extraction (parent: FEIP-7322). Lifts 10 read-only / inspection primitives from lakebase-scm-extension's GitService into the kit's `scripts/git/` surface so the extension can move to substrate proxies and the kit's library surface gets the helpers any future `lakebase-git` CLI will need.

## What's in scope

| Module | Functions |
| --- | --- |
| `scripts/git/branches.ts` | `listLocalBranches`, `listRemoteBranches`, `hasRemoteBranch` |
| `scripts/git/ancestry.ts` | `resolveNearestParent`, `getNearestParentName`, `getMergeBase` |
| `scripts/git/status.ts` | `hasUpstream`, `getAheadBehind`, `isDirty` |
| `scripts/git/migrations.ts` | `listMigrationsOnBranch` |

Substrate signatures take `cwd` + (for ancestry) explicit `candidates`, so the VS Code config-resolution layer (which assembles `[trunkBranch, "main", "master", stagingBranch, "staging"]`) stays in the extension. Behavior preserved verbatim:

- The 3-tier merge-base timestamp tie-break (newer merge-base wins) so feature/staging forks resolve to `staging`, not `main`.
- Silent `{}` / `[]` / `""` returns on non-git cwd, missing upstream, or missing branch (rather than throwing) so status-bar callers don't have to wrap every call.
- Migration filename default (Flyway-style `V<n>...sql`, case-insensitive) and basename normalization.

## Tests

- New `tests/bdd/git-inspection.test.ts` with 23 cases covering each primitive, including:
  - 3-tier staging fork: explicit `GIT_COMMITTER_DATE` per commit so merge-base timestamp ordering is deterministic regardless of test runtime
  - `listRemoteBranches` with a real local clone of a bare remote (no mocks)
  - `hasUpstream` + `getAheadBehind` covering both no-upstream and `push -u` paths
  - `listMigrationsOnBranch` with default Flyway pattern, custom Alembic pattern, missing branch, empty inputs
- Full kit suite: **517 passing**, 63 skipped (pre-existing), 0 failed.
- typecheck + build green.

## Not in this PR

- No callsite changes in the extension. Follow-up PR will pin to the new kit version and convert the 10 gitService.ts methods to substrate proxies.
- VS Code SCM hooks (`getStagedFiles`, `stageFile`, change-detection init, etc.) stay in the extension per FEIP-7322's scope map.
- No version bump yet (asking the user before bumping per their preference).

## Related

- Parent: FEIP-7322 (gitService.ts extraction audit + remaining lift)
- This ticket: FEIP-7323 (P5a workflow-coordination)
- Epic: FEIP-7058

## Test plan

- [x] vitest run tests/bdd/git-inspection.test.ts (23/23)
- [x] full kit suite (517 passing)
- [x] typecheck
- [x] build

This pull request and its description were written by Isaac.