### PR TITLE
docs: reflect P0 CLIs + 25-tool MCP surface (FEIP-7327)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd lakebase-app-dev-kit
 npm install   # prepare script builds dist/
 ```
 
-For a JS/TS host (extension, Node service) that imports substrate functions, depend on this repo via a git URL. npm publish is gated on org/scope/runner questions and intentionally deferred:
+For a JS/TS host (extension, Node service) that imports substrate functions, depend on this repo via a git URL:
 
 ```jsonc
 // host package.json
@@ -65,7 +65,9 @@ For a JS/TS host (extension, Node service) that imports substrate functions, dep
 }
 ```
 
-Pin to a sha for reproducibility. `prepare` builds `dist/` on install.
+Pin to a sha or release tag for reproducibility. `prepare` builds `dist/` on install.
+
+Package.json is publish-ready (`private: false`, `files` allow-list, `prepublishOnly` typecheck+test+build); npm publish lands once @databricks-solutions scope admin access is configured. After publish, `npm i -g @databricks-solutions/lakebase-app-dev-kit` becomes the canonical install path for the CLI bins.
 
 ### For coding agents
 
@@ -102,14 +104,30 @@ The root barrel `@databricks-solutions/lakebase-app-dev-kit` re-exports everythi
 
 ## CLIs
 
-The package exposes six bins (resolved relative to `node_modules/.bin/` when installed):
+The package exposes eleven bins (resolved relative to `node_modules/.bin/` when installed). Run any of them with `--help` for full subcommand + flag reference.
 
-- `lakebase-get-connection` – mint a DSN or pg.Pool against a branch
+**Project + connection**
+- `lakebase-create-project` – end-to-end Lakebase-paired project bootstrap (10-step QuickPick equivalent)
+- `lakebase-get-connection` – mint a DSN or pg.Pool against a branch (single-seam credential handoff)
+- `lakebase-doctor` – health check the local env: CLI version, auth, `.env` shape, project reachability, git remote, language, hooks. Exit codes 0/1/2 = OK/WARN/FAIL.
+
+**Branch lifecycle**
+- `lakebase-branch` – list / show / create / create-paired / create-tier (feature/test/uat/perf) / delete / delete-paired / checkout-paired / sync-env. Paired ops keep git + Lakebase + `.env` in lockstep.
+
+**PR flow**
+- `lakebase-pr` – open / merge / merge-paired (deletes Lakebase feature branch on merge) / status / files / reviews / comments
+
+**Schema + migrations**
 - `lakebase-schema-diff` – parent-aware schema diff between two Lakebase branches
-- `lakebase-github-token` – print/diagnose the resolved GitHub token
-- `lakebase-create-project` – end-to-end Lakebase-paired project bootstrap
 - `lakebase-migrate` – apply / rollback / status / list schema migrations against a branch
-- `lakebase-mcp-server` – stdio MCP server exposing the tool registry
+- `lakebase-detect-language` – detect project language (java / kotlin / python / nodejs) for CI step outputs
+
+**Operations**
+- `lakebase-cut-backup` – cut a no-expiry backup branch off a source branch
+- `lakebase-github-token` – print / diagnose the resolved GitHub token (single-seam GitHub auth)
+
+**Agents**
+- `lakebase-mcp-server` – stdio MCP server exposing 25 tools to MCP-capable agents (Claude Desktop, OpenAI Codex, Cursor-via-MCP, Genie Code)
 
 ## Contributing
 

--- a/skills/lakebase-scm-workflows/README.md
+++ b/skills/lakebase-scm-workflows/README.md
@@ -16,7 +16,7 @@ The control plane and data plane are owned by other Databricks artifacts. Instal
 
 ## Installing the substrate
 
-For a JS/TS host (extension, Node service) that imports substrate functions, depend on this repo via a git URL until the npm-publish path settles:
+For a JS/TS host (extension, Node service) that imports substrate functions, depend on this repo via a git URL:
 
 ```jsonc
 // host package.json
