### PR TITLE
feat(tdd): GatesState types + readGates / writeGates substrate (FEIP-7358)

### DIFF
--- a/scripts/tdd/gates.ts
+++ b/scripts/tdd/gates.ts
@@ -1,0 +1,203 @@
+// Structured HITL gate state for the TDD workflow.
+//
+// On-disk: .tdd/features/<F>/gates.json
+//
+// gates.json is the substrate's authoritative gate state. selection-log.md
+// stays as narrative-of-record (humans grep it when debugging). The
+// orchestrator + downstream primitives (FEIP-7213 test-list immutability,
+// FEIP-7215 feature-status) read this file instead of regex-scanning the log.
+//
+// Design: ADR-0004. Tracker: FEIP-7357. This module ships G1 only: types +
+// readGates + writeGates. approveGate / verifyGateIntegrity / withdrawGate /
+// hash-normalization / migration backfill / concurrent-write atomicity land
+// in G2 through G7.
+
+import { existsSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "fs";
+import { join } from "path";
+
+export const GATES_SCHEMA_VERSION = 1;
+
+export const GATE_NAMES = ["spec", "plan", "test_list", "promote"] as const;
+export type GateName = (typeof GATE_NAMES)[number];
+
+export const GATE_STATUSES = ["open", "approved", "superseded", "withdrawn"] as const;
+export type GateStatus = (typeof GATE_STATUSES)[number];
+
+export type GateHistoryAction =
+  | "approved"
+  | "withdrawn"
+  | "superseded"
+  | "cascade-withdrawn"
+  | "migrated";
+
+export interface GateHistoryEntry {
+  action: GateHistoryAction;
+  at: string;
+  approver: string;
+  artifact_hashes?: Record<string, string>;
+  reason?: string;
+  /** True when the history entry was synthesized by the selection-log backfill (G6). */
+  migrated?: boolean;
+}
+
+export interface GateRecord {
+  status: GateStatus;
+  approver?: string;
+  approved_at?: string;
+  artifact_hashes?: Record<string, string>;
+  withdrawal_reason?: string;
+  history: GateHistoryEntry[];
+}
+
+export interface GatesState {
+  feature_id: string;
+  schema_version: number;
+  gates: Record<GateName, GateRecord>;
+}
+
+export interface GatesIoOpts {
+  /** Path to the .tdd/ root. Default: "./.tdd". */
+  tddDir?: string;
+}
+
+export function defaultGatesState(featureId: string): GatesState {
+  return {
+    feature_id: featureId,
+    schema_version: GATES_SCHEMA_VERSION,
+    gates: {
+      spec: { status: "open", history: [] },
+      plan: { status: "open", history: [] },
+      test_list: { status: "open", history: [] },
+      promote: { status: "open", history: [] },
+    },
+  };
+}
+
+/**
+ * Read gates state for a feature. Returns the default-open shape when no
+ * gates.json exists yet (a fresh feature has all four gates open). Does NOT
+ * create the file; read is non-mutating.
+ *
+ * Throws when the feature directory cannot be resolved, or when gates.json
+ * exists but is malformed.
+ */
+export function readGates(featureId: string, opts: GatesIoOpts = {}): GatesState {
+  const tddDir = opts.tddDir ?? "./.tdd";
+  const file = gatesFilePath(tddDir, featureId);
+  if (!existsSync(file)) {
+    return defaultGatesState(featureId);
+  }
+  const raw = readFileSync(file, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(`gates.json at ${file} is not valid JSON: ${cause}`);
+  }
+  return validateGatesState(parsed, file);
+}
+
+/**
+ * Write gates state for a feature, atomic via temp-file + rename. If the
+ * process is killed mid-call the on-disk gates.json is either the prior
+ * content or the new content, never a partial write.
+ *
+ * Concurrent-write coordination (G7) is layered on top of this primitive;
+ * the rename is atomic but two callers can still race the read-modify-write
+ * cycle. Callers that need that guarantee should use approveGate (G3) or
+ * an explicit lock helper once G7 lands.
+ */
+export function writeGates(state: GatesState, opts: GatesIoOpts = {}): void {
+  if (state.feature_id.length === 0) {
+    throw new Error("writeGates: state.feature_id must not be empty");
+  }
+  const tddDir = opts.tddDir ?? "./.tdd";
+  const file = gatesFilePath(tddDir, state.feature_id);
+  const tempFile = `${file}.tmp.${process.pid}.${Date.now()}`;
+  const payload = JSON.stringify(state, null, 2) + "\n";
+  writeFileSync(tempFile, payload, "utf8");
+  try {
+    renameSync(tempFile, file);
+  } catch (err) {
+    try {
+      unlinkSync(tempFile);
+    } catch {
+      // Best-effort cleanup; surface the rename error.
+    }
+    throw err;
+  }
+}
+
+function gatesFilePath(tddDir: string, featureId: string): string {
+  return join(findFeatureDir(tddDir, featureId), "gates.json");
+}
+
+function findFeatureDir(tddDir: string, featureId: string): string {
+  const featuresDir = join(tddDir, "features");
+  if (!existsSync(featuresDir)) {
+    throw new Error(`${featuresDir} does not exist`);
+  }
+  const candidates = readdirSync(featuresDir).filter((d) => d.startsWith(featureId));
+  if (candidates.length === 0) {
+    throw new Error(`feature ${featureId} not found under ${featuresDir}`);
+  }
+  return join(featuresDir, candidates[0]);
+}
+
+function validateGatesState(parsed: unknown, file: string): GatesState {
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error(`gates.json at ${file} is not an object`);
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.feature_id !== "string" || obj.feature_id.length === 0) {
+    throw new Error(`gates.json at ${file}: missing or invalid feature_id`);
+  }
+  if (typeof obj.schema_version !== "number") {
+    throw new Error(`gates.json at ${file}: missing or invalid schema_version`);
+  }
+  if (typeof obj.gates !== "object" || obj.gates === null) {
+    throw new Error(`gates.json at ${file}: missing or invalid gates`);
+  }
+  const gates = obj.gates as Record<string, unknown>;
+  const out: Record<GateName, GateRecord> = {
+    spec: validateGateRecord(gates.spec, "spec", file),
+    plan: validateGateRecord(gates.plan, "plan", file),
+    test_list: validateGateRecord(gates.test_list, "test_list", file),
+    promote: validateGateRecord(gates.promote, "promote", file),
+  };
+  return {
+    feature_id: obj.feature_id,
+    schema_version: obj.schema_version,
+    gates: out,
+  };
+}
+
+function validateGateRecord(parsed: unknown, gateName: GateName, file: string): GateRecord {
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error(`gates.json at ${file}: gate ${gateName} is not an object`);
+  }
+  const obj = parsed as Record<string, unknown>;
+  const status = obj.status;
+  if (typeof status !== "string" || !GATE_STATUSES.includes(status as GateStatus)) {
+    throw new Error(
+      `gates.json at ${file}: gate ${gateName} has invalid status (${String(status)}); expected one of ${GATE_STATUSES.join(", ")}`
+    );
+  }
+  const history = obj.history;
+  if (history !== undefined && !Array.isArray(history)) {
+    throw new Error(`gates.json at ${file}: gate ${gateName} history must be an array`);
+  }
+  return {
+    status: status as GateStatus,
+    approver: typeof obj.approver === "string" ? obj.approver : undefined,
+    approved_at: typeof obj.approved_at === "string" ? obj.approved_at : undefined,
+    artifact_hashes:
+      obj.artifact_hashes && typeof obj.artifact_hashes === "object"
+        ? (obj.artifact_hashes as Record<string, string>)
+        : undefined,
+    withdrawal_reason:
+      typeof obj.withdrawal_reason === "string" ? obj.withdrawal_reason : undefined,
+    history: (history as GateHistoryEntry[] | undefined) ?? [],
+  };
+}

