### PR TITLE
feat(git): lift commit / sync / branch-tag ops to substrate (P5b/c/d)

### DIFF
--- a/scripts/git/branch-tag.ts
+++ b/scripts/git/branch-tag.ts
@@ -1,0 +1,135 @@
+// Branch + tag mutation primitives. Lifted from the extension's
+// GitService deleteBranch / renameBranch / mergeBranch / createTag /
+// deleteTag / deleteRemoteTag (P5d).
+//
+// Guardrail: deleteBranch refuses to operate on protected branches
+// (production, main, master) without an explicit override. The
+// reference_databricks_lakebase_skill memory notes "never delete the
+// production branch" - this enforces that at the substrate layer so
+// the rule survives across CLI, agent, and extension callers.
+
+import { exec, shq } from "../util/exec.js";
+
+const PROTECTED_BRANCHES = new Set(["production", "main", "master"]);
+
+export interface DeleteLocalBranchArgs {
+  cwd: string;
+  branch: string;
+  /**
+   * When true, uses `git branch -D` (force-delete unmerged branches);
+   * otherwise `git branch -d` which refuses unmerged branches. Default
+   * false.
+   */
+  force?: boolean;
+  /**
+   * Allow deleting a protected branch (production/main/master).
+   * Default false. Set true ONLY when the caller has explicit user
+   * confirmation; refuses with a typed error otherwise.
+   */
+  allowProtected?: boolean;
+}
+
+export interface RenameBranchArgs {
+  cwd: string;
+  /** New name for the CURRENT branch. */
+  newName: string;
+}
+
+export interface MergeBranchArgs {
+  cwd: string;
+  branch: string;
+}
+
+export interface CreateTagArgs {
+  cwd: string;
+  name: string;
+  /** When provided, makes an annotated tag (`git tag -a -m ...`). */
+  message?: string;
+  /** When provided, tags this sha; otherwise tags HEAD. */
+  sha?: string;
+}
+
+export interface DeleteTagArgs {
+  cwd: string;
+  name: string;
+}
+
+export interface DeleteRemoteTagArgs {
+  cwd: string;
+  name: string;
+  /** Remote name. Default: "origin". */
+  remote?: string;
+}
+
+export class ProtectedBranchError extends Error {
+  constructor(branch: string) {
+    super(
+      `Refusing to delete protected branch "${branch}". Pass ` +
+        `allowProtected: true to override (only after explicit user ` +
+        `confirmation).`
+    );
+    this.name = "ProtectedBranchError";
+  }
+}
+
+/**
+ * Delete a local git branch. Refuses production/main/master without
+ * `allowProtected: true`. The `force` flag controls -d vs -D
+ * independently of the protection check.
+ *
+ * Named with the "Local" suffix to disambiguate from the Lakebase
+ * `deleteBranch` (which deletes a Lakebase Postgres branch via API).
+ * Both verbs live at the kit's top-level barrel and would collide
+ * unqualified.
+ */
+export async function deleteLocalBranch(args: DeleteLocalBranchArgs): Promise<void> {
+  if (PROTECTED_BRANCHES.has(args.branch) && !args.allowProtected) {
+    throw new ProtectedBranchError(args.branch);
+  }
+  const flag = args.force ? "-D" : "-d";
+  await exec(`git branch ${flag} ${shq(args.branch)}`, {
+    cwd: args.cwd,
+  });
+}
+
+/** Rename the CURRENT branch (`git branch -m <newName>`). */
+export async function renameBranch(args: RenameBranchArgs): Promise<void> {
+  await exec(`git branch -m ${shq(args.newName)}`, { cwd: args.cwd });
+}
+
+/** Merge `branch` INTO the current branch (`git merge <branch>`). */
+export async function mergeBranch(args: MergeBranchArgs): Promise<void> {
+  await exec(`git merge ${shq(args.branch)}`, { cwd: args.cwd });
+}
+
+/**
+ * Create a tag. With `message`, makes an annotated tag; without, a
+ * lightweight tag. With `sha`, tags that commit; without, tags HEAD.
+ */
+export async function createTag(args: CreateTagArgs): Promise<void> {
+  const parts = ["git", "tag"];
+  if (args.message) parts.push("-a");
+  parts.push(shq(args.name));
+  if (args.message) parts.push("-m", shq(args.message));
+  if (args.sha) parts.push(shq(args.sha));
+  await exec(parts.join(" "), { cwd: args.cwd });
+}
+
+/** Delete a local tag (`git tag -d <name>`). */
+export async function deleteTag(args: DeleteTagArgs): Promise<void> {
+  await exec(`git tag -d ${shq(args.name)}`, { cwd: args.cwd });
+}
+
+/**
+ * Delete a tag from the remote. Uses `git push <remote> --delete
+ * refs/tags/<name>` so the call works whether or not the local tag
+ * still exists.
+ */
+export async function deleteRemoteTag(
+  args: DeleteRemoteTagArgs
+): Promise<void> {
+  const remote = args.remote ?? "origin";
+  await exec(`git push ${remote} --delete ${shq(`refs/tags/${args.name}`)}`, {
+    cwd: args.cwd,
+  });
+}