@@ -26,23 +26,41 @@ For a JS/TS host (extension, Node service) that imports substrate functions, dep
 }
 ```
 
-Pin to a sha. `prepare` builds `dist/` on install so consumers can import from the package name.
+Pin to a sha or release tag. `prepare` builds `dist/` on install so consumers can import from the package name. Once the npm scope admin step lands, `npm i -g @databricks-solutions/lakebase-app-dev-kit` becomes the canonical install path for the CLI bins.
 
-For agent use (running `node scripts/lakebase/<verb>.js` directly), clone this repo and run `npm install`. Same `prepare` build runs.
+For agent use (running the bins directly), clone the repo and run `npm install` once. The bins land in `node_modules/.bin/` and are also available as `node dist/scripts/.../<verb>.cli.js` for environments where adding to PATH is awkward.
 
 ## Operations
 
-Each operation is a CLI bin invocation that returns JSON on stdout. JS callers can import the same functions from the package.
+Each operation has a CLI bin AND a matching MCP tool. JS/TS callers can also import the same functions from the package. The 25-tool MCP server covers full parity with the 11 CLI bins.
 
-- `create-project` – bootstrap a fresh Lakebase-paired project
-- `schema-diff` – parent-aware diff between two Lakebase branches
-- `branch-create` / `branch-delete` – Lakebase branch lifecycle
-- `create-paired-branch` / `delete-paired-branch` / `checkout-paired` / `sync-env-to-current-branch` – paired ops that keep git + Lakebase + `.env` in lockstep
-- `get-endpoint` / `ensure-endpoint` / `get-credential` – branch endpoint + raw token/email
-- `query-branch-schema` / `query-branch-tables` – live pg introspection
-- `get-project-info` – project metadata (uid, display name, state)
-- `create-pull-request` / `get-pull-request` / `merge-pull-request` / `merge-paired-pull-request` – PR flow
-- `get-pull-request-reviews` / `get-pull-request-files` / `get-pull-request-comments` / `list-issue-comments` / `list-workflow-runs` – PR introspection
+**Branch lifecycle** (`lakebase-branch` / `lakebase_branch_*`)
+- `list` / `show` – enumerate or inspect branches on a project
+- `create` / `delete` – Lakebase branch only (no git side-effects)
+- `create-paired` / `delete-paired` – Lakebase + git + `.env` in lockstep
+- `create-tier feature|test|uat|perf` – convention-tier branches with PSA TTL defaults
+- `checkout-paired` / `sync-env` – recovery / drift-fix when `.env` lags
+
+**Schema + migrations** (`lakebase-schema-diff`, `lakebase-migrate`)
+- `lakebase-schema-diff` – parent-aware diff between any branch and its parent
+- `lakebase-migrate apply|rollback|status|list` – Flyway / Alembic / Knex migrations against a branch
+
+**PR flow** (`lakebase-pr` / `lakebase_pr_*`)
+- `open` / `merge` / `merge-paired` (Lakebase feature-branch cleanup baked into the merge)
+- `status` (by head branch) / `files` / `reviews` / `comments`
+
+**Project lifecycle** (`lakebase-create-project`, `lakebase-doctor`)
+- `lakebase-create-project` – end-to-end Lakebase + GitHub bootstrap
+- `lakebase-doctor` – health check the local env (CLI version, auth, `.env` shape, project reachability, git remote, language, hooks). Exit codes 0/1/2 = OK/WARN/FAIL for CI use.
+
+**Connection + auth** (`lakebase-get-connection`, `lakebase-github-token`)
+- `lakebase-get-connection` – mint DSN or pg.Pool against a branch (single-seam credential mint)
+- `lakebase-github-token` – resolve / diagnose the GitHub token (single-seam GitHub auth)
+
+**Backup** (`lakebase-cut-backup`)
+- Cut a no-expiry backup branch off a source branch
+
+Run any bin with `--help` for the full subcommand + flag reference.
 
 ## Under the covers
 
@@ -136,11 +154,16 @@ The agent reads the current git branch, calls `lakebase-get-connection --output 
 | Bin | Purpose |
 |---|---|
 | `lakebase-create-project` | End-to-end Lakebase + GitHub project bootstrap (see flow 1). |
+| `lakebase-branch` | Branch lifecycle: list / show / create / create-paired / create-tier / delete / delete-paired / checkout-paired / sync-env. Paired ops keep git + Lakebase + `.env` in lockstep. |
+| `lakebase-pr` | PR flow: open / merge / merge-paired / status (by --head) / files / reviews / comments. `merge-paired` deletes the matching Lakebase feature branch on merge. |
+| `lakebase-doctor` | Health-check the local env. Run first when something looks off. Exit codes 0/1/2 = OK/WARN/FAIL for CI. |
 | `lakebase-get-connection` | Mint a DSN string (`--output dsn`) or pg.Pool (`--output pool`) against any branch. Add `--write-env` to refresh `.env`. |
 | `lakebase-schema-diff` | Parent-aware schema diff between any branch and its parent (or a comparison override). |
