### PR TITLE
feat(tdd): gate-hash normalization helper (FEIP-7359)

### DIFF
--- a/scripts/tdd/gate-hash.ts
+++ b/scripts/tdd/gate-hash.ts
@@ -1,0 +1,64 @@
+// Hash normalization helper for gate artifacts.
+//
+// Captures a stable fingerprint of a gate's protected artifact (spec.md,
+// plan.json, test-list.json, ...) that survives formatter-only edits
+// (prettier, editor whitespace settings, CRLF/LF differences) while still
+// detecting any semantic change.
+//
+// Wrong normalization is the single biggest risk in the gates state machine:
+//   - Too STRICT (no normalization) -> a prettier run trips the integrity
+//     check; users lose trust and disable the gate.
+//   - Too LOOSE (over-normalization) -> a formatting-only edit slips
+//     through, but so does a semantic change that happens to look like
+//     formatting (e.g. AC text edit that prettier already reflowed).
+//
+// Rules per ADR-0004:
+//   1. Normalize line endings: CRLF and bare CR fold to LF.
+//   2. Strip TRAILING whitespace per line. Leading whitespace is preserved
+//      (markdown list indentation is semantic).
+//   3. Collapse runs of consecutive blank lines (3+ newlines) down to a
+//      single blank line (2 newlines). Blank lines that contained only
+//      whitespace become empty after rule 2 and are then collapsed by
+//      rule 3.
+//
+// The final hash is sha256 over the normalized text, returned as
+// lowercase hex. Callers should compare hex strings directly.
+
+import { createHash } from "crypto";
+
+/**
+ * Apply the ADR-0004 normalization rules. Exported for test + debug use;
+ * production callers should use hashArtifact.
+ *
+ * Idempotent: normalizeForHash(normalizeForHash(x)) === normalizeForHash(x).
+ */
+export function normalizeForHash(content: string): string {
+  // Rule 1: line-ending normalization. Order matters: handle CRLF first so
+  // we do not double-fold the \n half into a second blank line.
+  let normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+  // Rule 2: strip trailing whitespace per line. Split + map + join is
+  // straightforward and clearer than a single multi-line regex with the
+  // `m` flag.
+  normalized = normalized
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/, ""))
+    .join("\n");
+
+  // Rule 3: collapse 3+ consecutive newlines down to 2 (a single blank
+  // line between content). A 2-newline sequence is a single blank line
+  // and is preserved as-is.
+  normalized = normalized.replace(/\n{3,}/g, "\n\n");
+
+  return normalized;
+}
+
+/**
+ * Compute the canonical sha256 hex hash of an artifact's content after
+ * applying the ADR-0004 normalization rules.
+ *
+ * Returns a 64-character lowercase hex string.
+ */
+export function hashArtifact(content: string): string {
+  return createHash("sha256").update(normalizeForHash(content), "utf8").digest("hex");
+}

