### PR TITLE
feat(tdd): archiveExperiment lifecycle primitive (FEIP-7214)

### DIFF
--- a/scripts/tdd/archive-experiment.ts
+++ b/scripts/tdd/archive-experiment.ts
@@ -1,0 +1,233 @@
+// archiveExperiment lifecycle primitive (FEIP-7214). Atomically moves a
+// losing experiment's dir under _archive/, marks outcomes.json as
+// abandoned, optionally tears down its Lakebase branch + Databricks
+// Apps deployment via callbacks, and appends a selection-log entry.
+//
+// HITL-gated: refuses to run without hitlApproved=true so the orchestrator
+// can't archive without a recorded human decision. Mirrors the gate
+// pattern from promoteExperiment.
+//
+// Rollback: if a teardown callback fails after the dir+outcomes markers
+// were applied, both are reverted to their pre-archive state and the
+// selection-log records the partial-archive outcome.
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import { listExperiments, readOutcomes, writeOutcomes } from "./experiment.js";
+
+export class ArchiveExperimentError extends Error {
+  constructor(
+    message: string,
+    public readonly partial: boolean = false
+  ) {
+    super(message);
+    this.name = "ArchiveExperimentError";
+  }
+}
+
+export interface ArchiveExperimentArgs {
+  tddDir: string;
+  featureId: string;
+  experimentSlug: string;
+  /**
+   * Required. Refuses to run without explicit human approval; same
+   * pattern as promoteExperiment. The token shape is intentionally
+   * simple (boolean): the orchestrator's job is to gate on the actual
+   * HITL prompt; this enforces the boundary check.
+   */
+  hitlApproved: boolean;
+  /** Recorded in selection-log when provided. */
+  approverEmail?: string;
+  /**
+   * Optional Lakebase branch teardown callback. Receives the
+   * experiment's branch_id. Throw to surface the failure to the
+   * primitive's rollback handler. When omitted, the Lakebase branch is
+   * left in place and the result flags lakebase_branch_deleted: false.
+   */
+  deleteLakebaseBranch?: (branchId: string) => Promise<void>;
+  /**
+   * Optional Databricks Apps deployment teardown callback. Receives
+   * the experiment slug (same convention as the deploy-apps substrate).
+   * Throw to surface the failure. When omitted, the deployment is left
+   * in place and the result flags app_deployment_deleted: false.
+   */
+  deleteAppDeployment?: (experimentSlug: string) => Promise<void>;
+}
+
+export interface ArchiveExperimentResult {
+  experiment_slug: string;
+  /** Absolute path of the archived dir on disk. */
+  archived_dir: string;
+  /** True iff deleteLakebaseBranch was provided AND succeeded. */
+  lakebase_branch_deleted: boolean;
+  /** True iff deleteAppDeployment was provided AND succeeded. */
+  app_deployment_deleted: boolean;
+  /** The selection-log markdown body that was appended. */
+  selection_log_entry: string;
+}
+
+function selectionLogPath(tddDir: string): string {
+  return join(tddDir, "selection-log.md");
+}
+
+function appendSelectionLog(tddDir: string, entry: string): void {
+  const path = selectionLogPath(tddDir);
+  if (existsSync(path)) {
+    writeFileSync(path, readFileSync(path, "utf8") + entry);
+  } else {
+    writeFileSync(path, entry);
+  }
+}
+
+/**
+ * Archive a losing experiment. Atomic: either every step succeeds and
+ * the experiment is fully archived, or the dir + outcomes are rolled
+ * back and the failure is recorded in selection-log.
+ *
+ * Order of operations (matters for rollback):
+ *   1. Read prior outcomes (snapshot for rollback)
+ *   2. Mark outcomes status="abandoned"
+ *   3. Move dir from experiments/<F>/<slug>/ to experiments/<F>/_archive/<slug>/
+ *   4. Try deleteLakebaseBranch (best effort if callback omitted)
+ *   5. Try deleteAppDeployment (best effort if callback omitted)
+ *   6. On any callback throw: revert steps 2-3, append partial-archive
+ *      entry, throw ArchiveExperimentError with partial: true.
+ *   7. On full success: append archived entry, return result.
+ */
+export async function archiveExperiment(
+  args: ArchiveExperimentArgs
+): Promise<ArchiveExperimentResult> {
+  if (!args.hitlApproved) {
+    throw new ArchiveExperimentError(
+      "archiveExperiment requires hitlApproved: true (HITL Gate)"
+    );
+  }
+  const { tddDir, featureId, experimentSlug, approverEmail } = args;
+
+  const ts = new Date().toISOString();
+  const archiveBase = join(tddDir, "experiments", featureId, "_archive");
+  mkdirSync(archiveBase, { recursive: true });
+  const dest = join(archiveBase, experimentSlug);
+  const liveDir = join(tddDir, "experiments", featureId, experimentSlug);
+
+  // Idempotent re-run: if it's already archived and the live dir is gone,
+  // record a log entry and return without trying to look up the experiment
+  // (listExperiments only sees live dirs, so the lookup would fail).
+  if (existsSync(dest) && !existsSync(liveDir)) {
+    const entry =
+      [
+        "",
+        `## ${ts} – Archive ${experimentSlug} for ${featureId} (idempotent re-run)`,
+        `- **Already archived at:** ${dest}`,
+        "",
+      ].join("\n") + "\n";
+    appendSelectionLog(tddDir, entry);
+    return {
+      experiment_slug: experimentSlug,
+      archived_dir: dest,
+      lakebase_branch_deleted: false,
+      app_deployment_deleted: false,
+      selection_log_entry: entry,
+    };
+  }
+
+  // Resolve the live experiment to archive
+  const experiments = listExperiments(tddDir, featureId);
+  const target = experiments.find((e) => e.experiment_slug === experimentSlug);
+  if (!target) {
+    throw new ArchiveExperimentError(
+      `Experiment ${experimentSlug} not found under feature ${featureId}`
+    );
+  }
+
+  // 1. Snapshot prior outcomes for rollback
+  const priorOutcomes = readOutcomes(tddDir, featureId, experimentSlug);
+
+  // 2. Mark outcomes abandoned
+  writeOutcomes(tddDir, featureId, experimentSlug, {
+    ...(priorOutcomes ?? {}),
+    status: "abandoned",
+  });
+
+  // 3. Move dir
+  renameSync(target.dir, dest);
+
+  // 4+5. Try teardown callbacks; track success per side
+  let lakebaseDeleted = false;
+  let appDeleted = false;
+  let teardownError: Error | undefined;
+
+  if (args.deleteLakebaseBranch) {
+    try {
+      await args.deleteLakebaseBranch(target.branch_id);
+      lakebaseDeleted = true;
+    } catch (err) {
+      teardownError = err as Error;
+    }
+  }
+  if (!teardownError && args.deleteAppDeployment) {
+    try {
+      await args.deleteAppDeployment(experimentSlug);
+      appDeleted = true;
+    } catch (err) {
+      teardownError = err as Error;
+    }
+  }
+
+  // 6. Rollback on teardown failure
+  if (teardownError) {
+    // Revert dir move
+    try {
+      renameSync(dest, target.dir);
+    } catch {
+      // Couldn't move back; record but continue with rollback of outcomes
+    }
+    // Revert outcomes
+    if (priorOutcomes) {
+      writeOutcomes(tddDir, featureId, experimentSlug, priorOutcomes);
+    }
+    const entry =
+      [
+        "",
+        `## ${ts} – Archive ${experimentSlug} for ${featureId} (PARTIAL / rolled back)`,
+        `- **Reason:** teardown callback failed: ${teardownError.message}`,
+        `- **Lakebase branch deleted:** ${lakebaseDeleted}`,
+        `- **App deployment deleted:** ${appDeleted}`,
+        `- **Dir + outcomes:** restored to pre-archive state`,
+        `- **Approver:** ${approverEmail ?? "HITL (no email recorded)"}`,
+        "",
+      ].join("\n") + "\n";
+    appendSelectionLog(tddDir, entry);
+    throw new ArchiveExperimentError(
+      `Teardown failed mid-archive (${teardownError.message}); dir + outcomes rolled back. See selection-log.md.`,
+      true
+    );
+  }
+
+  // 7. Full success
+  const entry =
+    [
+      "",
+      `## ${ts} – Archive ${experimentSlug} for ${featureId}`,
+      `- **Archived dir:** ${dest}`,
+      `- **Lakebase branch deleted:** ${lakebaseDeleted}${args.deleteLakebaseBranch ? "" : " (no callback)"}`,
+      `- **App deployment deleted:** ${appDeleted}${args.deleteAppDeployment ? "" : " (no callback)"}`,
+      `- **Approver:** ${approverEmail ?? "HITL (no email recorded)"}`,
+      "",
+    ].join("\n") + "\n";
+  appendSelectionLog(tddDir, entry);
+
+  return {
+    experiment_slug: experimentSlug,
+    archived_dir: dest,
+    lakebase_branch_deleted: lakebaseDeleted,
+    app_deployment_deleted: appDeleted,
+    selection_log_entry: entry,
+  };
+}

