### PR TITLE
chore(release): v0.3.0-alpha.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.20",
+  "version": "0.3.0-alpha.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.20",
+      "version": "0.3.0-alpha.26",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",
@@ -22,6 +22,7 @@
       "bin": {
         "lakebase-create-project": "dist/scripts/lakebase/create-project.cli.js",
         "lakebase-cut-backup": "dist/scripts/lakebase/cut-backup.cli.js",
+        "lakebase-detect-language": "dist/scripts/lakebase/detect-language.cli.js",
         "lakebase-get-connection": "dist/scripts/lakebase/get-connection.cli.js",
         "lakebase-github-token": "dist/scripts/github/auth.cli.js",
         "lakebase-mcp-server": "dist/apps/mcp-server/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.25",
+  "version": "0.3.0-alpha.26",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary

Release the P5a workflow-coordination git primitives from #58.

- Bumps `package.json#version` to `0.3.0-alpha.26`
- Syncs `package-lock.json`

No code changes. Tag `v0.3.0-alpha.26` will be cut from the merge commit after this lands. lakebase-scm-extension's pin update follows.

## Test plan

- [x] npm install --package-lock-only (no surprises)
- [ ] Merge, then tag the merge commit