### PR TITLE
fix(git): shq + named args for cloneRepo (FEIP-7341)

### DIFF
--- a/scripts/git/clone.ts
+++ b/scripts/git/clone.ts
@@ -2,19 +2,38 @@
 // promoted to a focused module so create-project can call it without
 // pulling in the 1046-line gitService.
 
-import { exec } from "../util/exec.js";
+import { exec, shq } from "../util/exec.js";
+
+export interface CloneRepoArgs {
+  /** Git URL (https:// or ssh://). */
+  repoUrl: string;
+  /**
+   * Directory that will contain the cloned repo. Git creates the
+   * target directory as a subdir of `parentDir`, named after the repo.
+   */
+  parentDir: string;
+  /** Milliseconds before SIGTERM. Default: 60_000. */
+  timeoutMs?: number;
+}
 
 /**
- * Clone a Git repository into `parentDir`. Git creates the target dir as a
- * subdir of `parentDir` named after the repo.
+ * Clone a Git repository into `parentDir`. Git creates the target dir
+ * as a subdir of `parentDir` named after the repo.
  *
- * For HTTPS URLs, git will use whatever credential helper is configured –
- * typically the macOS keychain or `osxkeychain`. For SSH URLs, the user's
- * ssh agent. No GitHub token plumbing happens here.
+ * For HTTPS URLs, git uses the configured credential helper (typically
+ * the macOS keychain or `osxkeychain`). For SSH URLs, the user's ssh
+ * agent. No GitHub token plumbing happens here.
  *
- * @throws Error if the clone subprocess exits non-zero (auth failure, repo
- *   not found, network error, etc.).
+ * The URL is shq-escaped: shell-active characters in the URL (e.g. `$`
+ * or backticks in unusual self-hosted endpoints) are suppressed rather
+ * than expanded.
+ *
+ * @throws Error if the clone subprocess exits non-zero (auth failure,
+ *   repo not found, network error, etc.).
  */
-export async function cloneRepo(repoUrl: string, parentDir: string): Promise<void> {
-  await exec(`git clone "${repoUrl}"`, { cwd: parentDir, timeout: 60_000 });
+export async function cloneRepo(args: CloneRepoArgs): Promise<void> {
+  await exec(`git clone ${shq(args.repoUrl)}`, {
+    cwd: args.parentDir,
+    timeout: args.timeoutMs ?? 60_000,
+  });
 }

--- a/scripts/lakebase/create-project.ts
+++ b/scripts/lakebase/create-project.ts
@@ -131,7 +131,10 @@ export async function createProject(
       );
     }
     report("Cloning repository...", projectDir);
-    await cloneRepo(`https://github.com/${fullRepoName}.git`, input.parentDir);
+    await cloneRepo({
+      repoUrl: `https://github.com/${fullRepoName}.git`,
+      parentDir: input.parentDir,
+    });
   } else {
     report("Creating local project directory...", projectDir);
     if (fs.existsSync(projectDir)) {

--- a/tests/bdd/git-utils.test.ts
+++ b/tests/bdd/git-utils.test.ts
@@ -5,7 +5,8 @@ import * as path from "node:path";
 import { gitInit } from "../../scripts/git/init.js";
 import { commitAndPush, WorkflowScopeError } from "../../scripts/git/commit-push.js";
 import { commitAll } from "../../scripts/git/commits.js";
-import { exec } from "../../scripts/util/exec.js";
+import { cloneRepo } from "../../scripts/git/clone.js";
+import { exec, shq } from "../../scripts/util/exec.js";
 
 const tmpDirs: string[] = [];
 
@@ -84,5 +85,54 @@ describe("WorkflowScopeError", () => {
     expect(err.name).toBe("WorkflowScopeError");
     expect(err.message).toMatch(/cd \/tmp\/my-proj && git push -u origin main/);
     expect(err.message).toMatch(/workflow.*scope/);
+  });
+});
+
+describe("shq", () => {
+  it("suppresses shell variable expansion", () => {
+    expect(shq("$HOME")).toBe("'$HOME'");
+  });
+
+  it("suppresses command substitution backticks", () => {
+    expect(shq("a `b` c")).toBe("'a `b` c'");
+  });
+
+  it("escapes embedded single quotes", () => {
+    expect(shq("it's a test")).toBe("'it'\\''s a test'");
+  });
+});
+
+describe("cloneRepo", () => {
+  it("clones from a local bare repo into parentDir", async () => {
+    // Source: bare repo seeded with one commit
+    const sourceBare = mkTmp();
+    await exec("git init --bare -b main", { cwd: sourceBare });
+    const seed = mkTmp();
+    await gitInit(seed);
+    await configIdentity(seed);
+    fs.writeFileSync(path.join(seed, "README.md"), "# seed\n");
+    await commitAll({ cwd: seed, message: "seed" });
+    await exec(`git remote add origin ${shq(sourceBare)}`, { cwd: seed });
+    await exec("git push origin main", { cwd: seed });
+
+    // Clone into a fresh parent dir
+    const parent = mkTmp();
+    await cloneRepo({ repoUrl: sourceBare, parentDir: parent });
+
+    // git clone <bare> creates <parent>/<basename(bare)>
+    const cloned = path.join(parent, path.basename(sourceBare));
+    expect(fs.existsSync(path.join(cloned, ".git"))).toBe(true);
+    expect(fs.existsSync(path.join(cloned, "README.md"))).toBe(true);
+  });
+
+  it("propagates git's error when the URL is unreachable", async () => {
+    const parent = mkTmp();
+    await expect(
+      cloneRepo({
+        repoUrl: "/nonexistent/repo.git",
+        parentDir: parent,
+        timeoutMs: 5_000,
+      })
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

\`scripts/git/clone.ts\` still used naive double-quote interpolation for \`repoUrl\` (\`git clone "\${repoUrl}"\`), the same shell-active-char vulnerability fixed everywhere else in P5b/c/d via \`shq()\`. Switched to \`shq()\` and refactored the signature to a named-args object to match the rest of the post-P5 substrate.

## Before / after

\`\`\`ts
// Before
cloneRepo(repoUrl, parentDir)

// After
cloneRepo({ repoUrl, parentDir, timeoutMs? })
\`\`\`

## Caller updates in this PR

- \`scripts/lakebase/create-project.ts\` updated to named args
- Extension proxy will follow in the consumer PR (after this lands + release)

## Tests

- New \`shq()\` unit tests: $-expansion, backtick command substitution, embedded single-quote escaping
- \`cloneRepo\` happy-path (clones from a local bare repo into a fresh parent) + unreachable-URL error propagation. Uses a local bare-repo source so tests don't depend on network access.
- Full kit suite: **556 passing** (was 551), 0 failing.

## Test plan

- [x] typecheck
- [x] vitest run tests/bdd/git-utils.test.ts (10/10)
- [x] full suite (556 passing)
- [x] build

## Related

- Parent epic: FEIP-7058
- Introduced shq(): FEIP-7324 P5b
- Closes: FEIP-7341

This pull request and its description were written by Isaac.