-| `lakebase-github-token` | Resolve the GitHub token via the same auth chain CI uses. Useful for debugging permission issues. |
-| `lakebase-migrate` | Apply / rollback / status / list schema migrations against a branch. |
-| `lakebase-mcp-server` | Stdio MCP server exposing every script as an MCP tool – for Claude Desktop / OpenAI Codex consumers. |
+| `lakebase-migrate` | Apply / rollback / status / list schema migrations against a branch (Flyway / Alembic / Knex). |
+| `lakebase-cut-backup` | Cut a no-expiry backup branch off a source branch. |
+| `lakebase-detect-language` | Detect project language for CI step outputs. |
+| `lakebase-github-token` | Resolve / diagnose the GitHub token via the same auth chain CI uses. |
+| `lakebase-mcp-server` | Stdio MCP server exposing 25 tools (full parity with the CLI bins). For Claude Desktop / OpenAI Codex / Cursor-via-MCP / Genie Code consumers. |
 
 ## Composition
 

--- a/skills/lakebase-scm-workflows/SKILL.md
+++ b/skills/lakebase-scm-workflows/SKILL.md
@@ -140,40 +140,61 @@ Eleven-step orchestration. Non-fatal failures (CI secrets sync, runner setup, ho
 
 ### 2. Branch lifecycle
 
-Lakebase branch CRUD. Git-side operations stay with the caller; these scripts handle the paired Lakebase side.
+Lakebase branch CRUD plus paired git+Lakebase+.env ops. The `lakebase-branch` bin is the shell-friendly entrypoint; same operations import directly from the package for JS/TS hosts.
 
 ```bash
-# Create a paired Lakebase branch – parent resolves from explicit override,
-# then "branch I'm currently on" hint, then project default.
-node scripts/lakebase/branch-create.js \
-  --instance proj-checkout --branch feature-add-orders \
-  [--parent staging] [--current main]
-# -> { uid, name, state: "READY", sourceBranchName, isDefault }
+# Lakebase-only branch lifecycle
+lakebase-branch list --instance proj-checkout
+lakebase-branch show --instance proj-checkout --branch feature-add-orders
+lakebase-branch create --instance proj-checkout --branch feature-add-orders --parent staging
+lakebase-branch delete --instance proj-checkout --branch feature-add-orders
 
-node scripts/lakebase/branch-delete.js --instance proj-checkout --branch feature-add-orders
+# Paired (Lakebase + git + .env in lockstep)
+lakebase-branch create-paired --instance proj-checkout --branch feature-add-orders --cwd .
+lakebase-branch delete-paired --instance proj-checkout --branch feature-add-orders --cwd .
+
+# Recovery / drift fix when .env lags the current git branch
+lakebase-branch checkout-paired --cwd .
+lakebase-branch sync-env --cwd .
+
+# Convention tiers (PSA branching methodology, TTL defaults per tier)
+lakebase-branch create-tier feature --instance proj-checkout --branch feature-add-orders
+lakebase-branch create-tier test    --instance proj-checkout --branch test-cycle-q3
 ```
 
+All 9 subcommands have matching MCP tools (`lakebase_branch_list` / `_show` / `_create` / `_create_paired` / `_create_tier` / `_delete` / `_delete_paired` / `_checkout_paired` / `_sync_env`).
+
 ```ts
-import { createBranch, waitForBranchReady, deleteBranch }
+import { createBranch, deleteBranch, createPairedBranch, deletePairedBranch,
+         checkoutPaired, syncEnvToCurrentBranch }
   from "@databricks-solutions/lakebase-app-dev-kit";
 
+// Lakebase-only
 const branch = await createBranch({
   instance: "proj-checkout",
   branch: "feature-add-orders",     // sanitized to Lakebase id (lowercase, alphanumeric+hyphen, 3-63 chars)
-  parentBranch: "staging",            // optional – overrides "current" hint and default
-  currentBranch: "main",              // optional – git-like "fork from current" semantics
-  timeoutMs: 120_000,                 // default: 2min poll budget
+  parentBranch: "staging",            // optional – overrides default
 });
-
 await deleteBranch({ instance: "proj-checkout", branch: branch.uid });
+
+// Paired (extension-style behavior)
+await createPairedBranch({
+  instance: "proj-checkout",
+  branch: "feature-add-orders",
+  cwd: process.cwd(),
+  parentBranch: "staging",
+});
+// post-checkout-hook equivalent (rewrites .env)
+await checkoutPaired({ cwd: process.cwd() });
 ```
 
 **Parent resolution precedence:**
 1. `parentBranch` arg (explicit override – "branch from prod" / "branch from staging" hotfix)
-2. `currentBranch` arg (git-like "fork from the branch you're on") – skipped if it equals the target
-3. Project default branch (usually `production`)
+2. Project default branch (usually `production`)
 
 **Idempotency.** `createBranch` returns the existing branch unchanged if one with the same sanitized name already exists. Delete is NOT idempotent – throws when the branch isn't found.
+
+**Protected branches.** `deleteBranch` and `deleteLocalBranch` refuse `production` / `main` / `master` unless the caller explicitly passes `allowProtected: true`. The CLI doesn't expose that override on purpose – production deletion is a deliberate-action thing, not a flag.
 
 ### 3. Endpoint + credential
 
@@ -265,6 +286,22 @@ const diff = await getSchemaDiff({
 
 ### PR flow
 
+```bash
+# Open + introspect + merge from a plain shell
+lakebase-pr open --owner-repo my-org/proj-checkout --head feature-add-orders \
+                 --base staging --title "Add orders table" --body "..."
+lakebase-pr status --owner-repo my-org/proj-checkout --head feature-add-orders --pretty
+lakebase-pr files --owner-repo my-org/proj-checkout --pull-number 42
+lakebase-pr reviews --owner-repo my-org/proj-checkout --pull-number 42
+
+# Merge variants
+lakebase-pr merge --owner-repo my-org/proj-checkout --pull-number 42 --method squash
+# merge-paired: also deletes the matching Lakebase feature branch
+lakebase-pr merge-paired --owner-repo my-org/proj-checkout --pull-number 42 --instance proj-checkout
+```
+
+All 7 subcommands have matching MCP tools (`lakebase_pr_open` / `_merge` / `_merge_paired` / `_status` / `_files` / `_reviews` / `_comments`).
+
 ```ts
 import {
   createPullRequest, getPullRequest, mergePullRequest, mergePairedPullRequest,
@@ -274,10 +311,9 @@ import {
 // Open a PR with the current branch's schema diff embedded in the body.
 const diff = await getSchemaDiff({ instance: "proj-checkout", branch: "feature-add-orders" });
 await createPullRequest({
-  owner: "my-org",
-  repo: "proj-checkout",
-  base: "staging",
-  head: "feature-add-orders",
+  ownerRepo: "my-org/proj-checkout",
+  baseBranch: "staging",
+  headBranch: "feature-add-orders",
   title: "Add orders table",
   body: [
     "## Summary",
@@ -292,6 +328,18 @@ await createPullRequest({
 ```
 
 `mergePairedPullRequest` merges the git PR AND tears down the Lakebase feature branch in lockstep. Use it for clean post-merge state on paired projects.
+
+### Health check / doctor
+
+Run `lakebase-doctor` first when something looks off. Eight checks: Databricks CLI presence + version, auth describe, workspace identity, `.env` shape, Lakebase project reachability, git remote, detected language, git hooks installation.
+
+```bash
+lakebase-doctor                                # human-readable table; exit 0/1/2 = OK/WARN/FAIL
+lakebase-doctor --json --pretty                # machine-readable for CI / agent consumption
+lakebase-doctor --project-dir ~/code/proj-checkout
+```
+
+Also reachable as the `lakebase_doctor` MCP tool. When an agent reports cryptic "auth failed" or ".env not found" symptoms, this is the first thing to run.
 
 ## References
 


### PR DESCRIPTION
## Summary

Doc-only refresh to match the v0.3.0-alpha.30 surface shipped in #66 + #67. No code changes.

## Changes

**Kit \`README.md\`**
- CLI section: lists all **11 bins** (was 6) grouped by category (project+connection, branch lifecycle, PR flow, schema+migrations, operations, agents) with one-line purpose each
- Install section: drops the stale "npm publish... intentionally deferred" line and replaces with the publish-ready status + what gates the actual publish step (org scope admin access)
- MCP server row: notes the **25-tool count**

**\`skills/lakebase-scm-workflows/README.md\`**
- Operations section regrouped under the actual CLI bin names + MCP tool naming so the agent contract maps 1:1 to the shell surface
- CLI cheat sheet: 6 rows → 11 rows (adds branch / doctor / pr / cut-backup / detect-language)

**\`skills/lakebase-scm-workflows/SKILL.md\`**
- Branch lifecycle: rewrote bash examples from \`node scripts/lakebase/branch-create.js ...\` to \`lakebase-branch create ...\`. Adds paired / create-tier / checkout-paired / sync-env which were programmatic-only before.
- PR flow: prepended a bash block showing \`lakebase-pr\` subcommands; updated TS block to the \`{ ownerRepo, headBranch, baseBranch }\` shape
- New "Health check / doctor" section: documents \`lakebase-doctor\` + the matching MCP tool, exit codes, and when to run it
- Added MCP tool name lists wherever a CLI bin is documented so the parity stays visible to agents

## Net

\`\`\`
3 files changed, +132 insertions, -43 deletions
\`\`\`

## Related

- FEIP-7327 P0 standalone parity (parent)
- Builds on: kit PRs #66 (CLIs + MCP) + #67 (v0.3.0-alpha.30 release)

This pull request and its description were written by Isaac.