### PR TITLE
chore(release): v0.3.0-alpha.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.29",
+  "version": "0.3.0-alpha.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.29",
+      "version": "0.3.0-alpha.30",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",
@@ -20,13 +20,16 @@
         "tweetsodium": "^0.0.5"
       },
       "bin": {
+        "lakebase-branch": "dist/scripts/lakebase/branch.cli.js",
         "lakebase-create-project": "dist/scripts/lakebase/create-project.cli.js",
         "lakebase-cut-backup": "dist/scripts/lakebase/cut-backup.cli.js",
         "lakebase-detect-language": "dist/scripts/lakebase/detect-language.cli.js",
+        "lakebase-doctor": "dist/scripts/lakebase/doctor.cli.js",
         "lakebase-get-connection": "dist/scripts/lakebase/get-connection.cli.js",
         "lakebase-github-token": "dist/scripts/github/auth.cli.js",
         "lakebase-mcp-server": "dist/apps/mcp-server/index.js",
         "lakebase-migrate": "dist/scripts/lakebase/migrate.cli.js",
+        "lakebase-pr": "dist/scripts/github/pr.cli.js",
         "lakebase-schema-diff": "dist/scripts/lakebase/schema-diff.cli.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.29",
+  "version": "0.3.0-alpha.30",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": false,


### PR DESCRIPTION
Ships P0 standalone-parity CLIs + MCP tools from #66. Tag cut from the merge commit.