### PR TITLE
chore(release): v0.3.0-alpha.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.30",
+  "version": "0.3.0-alpha.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.30",
+      "version": "0.3.0-alpha.31",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",
@@ -25,6 +25,7 @@
         "lakebase-cut-backup": "dist/scripts/lakebase/cut-backup.cli.js",
         "lakebase-detect-language": "dist/scripts/lakebase/detect-language.cli.js",
         "lakebase-doctor": "dist/scripts/lakebase/doctor.cli.js",
+        "lakebase-feature-status": "dist/scripts/tdd/feature-status.cli.js",
         "lakebase-get-connection": "dist/scripts/lakebase/get-connection.cli.js",
         "lakebase-github-token": "dist/scripts/github/auth.cli.js",
         "lakebase-mcp-server": "dist/apps/mcp-server/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.30",
+  "version": "0.3.0-alpha.31",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## Summary

Cuts `v0.3.0-alpha.31`, consolidating 4 substantive PRs since `v0.3.0-alpha.30`:

- **FEIP-7140 workflow-drift detector** (#70) – detect drift between scaffolded YAMLs + kit templates
- **FEIP-7206 smell detectors** (#71) – 3 missing TDD detectors (`api-coherence-drift`, `cross-experiment-divergence`, `dead-requirement-signal`)
- **FEIP-7214 archiveExperiment** (#72) – lifecycle primitive with rollback semantics for N>=2 losers
- **FEIP-7215 feature-status** (#47) – one-screen snapshot CLI bin + MCP tool with stable JSON payload schema

## Why bump now

Clean release marker before the FEIP-7217 / FEIP-7357 gates state machine workstream opens. Each of the 4 features above is independently shipped + tested; bundling them with in-flight gates work would mix released and unreleased surface in the same alpha.

## Compatibility

No substrate function signatures changed. Downstream extension pin update will follow as a `chore(deps)` catch-up (same pattern as PR #40 for alpha.30) without touching the extension's own version.

## Verification

- `npm test` – 645 passed, 0 failed (post-merge of #47 + carry-fixed em-dash to en-dash regex in `feature-status.ts`)
- `npm run build` – clean
- `npm run typecheck` – clean

## Test plan

- [x] Branch off main
- [x] Bump `package.json` to `0.3.0-alpha.31` + regenerate `package-lock.json`
- [x] Full test suite green
- [ ] Squash-merge this PR
- [ ] Tag `v0.3.0-alpha.31` on main + push tag
- [ ] Open follow-up `chore(deps)` PR in `lakebase-scm-extension` pinning to the new tag

This pull request and its description were written by Isaac.