--- a/scripts/git/commit-push.ts
+++ b/scripts/git/commit-push.ts
@@ -1,17 +1,18 @@
 // Initial commit + (optional) push for a freshly-scaffolded project.
 //
 // Mirrors the tail of ProjectCreationService.createProject. The
-// workflow-scope error message is preserved verbatim – the raw remote
+// workflow-scope error message is preserved verbatim: the raw remote
 // rejection ("without `workflow` scope") is opaque if you haven't seen it.
+//
+// The general-purpose `commit` / `commitAll` / `commitAmend` / etc.
+// primitives live in ./commits.ts. This module's surface is now
+// strictly the project-scaffold + push flow.
 
 import { exec } from "../util/exec.js";
 
-export interface CommitArgs {
+export interface CommitAndPushArgs {
   projectDir: string;
   message: string;
-}
-
-export interface CommitAndPushArgs extends CommitArgs {
   /** Push to "origin main" after commit. Default: true. */
   push?: boolean;
   /** Remote name. Default: "origin". */
@@ -35,23 +36,20 @@ export class WorkflowScopeError extends Error {
   }
 }
 
-/** `git add -A` + `git commit -m <message>`. Does not push. */
-export async function commit(args: CommitArgs): Promise<void> {
+/**
+ * Commit and (by default) push to origin/main with -u. Stages
+ * everything first (`git add -A`), then commits with the given message,
+ * then pushes. Throws {@link WorkflowScopeError} when the remote
+ * rejects due to the GitHub token lacking the `workflow` OAuth scope.
+ *
+ * For non-initial-commit flows, prefer the primitives in ./commits.ts.
+ */
+export async function commitAndPush(args: CommitAndPushArgs): Promise<void> {
   await exec("git add -A", { cwd: args.projectDir });
   await exec(`git commit -m ${JSON.stringify(args.message)}`, {
     cwd: args.projectDir,
     timeout: 30_000,
   });
-}
-
-/**
- * Commit and (by default) push to origin/main with -u. Throws
- * {@link WorkflowScopeError} when the remote rejects due to the GitHub
- * token lacking the `workflow` OAuth scope – that error message is highly
- * actionable and worth preserving.
- */
-export async function commitAndPush(args: CommitAndPushArgs): Promise<void> {
-  await commit(args);
   if (args.push === false) return;
   const remote = args.remote ?? "origin";
   const branch = args.branch ?? "main";

--- a/scripts/git/commits.ts
+++ b/scripts/git/commits.ts
@@ -1,0 +1,128 @@
+// Commit-side workflow primitives. Lifted from lakebase-scm-extension's
+// GitService commit / amend / signoff / undo / discard methods (P5b).
+//
+// All shell-out args go through JSON.stringify rather than the
+// extension's naive double-quote escape, so messages containing
+// backticks, dollar signs, or newlines round-trip correctly. The kit's
+// commit-push.ts already uses this pattern.
+
+import { exec, shq } from "../util/exec.js";
+
+export interface CommitArgs {
+  cwd: string;
+  message: string;
+}
+
+export interface AmendArgs {
+  cwd: string;
+  /**
+   * New message. When omitted, the existing message is preserved
+   * (`git commit --amend --no-edit`). When provided, it replaces the
+   * existing message (`git commit --amend -m ...`).
+   */
+  message?: string;
+}
+
+export interface UndoLastCommitArgs {
+  cwd: string;
+}
+
+export interface DiscardAllChangesArgs {
+  cwd: string;
+  /**
+   * Destructive: must be set to `true` to actually wipe the working
+   * tree (runs `git checkout -- .` + `git clean -fd`). Required to
+   * keep accidental invocations from nuking uncommitted work; the
+   * extension's UI driver always sets it explicitly after user confirm.
+   */
+  confirm: true;
+}
+
+/** Commit ALREADY-staged changes. Throws when the message is empty. */
+export async function commit(args: CommitArgs): Promise<void> {
+  if (!args.message.trim()) {
+    throw new Error("Commit message is required");
+  }
+  await exec(`git commit -m ${shq(args.message)}`, {
+    cwd: args.cwd,
+  });
+}
+
+/** `git add -A` + commit. Throws when the message is empty. */
+export async function commitAll(args: CommitArgs): Promise<void> {
+  if (!args.message.trim()) {
+    throw new Error("Commit message is required");
+  }
+  await exec("git add -A", { cwd: args.cwd });
+  await exec(`git commit -m ${shq(args.message)}`, {
+    cwd: args.cwd,
+  });
+}
+
+/** Commit with DCO sign-off. Throws when the message is empty. */
+export async function commitSignedOff(args: CommitArgs): Promise<void> {
+  if (!args.message.trim()) {
+    throw new Error("Commit message is required");
+  }
+  await exec(`git commit -s -m ${shq(args.message)}`, {
+    cwd: args.cwd,
+  });
+}
+
+/** `git add -A` + commit with DCO sign-off. Throws when message is empty. */
+export async function commitAllSignedOff(args: CommitArgs): Promise<void> {
+  if (!args.message.trim()) {
+    throw new Error("Commit message is required");
+  }
+  await exec("git add -A", { cwd: args.cwd });
+  await exec(`git commit -s -m ${shq(args.message)}`, {
+    cwd: args.cwd,
+  });
+}
+
+/**
+ * Amend the previous commit. Without `message`, keeps the existing
+ * commit message (`--no-edit`). With `message`, replaces it.
+ */
+export async function commitAmend(args: AmendArgs): Promise<void> {
+  if (args.message !== undefined) {
+    if (!args.message.trim()) {
+      throw new Error("Commit message is required");
+    }
+    await exec(
+      `git commit --amend -m ${shq(args.message)}`,
+      { cwd: args.cwd }
+    );
+  } else {
+    await exec("git commit --amend --no-edit", { cwd: args.cwd });
+  }
+}
+
+/**
+ * Soft-reset to HEAD~1, keeping the working tree + index intact. The
+ * commit is removed from history but its changes remain staged so the
+ * caller can re-commit with a corrected message / scope.
+ */
+export async function undoLastCommit(args: UndoLastCommitArgs): Promise<void> {
+  await exec("git reset --soft HEAD~1", { cwd: args.cwd });
+}
+
+/**
+ * Hard-discard ALL changes in the working tree (tracked + untracked).
+ * Requires `confirm: true` as a typed safety latch so accidental calls
+ * don't wipe uncommitted work. Equivalent to:
+ *
+ *   git checkout -- .
+ *   git clean -fd
+ */
+export async function discardAllChanges(
+  args: DiscardAllChangesArgs
+): Promise<void> {
+  if (args.confirm !== true) {
+    throw new Error(
+      "discardAllChanges requires confirm: true (destructive operation)"
+    );
+  }
+  await exec("git checkout -- .", { cwd: args.cwd });
+  await exec("git clean -fd", { cwd: args.cwd });
+}

--- a/scripts/git/index.ts
+++ b/scripts/git/index.ts
@@ -8,3 +8,6 @@ export * from "./branches.js";
 export * from "./ancestry.js";
 export * from "./status.js";
 export * from "./migrations.js";
+export * from "./commits.js";
+export * from "./sync.js";
+export * from "./branch-tag.js";

--- a/scripts/git/sync.ts
+++ b/scripts/git/sync.ts
@@ -1,0 +1,82 @@
+// Sync primitives: push, pull, publish-branch, push-for-PR. Lifted
+// from the extension's GitService methods (P5c).
+//
+// publishBranch and pushCurrentBranchForPr both need the current
+// branch name; they resolve it internally via `git rev-parse
+// --abbrev-ref HEAD` so callers don't have to pass it (and so the
+// "no current branch" error message is consistent).
+
+import { exec, shq } from "../util/exec.js";
+import { hasUpstream } from "./status.js";
+
+export interface CwdOnly {
+  cwd: string;
+}
+
+export interface PublishBranchArgs {
+  cwd: string;
+  /** Remote to push to. Default: "origin". */
+  remote?: string;
+}
+
+export interface PushCurrentBranchForPrArgs {
+  cwd: string;
+  /** Remote for the initial publish (when no upstream yet). Default: "origin". */
+  remote?: string;
+}
+
+async function currentBranchName(cwd: string): Promise<string> {
+  try {
+    return await exec("git rev-parse --abbrev-ref HEAD", { cwd });
+  } catch {
+    return "";
+  }
+}
+
+/** `git push` with no args. Uses the configured upstream. */
+export async function push(args: CwdOnly): Promise<void> {
+  await exec("git push", { cwd: args.cwd });
+}
+
+/** `git pull` with no args. Uses the configured upstream. */
+export async function pull(args: CwdOnly): Promise<void> {
+  await exec("git pull", { cwd: args.cwd });
+}
+
+/**
+ * First push of a local branch: `git push -u <remote> <current-branch>`.
+ * Throws when no current branch exists (detached HEAD / empty repo).
+ */
+export async function publishBranch(args: PublishBranchArgs): Promise<void> {
+  const remote = args.remote ?? "origin";
+  const branch = await currentBranchName(args.cwd);
+  if (!branch) throw new Error("No current branch");
+  await exec(`git push -u ${remote} ${shq(branch)}`, {
+    cwd: args.cwd,
+  });
+}
+
+/**
+ * Ensure the current branch is pushed before PR creation. Publishes
+ * with `-u <remote>` when no upstream exists; otherwise plain `git
+ * push`. Throws when no current branch exists.
+ *
+ * Pairs with the host's PR-creation flow (e.g. extension's
+ * GitHubService.createPullRequest): this handles git push, the caller
+ * handles the REST API.
+ */
+export async function pushCurrentBranchForPr(
+  args: PushCurrentBranchForPrArgs
+): Promise<void> {
+  const remote = args.remote ?? "origin";
+  const branch = await currentBranchName(args.cwd);
+  if (!branch) throw new Error("No current branch");
+  const upstreamSet = await hasUpstream({ cwd: args.cwd });
+  if (!upstreamSet) {
+    await exec(`git push -u ${remote} ${shq(branch)}`, {
+      cwd: args.cwd,
+    });
+  } else {
+    await exec("git push", { cwd: args.cwd });
+  }
+}

--- a/scripts/util/exec.ts
+++ b/scripts/util/exec.ts
@@ -11,6 +11,25 @@ export interface ExecOptions {
   timeout?: number;
 }
 
+/**
+ * POSIX-shell single-quote escape. Wraps `s` in single quotes and
+ * escapes any literal single quotes as `'\''`. Resulting string is
+ * safe to interpolate as a single argv element under /bin/sh: variable
+ * expansion ($x), command substitution (`x`), backslash escapes, and
+ * glob/tilde expansion are all suppressed.
+ *
+ * Use this instead of JSON.stringify when building git / databricks
+ * shell commands. JSON.stringify produces double-quoted output, which
+ * leaves $ and ` shell-active and corrupts messages containing them.
+ *
+ * Windows note: this helper assumes a POSIX shell. The kit's CLI
+ * surface is currently POSIX-only (macOS / Linux / GitHub-hosted
+ * runners). Callers that target cmd.exe should pre-escape themselves.
+ */
+export function shq(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
 export function exec(command: string, opts: ExecOptions = {}): Promise<string> {
   return new Promise((resolve, reject) => {
     const options: cp.ExecOptions = {

--- a/tests/bdd/git-mutation.test.ts
+++ b/tests/bdd/git-mutation.test.ts
@@ -1,0 +1,547 @@
+// BDD coverage for the P5b/c/d mutation git primitives: commits.ts,
+// sync.ts, branch-tag.ts. Each describe block uses an isolated temp
+// repo so tests don't depend on the host's working tree.
+
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gitInit } from "../../scripts/git/init.js";
+import {
+  commit,
+  commitAll,
+  commitAmend,
+  commitSignedOff,
+  commitAllSignedOff,
+  undoLastCommit,
+  discardAllChanges,
+} from "../../scripts/git/commits.js";
+import {
+  push,
+  pull,
+  publishBranch,
+  pushCurrentBranchForPr,
+} from "../../scripts/git/sync.js";
+import {
+  deleteLocalBranch,
+  renameBranch,
+  mergeBranch,
+  createTag,
+  deleteTag,
+  deleteRemoteTag,
+  ProtectedBranchError,
+} from "../../scripts/git/branch-tag.js";
+import { exec } from "../../scripts/util/exec.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+});
+
+function mkTmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lbscm-gm-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function configIdentity(cwd: string): Promise<void> {
+  await exec("git config user.email test@example.com", { cwd });
+  await exec("git config user.name 'Test User'", { cwd });
+}
+
+async function writeAndStage(
+  cwd: string,
+  name: string,
+  contents: string
+): Promise<void> {
+  fs.writeFileSync(path.join(cwd, name), contents);
+  await exec(`git add ${JSON.stringify(name)}`, { cwd });
+}
+
+async function lastCommitMessage(cwd: string): Promise<string> {
+  return await exec("git log -1 --pretty=%B", { cwd });
+}
+
+async function lastCommitSha(cwd: string): Promise<string> {
+  return await exec("git rev-parse HEAD", { cwd });
+}
+
+// ---------- commits.ts ----------
+
+describe("commit", () => {
+  it("commits already-staged changes with the given message", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "first" });
+    expect((await lastCommitMessage(dir)).trim()).toBe("first");
+  });
+
+  it("does NOT auto-stage unstaged files", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    // Seed commit so HEAD exists for rev-list later
+    await writeAndStage(dir, "seed.txt", "");
+    await commit({ cwd: dir, message: "seed" });
+    // Unstaged write
+    fs.writeFileSync(path.join(dir, "unstaged.txt"), "x");
+    // commit with no staged changes should throw
+    await expect(commit({ cwd: dir, message: "should fail" })).rejects.toThrow();
+  });
+
+  it("throws on empty / whitespace-only message", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await expect(commit({ cwd: dir, message: "" })).rejects.toThrow(
+      /required/
+    );
+    await expect(commit({ cwd: dir, message: "   " })).rejects.toThrow(
+      /required/
+    );
+  });
+
+  it("handles messages with shell-special characters", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    const msg = 'a (b/c): "x" $y `z`';
+    await commit({ cwd: dir, message: msg });
+    expect((await lastCommitMessage(dir)).trim()).toBe(msg);
+  });
+});
+
+describe("commitAll", () => {
+  it("stages everything and commits", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    fs.writeFileSync(path.join(dir, "a.txt"), "a");
+    fs.writeFileSync(path.join(dir, "b.txt"), "b");
+    await commitAll({ cwd: dir, message: "both" });
+    const log = await exec(
+      "git log -1 --name-only --pretty=format:",
+      { cwd: dir }
+    );
+    expect(log.split("\n").filter(Boolean).sort()).toEqual(["a.txt", "b.txt"]);
+  });
+});
+
+describe("commitSignedOff", () => {
+  it("commits with a DCO Signed-off-by trailer", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commitSignedOff({ cwd: dir, message: "signed" });
+    const body = await lastCommitMessage(dir);
+    expect(body).toMatch(/Signed-off-by: Test User <test@example.com>/);
+  });
+});
+
+describe("commitAllSignedOff", () => {
+  it("stages everything AND adds the Signed-off-by trailer", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    fs.writeFileSync(path.join(dir, "a.txt"), "a");
+    fs.writeFileSync(path.join(dir, "b.txt"), "b");
+    await commitAllSignedOff({ cwd: dir, message: "both signed" });
+    const body = await lastCommitMessage(dir);
+    expect(body).toMatch(/Signed-off-by:/);
+    const log = await exec(
+      "git log -1 --name-only --pretty=format:",
+      { cwd: dir }
+    );
+    expect(log.split("\n").filter(Boolean).sort()).toEqual(["a.txt", "b.txt"]);
+  });
+});
+
+describe("commitAmend", () => {
+  it("preserves the previous message when called without a new one", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "original" });
+    // stage additional change and amend
+    fs.writeFileSync(path.join(dir, "a.txt"), "a2");
+    await exec("git add -A", { cwd: dir });
+    await commitAmend({ cwd: dir });
+    expect((await lastCommitMessage(dir)).trim()).toBe("original");
+  });
+
+  it("replaces the message when a new one is provided", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "original" });
+    await commitAmend({ cwd: dir, message: "rewritten" });
+    expect((await lastCommitMessage(dir)).trim()).toBe("rewritten");
+  });
+
+  it("throws when message is provided but empty", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await expect(commitAmend({ cwd: dir, message: "" })).rejects.toThrow(
+      /required/
+    );
+  });
+});
+
+describe("undoLastCommit", () => {
+  it("removes the last commit but keeps changes staged (--soft)", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await writeAndStage(dir, "b.txt", "b");
+    await commit({ cwd: dir, message: "to-undo" });
+    const beforeSha = await lastCommitSha(dir);
+    await undoLastCommit({ cwd: dir });
+    const afterSha = await lastCommitSha(dir);
+    expect(afterSha).not.toBe(beforeSha);
+    expect((await lastCommitMessage(dir)).trim()).toBe("seed");
+    // b.txt remains in the working tree + staged
+    expect(fs.existsSync(path.join(dir, "b.txt"))).toBe(true);
+    const staged = await exec("git diff --cached --name-only", { cwd: dir });
+    expect(staged.split("\n")).toContain("b.txt");
+  });
+});
+
+describe("discardAllChanges", () => {
+  it("requires confirm: true (typed safety latch)", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    // @ts-expect-error - intentionally omitting required confirm flag
+    await expect(discardAllChanges({ cwd: dir })).rejects.toThrow(
+      /confirm: true/
+    );
+  });
+
+  it("wipes tracked + untracked changes with confirm: true", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    // Both an unstaged modification and an untracked file
+    fs.writeFileSync(path.join(dir, "a.txt"), "modified");
+    fs.writeFileSync(path.join(dir, "untracked.txt"), "x");
+    await discardAllChanges({ cwd: dir, confirm: true });
+    expect(fs.readFileSync(path.join(dir, "a.txt"), "utf8")).toBe("a");
+    expect(fs.existsSync(path.join(dir, "untracked.txt"))).toBe(false);
+  });
+});
+
+// ---------- sync.ts ----------
+
+async function makeLocalAndRemote(): Promise<{
+  local: string;
+  remote: string;
+}> {
+  const remote = mkTmp();
+  await exec("git init --bare -b main", { cwd: remote });
+  const local = mkTmp();
+  await gitInit(local);
+  await configIdentity(local);
+  await writeAndStage(local, "a.txt", "a");
+  await commit({ cwd: local, message: "seed" });
+  await exec(`git remote add origin ${JSON.stringify(remote)}`, { cwd: local });
+  return { local, remote };
+}
+
+describe("publishBranch", () => {
+  it("pushes the current branch with -u origin", async () => {
+    const { local, remote } = await makeLocalAndRemote();
+    await publishBranch({ cwd: local });
+    const heads = await exec("git ls-remote --heads origin main", {
+      cwd: local,
+    });
+    expect(heads.trim().length).toBeGreaterThan(0);
+    // upstream is now set
+    const upstream = await exec("git rev-parse --abbrev-ref @{u}", {
+      cwd: local,
+    });
+    expect(upstream).toBe("origin/main");
+    expect(remote).toBeTruthy();
+  });
+
+  it("propagates git's error on detached HEAD (no current-branch detection)", async () => {
+    // Note: `git rev-parse --abbrev-ref HEAD` returns the literal "HEAD"
+    // in detached state, not an empty string. Substrate matches the
+    // extension's existing behavior (no detached-HEAD detection): it
+    // attempts `git push -u origin "HEAD"` which git rejects with a
+    // refname error. A future hardening pass could detect this and
+    // throw a friendlier error, but for the lift we preserve behavior.
+    const { local } = await makeLocalAndRemote();
+    const sha = await lastCommitSha(local);
+    await exec(`git checkout --detach ${sha}`, { cwd: local });
+    await expect(publishBranch({ cwd: local })).rejects.toThrow();
+  });
+});
+
+describe("push", () => {
+  it("succeeds with a configured upstream", async () => {
+    const { local } = await makeLocalAndRemote();
+    await publishBranch({ cwd: local });
+    // make a new commit, then push
+    await writeAndStage(local, "b.txt", "b");
+    await commit({ cwd: local, message: "second" });
+    await push({ cwd: local });
+    const remoteSha = await exec("git rev-parse origin/main", { cwd: local });
+    const localSha = await lastCommitSha(local);
+    expect(remoteSha).toBe(localSha);
+  });
+
+  it("rejects when no upstream is set", async () => {
+    const { local } = await makeLocalAndRemote();
+    await expect(push({ cwd: local })).rejects.toThrow();
+  });
+});
+
+describe("pull", () => {
+  it("fast-forwards local from upstream", async () => {
+    const { local, remote } = await makeLocalAndRemote();
+    await publishBranch({ cwd: local });
+    // Second clone simulates a peer pushing a new commit
+    const peer = mkTmp();
+    await exec(`git clone ${JSON.stringify(remote)} ${JSON.stringify(peer)}`, {
+      cwd: os.tmpdir(),
+    });
+    await configIdentity(peer);
+    await writeAndStage(peer, "from-peer.txt", "x");
+    await commit({ cwd: peer, message: "peer commit" });
+    await push({ cwd: peer });
+
+    await pull({ cwd: local });
+    expect(fs.existsSync(path.join(local, "from-peer.txt"))).toBe(true);
+  });
+});
+
+describe("pushCurrentBranchForPr", () => {
+  it("publishes with -u when no upstream", async () => {
+    const { local } = await makeLocalAndRemote();
+    await pushCurrentBranchForPr({ cwd: local });
+    const upstream = await exec("git rev-parse --abbrev-ref @{u}", {
+      cwd: local,
+    });
+    expect(upstream).toBe("origin/main");
+  });
+
+  it("plain-pushes when upstream is already set", async () => {
+    const { local } = await makeLocalAndRemote();
+    await publishBranch({ cwd: local });
+    await writeAndStage(local, "b.txt", "b");
+    await commit({ cwd: local, message: "second" });
+    await pushCurrentBranchForPr({ cwd: local });
+    const remoteSha = await exec("git rev-parse origin/main", { cwd: local });
+    const localSha = await lastCommitSha(local);
+    expect(remoteSha).toBe(localSha);
+  });
+});
+
+// ---------- branch-tag.ts ----------
+
+describe("deleteLocalBranch", () => {
+  it("deletes a merged branch with -d", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await exec("git checkout -b feature/x", { cwd: dir });
+    await exec("git checkout main", { cwd: dir });
+    await deleteLocalBranch({ cwd: dir, branch: "feature/x" });
+    const list = await exec("git branch", { cwd: dir });
+    expect(list).not.toMatch(/feature\/x/);
+  });
+
+  it("refuses to -d an unmerged branch without force", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await exec("git checkout -b feature/y", { cwd: dir });
+    await writeAndStage(dir, "b.txt", "b");
+    await commit({ cwd: dir, message: "diverge" });
+    await exec("git checkout main", { cwd: dir });
+    await expect(
+      deleteLocalBranch({ cwd: dir, branch: "feature/y" })
+    ).rejects.toThrow();
+  });
+
+  it("force-deletes an unmerged branch with force: true", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await exec("git checkout -b feature/y", { cwd: dir });
+    await writeAndStage(dir, "b.txt", "b");
+    await commit({ cwd: dir, message: "diverge" });
+    await exec("git checkout main", { cwd: dir });
+    await deleteLocalBranch({ cwd: dir, branch: "feature/y", force: true });
+    const list = await exec("git branch", { cwd: dir });
+    expect(list).not.toMatch(/feature\/y/);
+  });
+
+  for (const protectedName of ["production", "main", "master"]) {
+    it(`refuses to delete protected branch "${protectedName}"`, async () => {
+      const dir = mkTmp();
+      await gitInit(dir);
+      await configIdentity(dir);
+      await writeAndStage(dir, "a.txt", "a");
+      await commit({ cwd: dir, message: "seed" });
+      // create branch + checkout away so deleteBranch isn't blocked by "current"
+      if (protectedName !== "main") {
+        await exec(`git branch ${protectedName}`, { cwd: dir });
+      }
+      await exec("git checkout -b sandbox", { cwd: dir });
+      await expect(
+        deleteLocalBranch({ cwd: dir, branch: protectedName, force: true })
+      ).rejects.toBeInstanceOf(ProtectedBranchError);
+    });
+  }
+
+  it("deletes a protected branch with allowProtected: true override", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await exec("git branch production", { cwd: dir });
+    await deleteLocalBranch({
+      cwd: dir,
+      branch: "production",
+      allowProtected: true,
+    });
+    const list = await exec("git branch", { cwd: dir });
+    expect(list).not.toMatch(/production/);
+  });
+});
+
+describe("renameBranch", () => {
+  it("renames the current branch", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await exec("git checkout -b old-name", { cwd: dir });
+    await renameBranch({ cwd: dir, newName: "new-name" });
+    const current = await exec("git rev-parse --abbrev-ref HEAD", {
+      cwd: dir,
+    });
+    expect(current).toBe("new-name");
+  });
+});
+
+describe("mergeBranch", () => {
+  it("merges a branch into current", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await exec("git checkout -b feature/m", { cwd: dir });
+    await writeAndStage(dir, "b.txt", "b");
+    await commit({ cwd: dir, message: "feature commit" });
+    await exec("git checkout main", { cwd: dir });
+    await mergeBranch({ cwd: dir, branch: "feature/m" });
+    expect(fs.existsSync(path.join(dir, "b.txt"))).toBe(true);
+  });
+});
+
+describe("createTag", () => {
+  it("creates a lightweight tag on HEAD", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await createTag({ cwd: dir, name: "v1.0" });
+    const tags = await exec("git tag", { cwd: dir });
+    expect(tags).toMatch(/^v1\.0$/m);
+  });
+
+  it("creates an annotated tag with a message", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await createTag({
+      cwd: dir,
+      name: "v1.1",
+      message: "first annotated tag",
+    });
+    const out = await exec("git for-each-ref refs/tags/v1.1 --format='%(objecttype) %(contents:subject)'", {
+      cwd: dir,
+    });
+    expect(out).toMatch(/tag first annotated tag/);
+  });
+
+  it("tags a specific sha", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    const firstSha = await lastCommitSha(dir);
+    await writeAndStage(dir, "b.txt", "b");
+    await commit({ cwd: dir, message: "second" });
+    await createTag({ cwd: dir, name: "first", sha: firstSha });
+    const sha = await exec("git rev-parse first", { cwd: dir });
+    expect(sha).toBe(firstSha);
+  });
+});
+
+describe("deleteTag", () => {
+  it("deletes a local tag", async () => {
+    const dir = mkTmp();
+    await gitInit(dir);
+    await configIdentity(dir);
+    await writeAndStage(dir, "a.txt", "a");
+    await commit({ cwd: dir, message: "seed" });
+    await createTag({ cwd: dir, name: "tmp" });
+    await deleteTag({ cwd: dir, name: "tmp" });
+    const tags = await exec("git tag", { cwd: dir });
+    expect(tags).not.toMatch(/tmp/);
+  });
+});
+
+describe("deleteRemoteTag", () => {
+  it("deletes a tag from the remote", async () => {
+    const { local } = await makeLocalAndRemote();
+    await publishBranch({ cwd: local });
+    await createTag({ cwd: local, name: "remote-tag" });
+    await exec("git push origin remote-tag", { cwd: local });
+    await deleteRemoteTag({ cwd: local, name: "remote-tag" });
+    const remoteTags = await exec("git ls-remote --tags origin", {
+      cwd: local,
+    });
+    expect(remoteTags).not.toMatch(/remote-tag/);
+  });
+});