--- a/tests/bdd/tdd-gate-hash.test.ts
+++ b/tests/bdd/tdd-gate-hash.test.ts
@@ -1,0 +1,138 @@
+// G2 (FEIP-7359): hash normalization helper for gate artifacts.
+//
+// Test-FIRST per the ADR-0004 design rationale: this is the riskiest piece
+// of the gates state machine. Wrong normalization causes false drift (a
+// prettier run triggers an integrity violation) or false security (a
+// formatting-only edit slips past the integrity gate). Each rule from
+// ADR-0004 gets its own explicit case so the contract is unambiguous.
+//
+// Normalization rules (ADR-0004):
+//   1. Normalize line endings to LF (CRLF -> LF, CR -> LF)
+//   2. Strip TRAILING whitespace per line (leading whitespace preserved;
+//      markdown indentation is semantic)
+//   3. Collapse runs of consecutive blank lines to a single blank line
+//   4. Final hash is sha256 over the normalized text, returned as hex
+
+import { describe, it, expect } from "vitest";
+import { hashArtifact, normalizeForHash } from "../../scripts/tdd/gate-hash";
+
+describe("gate-hash: hashArtifact", () => {
+  it("returns a 64-char lowercase hex sha256 string", () => {
+    const h = hashArtifact("hello\n");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic: same input -> same hash", () => {
+    expect(hashArtifact("hello\n")).toBe(hashArtifact("hello\n"));
+  });
+
+  it("is sensitive to semantic content changes", () => {
+    expect(hashArtifact("hello\n")).not.toBe(hashArtifact("goodbye\n"));
+  });
+
+  it("handles UTF-8 content (non-ASCII characters)", () => {
+    const a = hashArtifact("césar\n");
+    const b = hashArtifact("césar\n");
+    expect(a).toBe(b);
+    expect(hashArtifact("césar\n")).not.toBe(hashArtifact("cesar\n"));
+  });
+});
+
+describe("gate-hash: rule 1 line-ending normalization", () => {
+  it("CRLF hashes identically to LF", () => {
+    expect(hashArtifact("a\r\nb\r\n")).toBe(hashArtifact("a\nb\n"));
+  });
+
+  it("CR (old Mac) hashes identically to LF", () => {
+    expect(hashArtifact("a\rb\r")).toBe(hashArtifact("a\nb\n"));
+  });
+
+  it("mixed CRLF + LF + CR all normalize to the same hash", () => {
+    expect(hashArtifact("a\r\nb\nc\rd")).toBe(hashArtifact("a\nb\nc\nd"));
+  });
+});
+
+describe("gate-hash: rule 2 trailing-whitespace stripping", () => {
+  it("trailing spaces on a line are ignored", () => {
+    expect(hashArtifact("hello   \n")).toBe(hashArtifact("hello\n"));
+  });
+
+  it("trailing tabs on a line are ignored", () => {
+    expect(hashArtifact("hello\t\t\n")).toBe(hashArtifact("hello\n"));
+  });
+
+  it("mixed trailing whitespace on multiple lines is ignored", () => {
+    const noisy = "alpha  \nbeta\t \ngamma   \t\n";
+    const clean = "alpha\nbeta\ngamma\n";
+    expect(hashArtifact(noisy)).toBe(hashArtifact(clean));
+  });
+
+  it("LEADING whitespace is preserved (markdown indentation is semantic)", () => {
+    const indented = "  - item\n    - nested\n";
+    const flat = "- item\n- nested\n";
+    expect(hashArtifact(indented)).not.toBe(hashArtifact(flat));
+  });
+
+  it("interior whitespace inside a line is preserved", () => {
+    expect(hashArtifact("a  b\n")).not.toBe(hashArtifact("a b\n"));
+  });
+});
+
+describe("gate-hash: rule 3 blank-line collapse", () => {
+  it("two consecutive blank lines collapse to one", () => {
+    expect(hashArtifact("a\n\n\nb\n")).toBe(hashArtifact("a\n\nb\n"));
+  });
+
+  it("many consecutive blank lines collapse to one", () => {
+    expect(hashArtifact("a\n\n\n\n\n\nb\n")).toBe(hashArtifact("a\n\nb\n"));
+  });
+
+  it("blank lines containing only whitespace are also collapsed", () => {
+    const padded = "a\n   \n\t\n\nb\n";
+    const clean = "a\n\nb\n";
+    expect(hashArtifact(padded)).toBe(hashArtifact(clean));
+  });
+
+  it("a single blank line is preserved (semantic separator)", () => {
+    expect(hashArtifact("a\n\nb\n")).not.toBe(hashArtifact("a\nb\n"));
+  });
+});
+
+describe("gate-hash: integration of all three rules", () => {
+  it("CRLF + trailing whitespace + extra blank lines all normalize together", () => {
+    const noisy = "alpha   \r\n\r\n\r\nbeta\t\r\n";
+    const clean = "alpha\n\nbeta\n";
+    expect(hashArtifact(noisy)).toBe(hashArtifact(clean));
+  });
+
+  it("prettier-equivalent reformat does not change the hash", () => {
+    // Simulated: trailing whitespace stripped, line endings normalized,
+    // double-blank sections collapsed.
+    const before = "# Title\r\n\r\n\r\nBody text   \r\n\r\nMore body  \r\n";
+    const after = "# Title\n\nBody text\n\nMore body\n";
+    expect(hashArtifact(before)).toBe(hashArtifact(after));
+  });
+
+  it("a semantic edit (word change) inside the body produces a different hash", () => {
+    const before = "# Title\n\nBody text\n";
+    const after = "# Title\n\nBody TEXT\n";
+    expect(hashArtifact(before)).not.toBe(hashArtifact(after));
+  });
+});
+
+describe("gate-hash: normalizeForHash exposed for debug", () => {
+  it("is idempotent: normalize(normalize(x)) == normalize(x)", () => {
+    const input = "alpha   \r\n\r\n\r\nbeta\t\r\n";
+    const once = normalizeForHash(input);
+    const twice = normalizeForHash(once);
+    expect(twice).toBe(once);
+  });
+
+  it("hashArtifact(x) == sha256(normalizeForHash(x))", async () => {
+    const input = "alpha   \r\nbeta\r\n";
+    const normalized = normalizeForHash(input);
+    const { createHash } = await import("crypto");
+    const expected = createHash("sha256").update(normalized).digest("hex");
+    expect(hashArtifact(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

G2 of the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track. **Test-first** per the [ADR-0004](~/code/docs/adr/ADR-0004-tdd-gates-state-machine.md) design rationale: this is the single biggest risk in the whole track, since wrong normalization causes either false drift (prettier trips the integrity check) or false security (formatting-only edits slip through).

## What ships

**`scripts/tdd/gate-hash.ts`** (66 lines):
- `normalizeForHash(content)`: apply the three ADR-0004 rules. Idempotent.
  1. **Line endings**: CRLF and bare CR fold to LF.
  2. **Trailing whitespace**: stripped per line; LEADING whitespace preserved (markdown indentation is semantic).
  3. **Blank-line collapse**: 3+ consecutive newlines collapse to 2 (single blank line between content). Whitespace-only blank lines collapse via rule 2 then rule 3.
- `hashArtifact(content)`: sha256 over normalized text, returned as 64-char lowercase hex.

**`tests/bdd/tdd-gate-hash.test.ts`** (21 tests, all green first run):
- Rule 1 isolation: CRLF / CR / mixed all hash identically to LF
- Rule 2 isolation: trailing spaces + tabs ignored; leading whitespace and interior whitespace preserved
- Rule 3 isolation: 2+ blank lines collapse to one; whitespace-only blanks collapse; single blank line preserved as a semantic separator
- Integration: simulated prettier reformat does NOT change the hash; semantic edits still differ
- Properties: 64-char lowercase hex output, deterministic, UTF-8 safe, `hashArtifact(x) === sha256(normalizeForHash(x))`

## Verification

- `npm run typecheck` clean
- New tests: 21/21 pass first run
- `npm test`: 677 passed, 0 failed (was 656; +21 new)

## Composition

- Built on G1 ([FEIP-7358](https://databricks.atlassian.net/browse/FEIP-7358)) `gates.ts` types.
- Consumed by G3 ([FEIP-7360](https://databricks.atlassian.net/browse/FEIP-7360)) `approveGate`, which calls `hashArtifact` on each per-gate artifact path captured at the approval moment.
- Consumed by G4 ([FEIP-7361](https://databricks.atlassian.net/browse/FEIP-7361)) `verifyGateIntegrity`, which re-hashes the current artifact and compares to the stored hash.

## Test plan

- [x] Author tests FIRST (per ticket's test-first directive)
- [x] Implement minimal normalization + hash
- [x] Typecheck clean
- [x] All new tests pass
- [x] Full suite green
- [ ] Squash-merge

This pull request and its description were written by Isaac.