--- a/tests/bdd/tdd-gates.test.ts
+++ b/tests/bdd/tdd-gates.test.ts
@@ -1,0 +1,165 @@
+// G1 (FEIP-7358): GatesState types + readGates / writeGates substrate.
+//
+// Covers the ADR-0004 test plan scenarios:
+//   S1.1 readGates returns the default-open shape when gates.json is absent
+//   S1.2 round-trip writeGates -> readGates
+//   S1.3 malformed gates.json throws a clear error
+//   S1.4 writeGates leaves no temp file behind on success (atomicity probe)
+//
+// approveGate / verifyGateIntegrity / withdrawGate / hash normalization /
+// migration / concurrent-write atomicity live in G2 through G7; their
+// scenarios are filed against their own sub-tasks.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  GATES_SCHEMA_VERSION,
+  GATE_NAMES,
+  defaultGatesState,
+  readGates,
+  writeGates,
+  type GatesState,
+} from "../../scripts/tdd/gates";
+
+let tdd: string;
+const FEATURE_ID = "F1-checkout";
+
+function makeFeatureDir(): string {
+  const dir = join(tdd, "features", FEATURE_ID);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+beforeEach(() => {
+  tdd = mkdtempSync(join(tmpdir(), "tdd-gates-"));
+});
+
+afterEach(() => {
+  rmSync(tdd, { recursive: true, force: true });
+});
+
+describe("gates: defaultGatesState", () => {
+  it("returns all four gates in the open state with empty history", () => {
+    const state = defaultGatesState(FEATURE_ID);
+    expect(state.feature_id).toBe(FEATURE_ID);
+    expect(state.schema_version).toBe(GATES_SCHEMA_VERSION);
+    for (const name of GATE_NAMES) {
+      expect(state.gates[name].status).toBe("open");
+      expect(state.gates[name].history).toEqual([]);
+    }
+  });
+});
+
+describe("gates: readGates (S1.1 default-open + S1.3 malformed)", () => {
+  it("S1.1: returns default-open shape when gates.json is absent", () => {
+    makeFeatureDir();
+    const state = readGates(FEATURE_ID, { tddDir: tdd });
+    expect(state).toEqual(defaultGatesState(FEATURE_ID));
+  });
+
+  it("S1.1: does NOT create gates.json on a default-open read", () => {
+    const dir = makeFeatureDir();
+    readGates(FEATURE_ID, { tddDir: tdd });
+    expect(existsSync(join(dir, "gates.json"))).toBe(false);
+  });
+
+  it("throws when the feature directory does not exist", () => {
+    expect(() => readGates(FEATURE_ID, { tddDir: tdd })).toThrow(
+      /does not exist|not found/
+    );
+  });
+
+  it("S1.3: throws a clear error on invalid JSON", () => {
+    const dir = makeFeatureDir();
+    writeFileSync(join(dir, "gates.json"), "{ not valid json");
+    expect(() => readGates(FEATURE_ID, { tddDir: tdd })).toThrow(/not valid JSON/);
+  });
+
+  it("S1.3: throws when feature_id is missing", () => {
+    const dir = makeFeatureDir();
+    writeFileSync(
+      join(dir, "gates.json"),
+      JSON.stringify({ schema_version: 1, gates: {} })
+    );
+    expect(() => readGates(FEATURE_ID, { tddDir: tdd })).toThrow(/feature_id/);
+  });
+
+  it("S1.3: throws when a gate has an invalid status", () => {
+    const dir = makeFeatureDir();
+    const bad: unknown = {
+      feature_id: FEATURE_ID,
+      schema_version: 1,
+      gates: {
+        spec: { status: "bogus", history: [] },
+        plan: { status: "open", history: [] },
+        test_list: { status: "open", history: [] },
+        promote: { status: "open", history: [] },
+      },
+    };
+    writeFileSync(join(dir, "gates.json"), JSON.stringify(bad));
+    expect(() => readGates(FEATURE_ID, { tddDir: tdd })).toThrow(/invalid status/);
+  });
+});
+
+describe("gates: writeGates (S1.2 round-trip + S1.4 atomicity)", () => {
+  it("S1.2: round-trip writeGates then readGates returns equivalent state", () => {
+    makeFeatureDir();
+    const state: GatesState = {
+      feature_id: FEATURE_ID,
+      schema_version: GATES_SCHEMA_VERSION,
+      gates: {
+        spec: {
+          status: "approved",
+          approver: "kevin.hartman@databricks.com",
+          approved_at: "2026-05-31T20:00:00Z",
+          artifact_hashes: { "spec.md": "sha256:abc", "feature.json": "sha256:def" },
+          history: [
+            {
+              action: "approved",
+              at: "2026-05-31T20:00:00Z",
+              approver: "kevin.hartman@databricks.com",
+              artifact_hashes: { "spec.md": "sha256:abc", "feature.json": "sha256:def" },
+            },
+          ],
+        },
+        plan: { status: "open", history: [] },
+        test_list: { status: "open", history: [] },
+        promote: { status: "open", history: [] },
+      },
+    };
+    writeGates(state, { tddDir: tdd });
+    const back = readGates(FEATURE_ID, { tddDir: tdd });
+    expect(back).toEqual(state);
+  });
+
+  it("S1.2: overwrites a prior gates.json on subsequent writes", () => {
+    makeFeatureDir();
+    const first = defaultGatesState(FEATURE_ID);
+    writeGates(first, { tddDir: tdd });
+    const second: GatesState = {
+      ...first,
+      gates: {
+        ...first.gates,
+        spec: { status: "withdrawn", withdrawal_reason: "po retracted", history: [] },
+      },
+    };
+    writeGates(second, { tddDir: tdd });
+    const back = readGates(FEATURE_ID, { tddDir: tdd });
+    expect(back.gates.spec.status).toBe("withdrawn");
+    expect(back.gates.spec.withdrawal_reason).toBe("po retracted");
+  });
+
+  it("S1.4: leaves no temp file behind on a successful write", () => {
+    const dir = makeFeatureDir();
+    writeGates(defaultGatesState(FEATURE_ID), { tddDir: tdd });
+    const stray = readdirSync(dir).filter((f) => f.includes(".tmp."));
+    expect(stray).toEqual([]);
+  });
+
+  it("rejects an empty feature_id", () => {
+    const bad: GatesState = { ...defaultGatesState(FEATURE_ID), feature_id: "" };
+    expect(() => writeGates(bad, { tddDir: tdd })).toThrow(/feature_id/);
+  });
+});


### PR DESCRIPTION
## Summary

G1 of the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track ([ADR-0004](~/code/docs/adr/ADR-0004-tdd-gates-state-machine.md)). First of 11 sub-tasks. Lays the type + I/O foundation that the rest of the track builds on: G2 hash normalization, G3 `approveGate`, G4 `verifyGateIntegrity`, G5 `withdrawGate` + cascade, G6 selection-log backfill, G7 concurrent-write atomicity.

## What ships

**`scripts/tdd/gates.ts`** (190 lines):
- `GateName` / `GateStatus` / `GateRecord` / `GateHistoryEntry` / `GatesState` types per ADR-0004 (named gates `spec` / `plan` / `test_list` / `promote`; statuses `open` / `approved` / `superseded` / `withdrawn`; per-gate `history[]` array)
- `defaultGatesState(featureId)`: all four gates `open`, empty history
- `readGates(featureId, opts)`: returns default-open shape when `gates.json` is absent; throws on malformed JSON or invalid schema with the file path in the message. Non-mutating (does NOT create the file on read)
- `writeGates(state, opts)`: atomic via temp-file + `fs.renameSync`. No partial writes if the process is killed mid-call; cleans up temp on rename failure. G7 will layer optimistic-retry concurrency on top of this primitive

**`tests/bdd/tdd-gates.test.ts`** (11 tests, all green):
- **S1.1** default-open shape returned when `gates.json` absent + non-mutating read
- **S1.2** round-trip `writeGates` -> `readGates` preserves all fields (approver, hashes, history); overwrite semantics on second write
- **S1.3** malformed JSON, missing `feature_id`, invalid status all throw clear errors that include the file path
- **S1.4** successful `writeGates` leaves no temp file behind

## Verification

- `npm run typecheck` clean
- `npx vitest run tests/bdd/tdd-gates.test.ts`: 11/11 pass
- `npm test`: 656 passed, 0 failed (was 645; +11 new)

## What's NOT in this PR

Out of scope for G1, scoped to follow-up sub-tasks:
- Hash normalization helper (G2 / FEIP-7359, test-first)
- `approveGate` (G3 / FEIP-7360)
- `verifyGateIntegrity` (G4 / FEIP-7361)
- `withdrawGate` + cascade-on-withdrawal (G5 / FEIP-7362)
- Migration backfill from selection-log (G6 / FEIP-7363)
- Concurrent-write atomicity / optimistic retry (G7 / FEIP-7364)
- Orchestrator wiring + agent prompt updates (G8 / FEIP-7365)
- End-to-end SCM-workflow integration test (G9 / FEIP-7366)
- Product + cross-cutting acceptance tests (G10 / FEIP-7367)
- Docs + SKILL.md updates (G11 / FEIP-7368)

## Test plan

- [x] Branch off main (post-alpha.31)
- [x] Author types + I/O substrate + tests
- [x] Typecheck clean
- [x] New tests 11/11
- [x] Full suite 656 passed, 0 failed
- [ ] Squash-merge

This pull request and its description were written by Isaac.