### PR TITLE
chore(release): v0.3.0-alpha.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.26",
+  "version": "0.3.0-alpha.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.26",
+      "version": "0.3.0-alpha.27",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.26",
+  "version": "0.3.0-alpha.27",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary

Ship P5b/c/d primitives from #60.

- Bumps \`package.json#version\` to \`0.3.0-alpha.27\`
- Syncs \`package-lock.json\`

Tag \`v0.3.0-alpha.27\` cut from the merge commit after this lands. lakebase-scm-extension's pin update follows.