--- a/tests/bdd/git-utils.test.ts
+++ b/tests/bdd/git-utils.test.ts
@@ -3,7 +3,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { gitInit } from "../../scripts/git/init.js";
-import { commit, commitAndPush, WorkflowScopeError } from "../../scripts/git/commit-push.js";
+import { commitAndPush, WorkflowScopeError } from "../../scripts/git/commit-push.js";
+import { commitAll } from "../../scripts/git/commits.js";
 import { exec } from "../../scripts/util/exec.js";
 
 const tmpDirs: string[] = [];
@@ -38,13 +39,17 @@ describe("gitInit", () => {
   });
 });
 
-describe("commit", () => {
+// The standalone `commit` export from commit-push.ts was removed in
+// FEIP-7324 in favor of the more general primitives in scripts/git/commits.ts.
+// commitAll covers the "stage everything + commit" behavior these tests
+// previously exercised via the old commit-push.commit shim.
+describe("commitAll (project-scaffold stage-and-commit equivalent)", () => {
   it("stages everything and creates a commit with the given message", async () => {
     const dir = mkTmp();
     await gitInit(dir);
     await configIdentity(dir);
     fs.writeFileSync(path.join(dir, "README.md"), "# Test\n");
-    await commit({ projectDir: dir, message: "Initial test commit" });
+    await commitAll({ cwd: dir, message: "Initial test commit" });
     const log = await exec("git log -1 --pretty=%s", { cwd: dir });
     expect(log).toBe("Initial test commit");
   });
@@ -55,7 +60,7 @@ describe("commit", () => {
     await configIdentity(dir);
     fs.writeFileSync(path.join(dir, "x"), "");
     const msg = `Initial scaffold (Java/Spring Boot + Lakebase): "test"`;
-    await commit({ projectDir: dir, message: msg });
+    await commitAll({ cwd: dir, message: msg });
     const log = await exec("git log -1 --pretty=%s", { cwd: dir });
     expect(log).toBe(msg);
   });


### PR DESCRIPTION
## Summary

Completes the last three P5 sub-tasks in one PR. Lifts 17 inline git mutation ops from the extension's GitService into three new substrate modules.

## Scope

| Sub-task | Module | Primitives |
| --- | --- | --- |
| FEIP-7324 P5b | \`scripts/git/commits.ts\` | \`commit\`, \`commitAll\`, \`commitSignedOff\`, \`commitAllSignedOff\`, \`commitAmend\` (handles both --no-edit and message-replace), \`undoLastCommit\`, \`discardAllChanges\` |
| FEIP-7325 P5c | \`scripts/git/sync.ts\` | \`push\`, \`pull\`, \`publishBranch\`, \`pushCurrentBranchForPr\` |
| FEIP-7326 P5d | \`scripts/git/branch-tag.ts\` | \`deleteLocalBranch\`, \`renameBranch\`, \`mergeBranch\`, \`createTag\`, \`deleteTag\`, \`deleteRemoteTag\` |

## Safety guardrails

- \`discardAllChanges\` requires \`confirm: true\` as a typed safety latch. Without it, the call throws rather than wiping uncommitted work.
- \`deleteLocalBranch\` refuses \`production\` / \`main\` / \`master\` without \`allowProtected: true\`. Throws a typed \`ProtectedBranchError\` so callers can distinguish the protection refusal from other delete failures. Enforces \`reference_databricks_lakebase_skill\` memory rule at the substrate layer.

## Renames + drive-bys

- **\`deleteBranch\` -> \`deleteLocalBranch\`**: the kit's top-level barrel already exports a Lakebase \`deleteBranch\` (Lakebase Postgres branch). The new git verb is qualified to disambiguate. Extension proxy will preserve the unqualified \`GitService.deleteBranch\` name and delegate to \`deleteLocalBranch\` internally.
- **New \`shq()\` helper in \`scripts/util/exec.ts\`**: POSIX-shell single-quote escape. Replaces \`JSON.stringify\` in all new shell-out paths. JSON.stringify produces double-quoted output which leaves \`$\` and backticks shell-active; the old escape would corrupt commit messages containing them. Existing JSON.stringify calls in \`commit-push.ts\` left as-is for this PR (their callsites only handle scaffold messages).
- **Drop standalone \`commit\` / \`CommitArgs\` exports from \`commit-push.ts\`**. Subsumed by the new \`commits.ts\` primitives. Only \`commitAndPush\` (and \`WorkflowScopeError\`) remain as the project-scaffold initial-commit entrypoint. Existing test in \`git-utils.test.ts\` updated to use \`commitAll\` from the new module.

## Tests

- **34 new vitest cases** in \`tests/bdd/git-mutation.test.ts\`. Each primitive exercised against an isolated temp git repo (and where relevant, a bare-remote pair). Coverage includes:
  - Shell-active chars in commit messages (\`\$y \`z\`\` round-trips)
  - \`commitAmend\` both branches (with + without message)
  - \`undoLastCommit\` verifies --soft semantics (staged changes preserved)
  - \`discardAllChanges\` typed-safety-latch refusal
  - \`deleteLocalBranch\` protected-branch refusal for all 3 names + \`allowProtected\` override
  - \`pushCurrentBranchForPr\` no-upstream vs has-upstream paths
- **Full kit suite: 551 passing** (+34 new), 63 skipped (pre-existing), 0 failed.
- typecheck + build clean.

## Not in this PR

- No callsite changes in the extension. Follow-up PR will pin to alpha.27 and convert the 17 GitService methods to substrate proxies.
- VS Code SCM hooks (\`getStagedFiles\`, \`stageFile\`, change-detection init, etc.) stay in the extension per FEIP-7322's scope map.

## Related

- Parent: FEIP-7322 (gitService.ts extraction audit + remaining lift)
- Sub-tasks: FEIP-7324 (commit), FEIP-7325 (sync), FEIP-7326 (branch+tag)
- Builds on: FEIP-7323 (P5a workflow-coordination, v0.3.0-alpha.26)

## Test plan

- [x] vitest run tests/bdd/git-mutation.test.ts (34/34)
- [x] full kit suite (551 passing)
- [x] typecheck
- [x] build

This pull request and its description were written by Isaac.