--- a/scripts/tdd/promote-experiment.ts
+++ b/scripts/tdd/promote-experiment.ts
@@ -1,7 +1,8 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { listExperiments, readOutcomes, writeOutcomes } from "./experiment";
 import { readFeature, writeFeature } from "./spec-sync";
+import { archiveExperiment } from "./archive-experiment";
 
 export interface PromoteArgs {
   tddDir: string;
@@ -10,6 +11,19 @@ export interface PromoteArgs {
   /** Set to true to record the HITL approval. Refuses to run without it. */
   hitlApproved: boolean;
   approverEmail?: string;
+  /**
+   * Forwarded to archiveExperiment for each loser. When omitted, the
+   * loser's Lakebase branch is left in place (dir + outcomes marker
+   * still get applied). FEIP-7214: callers that want full branch
+   * teardown wire this; promote stays pure-substrate when the callback
+   * is absent.
+   */
+  deleteLakebaseBranch?: (branchId: string) => Promise<void>;
+  /**
+   * Forwarded to archiveExperiment for each loser. Same contract as
+   * deleteLakebaseBranch.
+   */
+  deleteAppDeployment?: (experimentSlug: string) => Promise<void>;
 }
 
 export interface PromoteResult {
@@ -32,7 +46,7 @@ export interface PromoteResult {
  * to run otherwise so the orchestrator cannot promote without a recorded
  * human decision.
  */
-export function promoteExperiment(args: PromoteArgs): PromoteResult {
+export async function promoteExperiment(args: PromoteArgs): Promise<PromoteResult> {
   if (!args.hitlApproved) {
     throw new Error("promoteExperiment requires hitlApproved: true (HITL Gate)");
   }
@@ -44,24 +58,25 @@ export function promoteExperiment(args: PromoteArgs): PromoteResult {
   }
   const losers = experiments.filter((e) => e.experiment_slug !== winnerSlug);
 
-  // Update outcomes
+  // Mark winner succeeded
   const winnerOutcome = readOutcomes(tddDir, featureId, winnerSlug);
   writeOutcomes(tddDir, featureId, winnerSlug, { ...(winnerOutcome ?? {}), status: "succeeded" });
 
-  const archiveDir = join(tddDir, "experiments", featureId, "_archive");
-  mkdirSync(archiveDir, { recursive: true });
+  // Archive each loser via the lifecycle primitive (FEIP-7214). Each
+  // archive is atomic + HITL-gated; promote inherits the HITL approval
+  // for the whole flow by passing hitlApproved: true to each call.
+  const archivedSlugs: string[] = [];
   for (const loser of losers) {
-    const prior = readOutcomes(tddDir, featureId, loser.experiment_slug);
-    writeOutcomes(tddDir, featureId, loser.experiment_slug, {
-      ...(prior ?? {}),
-      status: "abandoned",
+    await archiveExperiment({
+      tddDir,
+      featureId,
+      experimentSlug: loser.experiment_slug,
+      hitlApproved: true,
+      approverEmail,
+      deleteLakebaseBranch: args.deleteLakebaseBranch,
+      deleteAppDeployment: args.deleteAppDeployment,
     });
-    const dest = join(archiveDir, loser.experiment_slug);
-    if (existsSync(dest)) {
-      // Already archived; skip rename to avoid collision.
-      continue;
-    }
-    renameSync(loser.dir, dest);
+    archivedSlugs.push(loser.experiment_slug);
   }
 
   // Feature → ready-for-review
@@ -73,7 +88,8 @@ export function promoteExperiment(args: PromoteArgs): PromoteResult {
     // No feature.json – caller's responsibility. Don't block promotion.
   }
 
-  // Append to selection log
+  // Append a single "Promote" entry to selection log on top of the
+  // per-loser "Archive" entries archiveExperiment writes.
   const logPath = join(tddDir, "selection-log.md");
   const ts = new Date().toISOString();
   const lines = [
@@ -81,7 +97,7 @@ export function promoteExperiment(args: PromoteArgs): PromoteResult {
     `## ${ts} – Promote ${winnerSlug} for ${featureId}`,
     `- **Winner:** ${winnerSlug} (branch ${winner.branch_id})`,
     losers.length > 0
-      ? `- **Archived:** ${losers.map((l) => l.experiment_slug).join(", ")}`
+      ? `- **Archived (see entries above):** ${losers.map((l) => l.experiment_slug).join(", ")}`
       : `- **Archived:** none (no parallel experiments)`,
     `- **Approved by:** ${approverEmail ?? "HITL (no email recorded)"}`,
     "",
@@ -94,7 +110,7 @@ export function promoteExperiment(args: PromoteArgs): PromoteResult {
 
   return {
     winner_slug: winnerSlug,
-    archived_slugs: losers.map((l) => l.experiment_slug),
+    archived_slugs: archivedSlugs,
     feature_status: "ready-for-review",
   };
 }

--- a/tests/bdd/tdd-archive-experiment.test.ts
+++ b/tests/bdd/tdd-archive-experiment.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  archiveExperiment,
+  ArchiveExperimentError,
+} from "../../scripts/tdd/archive-experiment";
+
+let tdd: string;
+
+function seedExperiment(slug: string, outcomes: object): string {
+  const dir = join(tdd, "experiments", "F1", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "branch.txt"), `feature/${slug}`);
+  writeFileSync(join(dir, "outcomes.json"), JSON.stringify(outcomes));
+  return dir;
+}
+
+beforeEach(() => {
+  tdd = mkdtempSync(join(tmpdir(), "tdd-archive-"));
+});
+
+afterEach(() => {
+  rmSync(tdd, { recursive: true, force: true });
+});
+
+describe("archiveExperiment", () => {
+  it("throws when hitlApproved is false", async () => {
+    seedExperiment("exp-a", { status: "running" });
+    await expect(
+      archiveExperiment({
+        tddDir: tdd,
+        featureId: "F1",
+        experimentSlug: "exp-a",
+        hitlApproved: false,
+      })
+    ).rejects.toThrow(/HITL/);
+  });
+
+  it("throws when experimentSlug does not exist", async () => {
+    await expect(
+      archiveExperiment({
+        tddDir: tdd,
+        featureId: "F1",
+        experimentSlug: "ghost",
+        hitlApproved: true,
+      })
+    ).rejects.toThrow(/not found/);
+  });
+
+  it("moves the dir under _archive/, marks outcomes abandoned, appends selection-log", async () => {
+    seedExperiment("exp-a", { status: "running", api_pass: true });
+    const result = await archiveExperiment({
+      tddDir: tdd,
+      featureId: "F1",
+      experimentSlug: "exp-a",
+      hitlApproved: true,
+      approverEmail: "kevin@example.com",
+    });
+    expect(result.experiment_slug).toBe("exp-a");
+    expect(existsSync(join(tdd, "experiments", "F1", "exp-a"))).toBe(false);
+    expect(existsSync(join(tdd, "experiments", "F1", "_archive", "exp-a"))).toBe(true);
+    // outcomes.json preserved in the moved dir + marked abandoned
+    const archivedOutcomes = JSON.parse(
+      readFileSync(
+        join(tdd, "experiments", "F1", "_archive", "exp-a", "outcomes.json"),
+        "utf8"
+      )
+    );
+    expect(archivedOutcomes.status).toBe("abandoned");
+    expect(archivedOutcomes.api_pass).toBe(true); // prior state preserved
+    // selection-log entry written
+    const log = readFileSync(join(tdd, "selection-log.md"), "utf8");
+    expect(log).toMatch(/Archive exp-a for F1/);
+    expect(log).toMatch(/kevin@example.com/);
+  });
+
+  it("invokes deleteLakebaseBranch with the experiment's branch_id", async () => {
+    seedExperiment("exp-a", { status: "running" });
+    const seen: string[] = [];
+    const result = await archiveExperiment({
+      tddDir: tdd,
+      featureId: "F1",
+      experimentSlug: "exp-a",
+      hitlApproved: true,
+      deleteLakebaseBranch: async (branchId) => {
+        seen.push(branchId);
+      },
+    });
+    expect(seen).toEqual(["feature/exp-a"]);
+    expect(result.lakebase_branch_deleted).toBe(true);
+  });
+
+  it("rolls back dir + outcomes when deleteLakebaseBranch throws", async () => {
+    seedExperiment("exp-a", { status: "running" });
+    await expect(
+      archiveExperiment({
+        tddDir: tdd,
+        featureId: "F1",
+        experimentSlug: "exp-a",
+        hitlApproved: true,
+        deleteLakebaseBranch: async () => {
+          throw new Error("lakebase branch delete failed");
+        },
+      })
+    ).rejects.toBeInstanceOf(ArchiveExperimentError);
+
+    // Dir restored
+    expect(existsSync(join(tdd, "experiments", "F1", "exp-a"))).toBe(true);
+    expect(existsSync(join(tdd, "experiments", "F1", "_archive", "exp-a"))).toBe(false);
+    // Outcomes restored
+    const outcomes = JSON.parse(
+      readFileSync(join(tdd, "experiments", "F1", "exp-a", "outcomes.json"), "utf8")
+    );
+    expect(outcomes.status).toBe("running");
+    // Selection-log records partial state
+    const log = readFileSync(join(tdd, "selection-log.md"), "utf8");
+    expect(log).toMatch(/PARTIAL \/ rolled back/);
+    expect(log).toMatch(/lakebase branch delete failed/);
+  });
+
+  it("rolls back when deleteAppDeployment throws (after Lakebase delete succeeded)", async () => {
+    seedExperiment("exp-a", { status: "running" });
+    let lakebaseCalled = false;
+    await expect(
+      archiveExperiment({
+        tddDir: tdd,
+        featureId: "F1",
+        experimentSlug: "exp-a",
+        hitlApproved: true,
+        deleteLakebaseBranch: async () => {
+          lakebaseCalled = true;
+        },
+        deleteAppDeployment: async () => {
+          throw new Error("app teardown failed");
+        },
+      })
+    ).rejects.toBeInstanceOf(ArchiveExperimentError);
+
+    expect(lakebaseCalled).toBe(true);
+    // Dir restored despite lakebase having been deleted
+    expect(existsSync(join(tdd, "experiments", "F1", "exp-a"))).toBe(true);
+    const log = readFileSync(join(tdd, "selection-log.md"), "utf8");
+    expect(log).toMatch(/Lakebase branch deleted:\*\* true/);
+    expect(log).toMatch(/App deployment deleted:\*\* false/);
+  });
+
+  it("is idempotent: re-archiving an already-archived experiment writes a re-run log entry", async () => {
+    seedExperiment("exp-a", { status: "running" });
+    await archiveExperiment({
+      tddDir: tdd,
+      featureId: "F1",
+      experimentSlug: "exp-a",
+      hitlApproved: true,
+    });
+    const second = await archiveExperiment({
+      tddDir: tdd,
+      featureId: "F1",
+      experimentSlug: "exp-a",
+      hitlApproved: true,
+    });
+    expect(second.archived_dir).toBe(
+      join(tdd, "experiments", "F1", "_archive", "exp-a")
+    );
+    const log = readFileSync(join(tdd, "selection-log.md"), "utf8");
+    expect(log).toMatch(/idempotent re-run/);
+  });
+
+  it("when no callbacks are provided, both deletion flags are false but archive still succeeds", async () => {
+    seedExperiment("exp-a", { status: "running" });
+    const result = await archiveExperiment({
+      tddDir: tdd,
+      featureId: "F1",
+      experimentSlug: "exp-a",
+      hitlApproved: true,
+    });
+    expect(result.lakebase_branch_deleted).toBe(false);
+    expect(result.app_deployment_deleted).toBe(false);
+    // Dir moved, outcomes marked
+    expect(existsSync(join(tdd, "experiments", "F1", "_archive", "exp-a"))).toBe(true);
+    const log = readFileSync(join(tdd, "selection-log.md"), "utf8");
+    expect(log).toMatch(/Lakebase branch deleted:\*\* false \(no callback\)/);
+    expect(log).toMatch(/App deployment deleted:\*\* false \(no callback\)/);
+  });
+});

--- a/tests/bdd/tdd-promote-experiment.test.ts
+++ b/tests/bdd/tdd-promote-experiment.test.ts
@@ -33,25 +33,25 @@ afterEach(() => {
 });
 
 describe("promoteExperiment", () => {
-  it("throws when hitlApproved is false", () => {
+  it("throws when hitlApproved is false", async () => {
     seedExperiment("exp-winner", { status: "succeeded" });
-    expect(() =>
+    await expect(
       promoteExperiment({ tddDir: tdd, featureId: "F1", winnerSlug: "exp-winner", hitlApproved: false })
-    ).toThrow(/HITL/);
+    ).rejects.toThrow(/HITL/);
   });
 
-  it("throws when winnerSlug does not exist", () => {
+  it("throws when winnerSlug does not exist", async () => {
     seedExperiment("exp-a", { status: "succeeded" });
-    expect(() =>
+    await expect(
       promoteExperiment({ tddDir: tdd, featureId: "F1", winnerSlug: "ghost", hitlApproved: true })
-    ).toThrow(/not found/);
+    ).rejects.toThrow(/not found/);
   });
 
-  it("marks winner succeeded and losers abandoned", () => {
+  it("marks winner succeeded and losers abandoned", async () => {
     seedExperiment("exp-a", { status: "succeeded" });
     seedExperiment("exp-b", { status: "running" });
     seedExperiment("exp-c", { status: "running" });
-    const result = promoteExperiment({
+    const result = await promoteExperiment({
       tddDir: tdd,
       featureId: "F1",
       winnerSlug: "exp-a",
@@ -69,10 +69,10 @@ describe("promoteExperiment", () => {
     ).toBe(true);
   });
 
-  it("transitions feature status to ready-for-review when feature.json exists", () => {
+  it("transitions feature status to ready-for-review when feature.json exists", async () => {
     seedFeature();
     seedExperiment("exp-a", { status: "succeeded" });
-    const result = promoteExperiment({
+    const result = await promoteExperiment({
       tddDir: tdd,
       featureId: "F1",
       winnerSlug: "exp-a",
@@ -85,9 +85,9 @@ describe("promoteExperiment", () => {
     expect(feature.status).toBe("ready-for-review");
   });
 
-  it("appends a decision record to selection-log.md", () => {
+  it("appends a decision record to selection-log.md", async () => {
     seedExperiment("exp-a", { status: "succeeded" });
-    promoteExperiment({
+    await promoteExperiment({
       tddDir: tdd,
       featureId: "F1",
       winnerSlug: "exp-a",


### PR DESCRIPTION
## Summary

Extracts the loser-archival logic from \`promote-experiment.ts\` into a standalone, HITL-gated, atomic primitive. Adds optional Lakebase branch + Databricks Apps teardown callbacks with full rollback semantics. \`promoteExperiment\` now auto-invokes \`archiveExperiment\` per loser; PO sees one atomic call.

Closes [FEIP-7214](https://databricks.atlassian.net/browse/FEIP-7214).

## New primitive: \`archiveExperiment\`

\`\`\`ts
await archiveExperiment({
  tddDir, featureId, experimentSlug,
  hitlApproved: true,
  approverEmail?: string,
  deleteLakebaseBranch?: (branchId: string) => Promise<void>,
  deleteAppDeployment?: (slug: string) => Promise<void>,
});
\`\`\`

**Order of operations** (matters for rollback):
1. Snapshot prior outcomes
2. Mark outcomes status="abandoned"
3. Move dir to \`_archive/<slug>/\`
4. Try \`deleteLakebaseBranch\` (best-effort if callback omitted)
5. Try \`deleteAppDeployment\` (best-effort if callback omitted)
6. On any callback throw: revert dir + outcomes, append PARTIAL entry, throw \`ArchiveExperimentError\` with \`partial: true\`
7. On full success: append archived entry, return result

**Idempotent**: re-archiving an already-archived experiment writes a re-run log entry and returns without error.

## Promote refactor

- \`promoteExperiment\` is now async (delegates through to \`archiveExperiment\`)
- For each loser, calls \`archiveExperiment\` instead of inlining the dir move + outcomes marker
- Forwards optional teardown callbacks down so promote can do full Lakebase + Apps cleanup when wired
- Existing 5 promote tests updated to \`await\`; still passing

## Tests

- **8 new vitest cases** in \`tdd-archive-experiment.test.ts\`:
  - HITL gate refusal
  - not-found
  - happy path (dir + outcomes + selection-log)
  - Lakebase callback invocation
  - rollback on Lakebase throw
  - rollback on Apps throw (after Lakebase succeeded)
  - idempotent re-run
  - no-callbacks branch
- **Promote tests** updated to await async calls
- **Full kit suite: 626 passing** (was 618), 0 failing
- typecheck + build clean

## Related

- [FEIP-7214](https://databricks.atlassian.net/browse/FEIP-7214) archiveExperiment lifecycle primitive
- Consumer for branch teardown: FEIP-7130 lakebase-apps-deploy substrate (deleteAppDeployment callback shape mirrors what that primitive expects)

This pull request and its description were written by Isaac.