### PR TITLE
feat(workflow-drift): detect drift between scaffolded YAMLs + kit templates (FEIP-7140)

### DIFF
--- a/apps/mcp-server/tools.ts
+++ b/apps/mcp-server/tools.ts
@@ -33,6 +33,8 @@ import {
 } from "../../scripts/github/pr.js";
 // FEIP-7330 P0.4: doctor MCP tool.
 import { runDoctor } from "../../scripts/lakebase/doctor.js";
+// FEIP-7140: workflow drift MCP tool.
+import { detectWorkflowDrift } from "../../scripts/lakebase/workflow-drift.js";
 // FEIP-7331 P0.1: branch MCP tools (full parity with the CLI).
 import {
   listBranches,
@@ -507,6 +509,26 @@ export const TOOLS: ToolDefinition[] = [
         projectDir: optionalString(args, "projectDir"),
         profile: optionalString(args, "profile"),
         host: optionalString(args, "host"),
+      });
+    },
+  },
+  // ------------------------- FEIP-7140 workflow drift ----------------------
+  {
+    name: "lakebase_workflow_drift",
+    description: "Detect drift between a scaffolded project's .github/workflows/*.yml and the kit's current templates. Returns per-file status (unchanged / drifted / missing / extra) and a unified diff for drifted files. Use when a maintainer wants to know if a project's CI templates are stale vs the kit it pins.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectDir: { type: "string", description: "Project directory containing .github/workflows/." },
+        kitDir: { type: "string", description: "Override the kit directory (default: bundled templates path)." },
+      },
+      required: ["projectDir"],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      return detectWorkflowDrift({
+        projectDir: requireString(args, "projectDir"),
+        kitDir: optionalString(args, "kitDir"),
       });
     },
   },

--- a/scripts/lakebase/doctor.ts
+++ b/scripts/lakebase/doctor.ts
@@ -10,6 +10,7 @@ import { resolveDatabricksHost } from "./databricks-host.js";
 import { listBranches } from "./branch-utils.js";
 import { verifyHooks } from "./project-verify.js";
 import { detectLanguage } from "./migrate.js";
+import { detectWorkflowDrift } from "./workflow-drift.js";
 
 export type CheckStatus = "ok" | "warn" | "fail" | "skip";
 
@@ -297,6 +298,36 @@ function checkHooks(projectDir: string): CheckResult {
   };
 }
 
+function checkWorkflowDrift(projectDir: string): CheckResult {
+  try {
+    const report = detectWorkflowDrift({ projectDir });
+    const drifted = report.files.filter((f) => f.status === "drifted").length;
+    const missing = report.files.filter((f) => f.status === "missing").length;
+    if (report.overall === "ok") {
+      return {
+        name: "workflow-drift",
+        status: "ok",
+        message: "Scaffolded .github/workflows/*.yml match the kit's templates",
+        detail: { files: report.files.map((f) => ({ name: f.name, status: f.status })) },
+      };
+    }
+    return {
+      name: "workflow-drift",
+      status: "warn",
+      message: `Scaffolded workflows drift from kit: ${drifted} drifted, ${missing} missing`,
+      detail: { files: report.files.map((f) => ({ name: f.name, status: f.status })) },
+      hint: "Inspect via the lakebase_workflow_drift MCP tool (or detectWorkflowDrift import). Refresh manually until FEIP-7139 updateWorkflows lands.",
+    };
+  } catch (err) {
+    return {
+      name: "workflow-drift",
+      status: "skip",
+      message: "Could not run drift check",
+      detail: { error: (err as Error).message },
+    };
+  }
+}
+
 function worstOf(statuses: CheckStatus[]): CheckStatus {
   const order: CheckStatus[] = ["ok", "skip", "warn", "fail"];
   return statuses.reduce<CheckStatus>(
@@ -349,6 +380,7 @@ export async function runDoctor(args: DoctorArgs = {}): Promise<DoctorReport> {
   const gitRemote = await checkGitRemote(projectDir);
   const language = checkLanguage(projectDir);
   const hooks = checkHooks(projectDir);
+  const workflowDrift = checkWorkflowDrift(projectDir);
 
   const checks: CheckResult[] = [
     cli,
@@ -359,6 +391,7 @@ export async function runDoctor(args: DoctorArgs = {}): Promise<DoctorReport> {
     gitRemote,
     language,
     hooks,
+    workflowDrift,
   ];
 
   return {

--- a/scripts/lakebase/workflow-drift.ts
+++ b/scripts/lakebase/workflow-drift.ts
@@ -1,0 +1,178 @@
+// Drift detector: scaffolded project's .github/workflows/*.yml vs the
+// kit's current templates (FEIP-7140).
+//
+// Scaffolded projects ship copies of pr.yml, merge.yml, cleanup-orphans.yml
+// at scaffold time. The kit's templates evolve (new lint steps, schema-
+// diff gates, bug fixes) but existing projects never auto-pick those
+// changes up. This primitive surfaces the drift so a maintainer can
+// decide whether to refresh (via FEIP-7139 updateWorkflows when that
+// lands) or pin intentionally.
+//
+// The "kit version pinned by the project" surfaces via npm's installed
+// view: if the project depends on @databricks-solutions/lakebase-app-dev-kit,
+// the templates at node_modules/.../templates/project/common/.github/workflows/
+// are the canonical reference for the pinned version. The drift detector
+// doesn't fetch from npm or github; it diffs against whatever is currently
+// on disk in the kit (resolved either via the bundled templates path or an
+// explicit kitDir override).
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export type WorkflowStatus = "unchanged" | "drifted" | "missing" | "extra";
+
+export interface WorkflowFileStatus {
+  /** File name (e.g. "pr.yml"). */
+  name: string;
+  status: WorkflowStatus;
+  /**
+   * Unified diff when status is "drifted". Empty string otherwise.
+   * Diff is project-vs-template (project's lines marked -, template's +).
+   */
+  diff?: string;
+}
+
+export interface WorkflowDriftReport {
+  /** Aggregate: ok if every file is unchanged, otherwise drift. */
+  overall: "ok" | "drift";
+  /** Per-file status entries. Includes missing + extra files for completeness. */
+  files: WorkflowFileStatus[];
+}
+
+export interface DetectWorkflowDriftArgs {
+  /** Project directory containing .github/workflows/. */
+  projectDir: string;
+  /**
+   * Kit directory containing templates/project/common/.github/workflows/.
+   * Default: walks up from this module looking for the templates marker
+   * (same logic as scaffold.findTemplatesDir).
+   */
+  kitDir?: string;
+}
+
+function findKitTemplatesDir(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 6; i++) {
+    const candidate = path.join(
+      dir,
+      "templates",
+      "project",
+      "common",
+      ".github",
+      "workflows"
+    );
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(
+    `Could not locate templates/project/common/.github/workflows/ relative to ${start}. ` +
+      `Pass explicit kitDir.`
+  );
+}
+
+function unifiedDiff(name: string, projectContent: string, templateContent: string): string {
+  if (projectContent === templateContent) return "";
+  const a = projectContent.split("\n");
+  const b = templateContent.split("\n");
+  // Minimal line-by-line diff suitable for human review. For full unified
+  // diff use `diff -u` externally; this primitive favors no native deps.
+  const out: string[] = [`--- project/${name}`, `+++ template/${name}`];
+  const max = Math.max(a.length, b.length);
+  for (let i = 0; i < max; i++) {
+    const av = a[i];
+    const bv = b[i];
+    if (av === bv) continue;
+    if (av !== undefined) out.push(`-${i + 1}: ${av}`);
+    if (bv !== undefined) out.push(`+${i + 1}: ${bv}`);
+  }
+  return out.join("\n");
+}
+
+/**
+ * Compare a project's .github/workflows/*.yml against the kit's
+ * templates. Returns a per-file report flagging missing, extra, and
+ * drifted files.
+ *
+ * Use cases:
+ *   - lakebase-doctor surfaces drift as a WARN check
+ *   - CI: nightly job that PRs an updateWorkflows when drift detected
+ *   - One-off: maintainer runs lakebase-doctor --json before a release
+ *
+ * Returns overall: "ok" iff every workflow file is unchanged AND no
+ * missing files exist. Extra files (project has a workflow the kit
+ * doesn't template) are reported as "extra" status but DON'T count
+ * against "ok" - projects legitimately add their own workflows.
+ */
+export function detectWorkflowDrift(
+  args: DetectWorkflowDriftArgs
+): WorkflowDriftReport {
+  const projectWorkflowsDir = path.join(
+    args.projectDir,
+    ".github",
+    "workflows"
+  );
+  const here = path.dirname(new URL(import.meta.url).pathname);
+  const kitWorkflowsDir = args.kitDir
+    ? path.join(
+        args.kitDir,
+        "templates",
+        "project",
+        "common",
+        ".github",
+        "workflows"
+      )
+    : findKitTemplatesDir(here);
+
+  const templateFiles = fs.existsSync(kitWorkflowsDir)
+    ? fs.readdirSync(kitWorkflowsDir).filter((f) => f.endsWith(".yml"))
+    : [];
+  const projectFiles = fs.existsSync(projectWorkflowsDir)
+    ? fs.readdirSync(projectWorkflowsDir).filter((f) => f.endsWith(".yml"))
+    : [];
+
+  const seen = new Set<string>();
+  const files: WorkflowFileStatus[] = [];
+
+  for (const name of templateFiles) {
+    seen.add(name);
+    const projectPath = path.join(projectWorkflowsDir, name);
+    const templatePath = path.join(kitWorkflowsDir, name);
+    if (!fs.existsSync(projectPath)) {
+      files.push({ name, status: "missing" });
+      continue;
+    }
+    const projectContent = fs.readFileSync(projectPath, "utf8");
+    const templateContent = fs.readFileSync(templatePath, "utf8");
+    if (projectContent === templateContent) {
+      files.push({ name, status: "unchanged" });
+    } else {
+      files.push({
+        name,
+        status: "drifted",
+        diff: unifiedDiff(name, projectContent, templateContent),
+      });
+    }
+  }
+
+  for (const name of projectFiles) {
+    if (seen.has(name)) continue;
+    files.push({ name, status: "extra" });
+  }
+
+  // Sort for stable output: drifted first, then missing, then extra, then unchanged.
+  const order: Record<WorkflowStatus, number> = {
+    drifted: 0,
+    missing: 1,
+    extra: 2,
+    unchanged: 3,
+  };
+  files.sort((a, b) => order[a.status] - order[b.status] || a.name.localeCompare(b.name));
+
+  const hasDrift = files.some((f) => f.status === "drifted" || f.status === "missing");
+  return {
+    overall: hasDrift ? "drift" : "ok",
+    files,
+  };
+}

--- a/tests/bdd/lakebase-doctor-cli-live.test.ts
+++ b/tests/bdd/lakebase-doctor-cli-live.test.ts
@@ -159,7 +159,7 @@ describe.skipIf(!RUN_SUITE)(
       expect(r.parsed).toBeDefined();
       const report = r.parsed as DoctorReport;
       expect(["ok", "warn"]).toContain(report.overall);
-      expect(report.checks.length).toBe(8);
+      expect(report.checks.length).toBe(9);
       const names = report.checks.map((c) => c.name).sort();
       expect(names).toEqual(
         [
@@ -170,6 +170,7 @@ describe.skipIf(!RUN_SUITE)(
           "git-hooks",
           "git-remote",
           "lakebase-project",
+          "workflow-drift",
           "workspace-identity",
         ].sort()
       );

--- a/tests/bdd/workflow-drift.test.ts
+++ b/tests/bdd/workflow-drift.test.ts
@@ -1,0 +1,136 @@
+// Coverage for the workflow drift detector (FEIP-7140). Pure
+// filesystem; no live Lakebase, runs in the standard non-live suite.
+
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { detectWorkflowDrift } from "../../scripts/lakebase/workflow-drift.js";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
+  }
+});
+
+function mkProject(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lbscm-drift-"));
+  tmpDirs.push(dir);
+  fs.mkdirSync(path.join(dir, ".github", "workflows"), { recursive: true });
+  return dir;
+}
+
+function copyTemplate(projectDir: string, name: string): void {
+  const src = path.join(
+    REPO_ROOT,
+    "templates",
+    "project",
+    "common",
+    ".github",
+    "workflows",
+    name
+  );
+  const dst = path.join(projectDir, ".github", "workflows", name);
+  fs.copyFileSync(src, dst);
+}
+
+describe("detectWorkflowDrift", () => {
+  it("reports overall=ok when project matches the kit verbatim", () => {
+    const dir = mkProject();
+    copyTemplate(dir, "pr.yml");
+    copyTemplate(dir, "merge.yml");
+    copyTemplate(dir, "cleanup-orphans.yml");
+    const report = detectWorkflowDrift({ projectDir: dir });
+    expect(report.overall).toBe("ok");
+    const byName = (n: string) => report.files.find((f) => f.name === n)!;
+    expect(byName("pr.yml").status).toBe("unchanged");
+    expect(byName("merge.yml").status).toBe("unchanged");
+    expect(byName("cleanup-orphans.yml").status).toBe("unchanged");
+  });
+
+  it("reports drifted when project's pr.yml has been edited", () => {
+    const dir = mkProject();
+    copyTemplate(dir, "pr.yml");
+    copyTemplate(dir, "merge.yml");
+    copyTemplate(dir, "cleanup-orphans.yml");
+    // Mutate the project copy
+    const prPath = path.join(dir, ".github", "workflows", "pr.yml");
+    fs.writeFileSync(
+      prPath,
+      fs.readFileSync(prPath, "utf8") + "\n# locally added comment\n"
+    );
+    const report = detectWorkflowDrift({ projectDir: dir });
+    expect(report.overall).toBe("drift");
+    const pr = report.files.find((f) => f.name === "pr.yml")!;
+    expect(pr.status).toBe("drifted");
+    expect(pr.diff).toMatch(/locally added comment/);
+  });
+
+  it("reports missing when project lacks a template file", () => {
+    const dir = mkProject();
+    // Only copy pr.yml, not merge.yml or cleanup-orphans.yml
+    copyTemplate(dir, "pr.yml");
+    const report = detectWorkflowDrift({ projectDir: dir });
+    expect(report.overall).toBe("drift");
+    const missing = report.files.filter((f) => f.status === "missing").map((f) => f.name);
+    expect(missing).toContain("merge.yml");
+    expect(missing).toContain("cleanup-orphans.yml");
+  });
+
+  it("reports extra when project has a workflow the kit doesn't template", () => {
+    const dir = mkProject();
+    copyTemplate(dir, "pr.yml");
+    copyTemplate(dir, "merge.yml");
+    copyTemplate(dir, "cleanup-orphans.yml");
+    // Add a project-specific workflow
+    fs.writeFileSync(
+      path.join(dir, ".github", "workflows", "project-custom.yml"),
+      "name: custom\non: push\njobs: {}\n"
+    );
+    const report = detectWorkflowDrift({ projectDir: dir });
+    // Extra files DON'T count as drift; overall stays ok if all template-files are unchanged.
+    expect(report.overall).toBe("ok");
+    const extra = report.files.find((f) => f.name === "project-custom.yml")!;
+    expect(extra.status).toBe("extra");
+  });
+
+  it("sort order: drifted -> missing -> extra -> unchanged", () => {
+    const dir = mkProject();
+    copyTemplate(dir, "pr.yml");
+    // Edit pr.yml (drift)
+    const prPath = path.join(dir, ".github", "workflows", "pr.yml");
+    fs.writeFileSync(prPath, fs.readFileSync(prPath, "utf8") + "\n# edit\n");
+    // merge.yml + cleanup-orphans.yml missing
+    // Add an extra
+    fs.writeFileSync(
+      path.join(dir, ".github", "workflows", "extra.yml"),
+      "name: x\n"
+    );
+    const report = detectWorkflowDrift({ projectDir: dir });
+    const statuses = report.files.map((f) => f.status);
+    // Sort priority: drifted -> missing -> extra -> unchanged
+    expect(statuses[0]).toBe("drifted");
+    // missing entries follow drifted (cleanup-orphans.yml + merge.yml)
+    expect(statuses.slice(1, 3).every((s) => s === "missing")).toBe(true);
+    // extra entry is last (no unchanged exist in this setup)
+    expect(statuses[statuses.length - 1]).toBe("extra");
+  });
+
+  it("returns missing for everything when project has no .github/workflows dir", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lbscm-drift-bare-"));
+    tmpDirs.push(dir);
+    const report = detectWorkflowDrift({ projectDir: dir });
+    expect(report.overall).toBe("drift");
+    expect(report.files.every((f) => f.status === "missing")).toBe(true);
+  });
+});

--- a/tests/mcp-server/handshake.test.ts
+++ b/tests/mcp-server/handshake.test.ts
@@ -136,6 +136,7 @@ describe("MCP server stdio handshake", () => {
       "lakebase_pr_status",
       "lakebase_rollback_migration",
       "lakebase_schema_diff",
+      "lakebase_workflow_drift",
     ]);
 
     const callResp = await client.request("tools/call", {

--- a/tests/mcp-server/live-tools.test.ts
+++ b/tests/mcp-server/live-tools.test.ts
@@ -186,7 +186,7 @@ describe.skipIf(!RUN_SUITE)(
     it("tools/list advertises all 25 expected tools", async () => {
       const resp = await client.request("tools/list", {});
       const tools = (resp.result as { tools: { name: string }[] }).tools;
-      expect(tools.length).toBe(25);
+      expect(tools.length).toBe(26);
       const names = tools.map((t) => t.name).sort();
       expect(names).toContain("lakebase_branch_list");
       expect(names).toContain("lakebase_branch_show");
@@ -266,7 +266,7 @@ describe.skipIf(!RUN_SUITE)(
         overall: string;
         checks: { name: string; status: string }[];
       };
-      expect(report.checks.length).toBe(8);
+      expect(report.checks.length).toBe(9);
       expect(["ok", "warn"]).toContain(report.overall);
       const byName = (n: string) =>
         report.checks.find((c) => c.name === n)!;

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -63,6 +63,7 @@ describe("MCP tool registry", () => {
       "lakebase_pr_status",
       "lakebase_rollback_migration",
       "lakebase_schema_diff",
+      "lakebase_workflow_drift",
     ]);
   });
 


### PR DESCRIPTION
## Summary

Detects drift between a scaffolded project's \`.github/workflows/*.yml\` and the kit's current templates. Closes [FEIP-7140](https://databricks.atlassian.net/browse/FEIP-7140).

## What ships

| Surface | Behavior |
| --- | --- |
| \`detectWorkflowDrift({ projectDir, kitDir? })\` | Substrate primitive. Returns per-file status (unchanged / drifted / missing / extra) with a unified-style line diff for drifted files. |
| \`lakebase-doctor\` 9th check | Surfaces drift as a WARN. CLI + MCP versions of doctor pick this up automatically. |
| \`lakebase_workflow_drift\` MCP tool | Returns the full per-file diff payload (doctor's CheckResult.detail truncates). |

## Semantics

- **Extra files don't count as drift**. A project legitimately adds its own workflows (project-specific deploys, lint configs, etc.); drift is about the kit-template subset staying current.
- **Missing files DO count**. A scaffolded project missing \`pr.yml\` is broken.
- **Sort order**: drifted -> missing -> extra -> unchanged. So the loud entries surface first.

## Tests

- 6 new vitest cases in \`tests/bdd/workflow-drift.test.ts\` covering matched / drifted / missing / extra / sort-order / no-workflows-dir paths
- handshake + tools-surface assertions updated for 26-tool MCP surface (was 25)
- live-tools + lakebase-doctor-cli-live expect 9 doctor checks (was 8)
- Full kit suite: **609 passing** (up from 603), 0 failing

## What's NOT in this PR

FEIP-7139 (\`updateWorkflows()\` for in-place refresh of drifted YAMLs) is the natural sequel. This PR only detects; refresh requires a separate primitive that handles the merge-vs-overwrite decision per drifted file. Today the recovery is manual: \`cp templates/project/common/.github/workflows/*.yml <project>/.github/workflows/\`.

## Related

- [FEIP-7140](https://databricks.atlassian.net/browse/FEIP-7140) Substrate: drift detector for scaffolded YAMLs vs pinned kit version
- Future: [FEIP-7139](https://databricks.atlassian.net/browse/FEIP-7139) updateWorkflows() in-place refresh

## Test plan

- [x] vitest run tests/bdd/workflow-drift.test.ts (6/6)
- [x] full kit suite (609 passing)
- [x] typecheck
- [x] build

This pull request and its description were written by Isaac.