### PR TITLE
feat(tdd): verifyGateIntegrity primitive (FEIP-7361)

### DIFF
--- a/scripts/tdd/verify-gate-integrity.ts
+++ b/scripts/tdd/verify-gate-integrity.ts
@@ -1,0 +1,88 @@
+// verifyGateIntegrity primitive: pure read + compare of stored vs current
+// artifact hashes for a single gate. Pairs with approveGate (G3) on the
+// write side.
+//
+// Design: ADR-0004. Tracker: FEIP-7357 (G4 / FEIP-7361).
+//
+// The substrate is file-I/O-free for the artifact side: callers pass the
+// current artifact contents in `currentInputs` (same shape as approveGate's
+// artifactInputs). verifyGateIntegrity:
+//   - reads the gate's stored artifact_hashes from gates.json
+//   - re-hashes each currentInputs value via G2 hashArtifact
+//   - compares stored vs current; reports drifts
+//
+// Does NOT mutate gates.json. The caller decides what to do with a drift
+// verdict (refuse a mutation, prompt the user, log a warning, ...). G8
+// (FEIP-7365) wires verify into the test-list-immutability + cycle-start
+// flows.
+
+import { hashArtifact } from "./gate-hash";
+import { readGates, type GateName, type GateStatus } from "./gates";
+
+export interface VerifyGateIntegrityArgs {
+  featureId: string;
+  gate: GateName;
+  /** Artifact name -> current content. Must match the names stored at approval. */
+  currentInputs: Record<string, string>;
+  tddDir?: string;
+}
+
+export interface ArtifactDrift {
+  artifact: string;
+  expected: string;
+  actual: string;
+}
+
+export type VerifyGateIntegrityResult =
+  | { status: "ok"; gate: GateName }
+  | { status: "gate-not-approved"; gate: GateName; current_status: GateStatus }
+  | { status: "drift"; gate: GateName; drifts: ArtifactDrift[] };
+
+export function verifyGateIntegrity(
+  args: VerifyGateIntegrityArgs
+): VerifyGateIntegrityResult {
+  const tddDir = args.tddDir ?? "./.tdd";
+  const state = readGates(args.featureId, { tddDir });
+  const record = state.gates[args.gate];
+
+  if (record.status !== "approved") {
+    return {
+      status: "gate-not-approved",
+      gate: args.gate,
+      current_status: record.status,
+    };
+  }
+
+  const stored = record.artifact_hashes ?? {};
+  const storedNames = new Set(Object.keys(stored));
+  const currentNames = new Set(Object.keys(args.currentInputs));
+
+  if (
+    storedNames.size !== currentNames.size ||
+    [...storedNames].some((n) => !currentNames.has(n))
+  ) {
+    const missing = [...storedNames].filter((n) => !currentNames.has(n));
+    const extra = [...currentNames].filter((n) => !storedNames.has(n));
+    const parts: string[] = [];
+    if (missing.length > 0) parts.push(`missing: ${missing.join(", ")}`);
+    if (extra.length > 0) parts.push(`unexpected: ${extra.join(", ")}`);
+    throw new Error(
+      `verifyGateIntegrity: artifact name mismatch for ${args.gate} gate (${parts.join("; ")}). ` +
+        `Caller must pass exactly the same artifact names that were captured at approval.`
+    );
+  }
+
+  const drifts: ArtifactDrift[] = [];
+  for (const name of storedNames) {
+    const expected = stored[name];
+    const actual = hashArtifact(args.currentInputs[name]);
+    if (expected !== actual) {
+      drifts.push({ artifact: name, expected, actual });
+    }
+  }
+
+  if (drifts.length === 0) {
+    return { status: "ok", gate: args.gate };
+  }
+  return { status: "drift", gate: args.gate, drifts };
+}

--- a/tests/bdd/tdd-verify-gate-integrity.test.ts
+++ b/tests/bdd/tdd-verify-gate-integrity.test.ts
@@ -1,0 +1,232 @@
+// G4 (FEIP-7361): verifyGateIntegrity primitive.
+//
+// Covers ADR-0004 test plan scenarios S5 (no-drift after prettier run on
+// test-list.json) + S5b (drift detected on semantic AC text change), plus
+// the open/withdrawn/superseded gate-not-approved cases and the artifact
+// name mismatch refusal.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { approveGate } from "../../scripts/tdd/approve-gate";
+import { defaultGatesState, writeGates } from "../../scripts/tdd/gates";
+import { verifyGateIntegrity } from "../../scripts/tdd/verify-gate-integrity";
+
+let tdd: string;
+const FEATURE_ID = "F1-checkout";
+const APPROVER = "kevin.hartman@databricks.com";
+const FIXED_NOW = () => new Date("2026-05-31T20:00:00Z");
+
+function makeFeatureDir(): string {
+  const dir = join(tdd, "features", FEATURE_ID);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function approveSpec(specMd: string, featureJson: string): void {
+  approveGate({
+    featureId: FEATURE_ID,
+    gate: "spec",
+    approver: APPROVER,
+    hitlApproved: true,
+    artifactInputs: { "spec.md": specMd, "feature.json": featureJson },
+    tddDir: tdd,
+    now: FIXED_NOW,
+  });
+}
+
+beforeEach(() => {
+  tdd = mkdtempSync(join(tmpdir(), "tdd-verify-gate-"));
+});
+
+afterEach(() => {
+  rmSync(tdd, { recursive: true, force: true });
+});
+
+describe("verifyGateIntegrity: S5 no-drift after formatter-equivalent reformat", () => {
+  it("returns ok when current content is identical to approval-time content", () => {
+    makeFeatureDir();
+    approveSpec("# spec\n\nbody\n", '{"id":"F1"}');
+    const result = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      currentInputs: { "spec.md": "# spec\n\nbody\n", "feature.json": '{"id":"F1"}' },
+      tddDir: tdd,
+    });
+    expect(result.status).toBe("ok");
+  });
+
+  it("returns ok after a prettier-equivalent reformat (whitespace + line-ending normalization)", () => {
+    makeFeatureDir();
+    approveSpec("# spec\n\nbody\n", '{"id":"F1"}');
+    const result = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      currentInputs: {
+        // Same content as approved, but with CRLF + trailing spaces + extra blank lines
+        "spec.md": "# spec   \r\n\r\n\r\nbody  \r\n",
+        "feature.json": '{"id":"F1"}',
+      },
+      tddDir: tdd,
+    });
+    expect(result.status).toBe("ok");
+  });
+});
+
+describe("verifyGateIntegrity: S5b drift on semantic edits", () => {
+  it("returns drift when a single artifact's content has changed semantically", () => {
+    makeFeatureDir();
+    approveSpec("# spec\n\nbody\n", '{"id":"F1"}');
+    const result = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      currentInputs: { "spec.md": "# spec\n\nDIFFERENT body\n", "feature.json": '{"id":"F1"}' },
+      tddDir: tdd,
+    });
+    expect(result.status).toBe("drift");
+    if (result.status !== "drift") return;
+    expect(result.drifts).toHaveLength(1);
+    expect(result.drifts[0].artifact).toBe("spec.md");
+    expect(result.drifts[0].expected).not.toBe(result.drifts[0].actual);
+  });
+
+  it("returns drift with every changed artifact listed when multiple changed", () => {
+    makeFeatureDir();
+    approveSpec("# spec\n\nbody\n", '{"id":"F1"}');
+    const result = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      currentInputs: { "spec.md": "# SPEC\n\nbody\n", "feature.json": '{"id":"F2"}' },
+      tddDir: tdd,
+    });
+    expect(result.status).toBe("drift");
+    if (result.status !== "drift") return;
+    const names = result.drifts.map((d) => d.artifact).sort();
+    expect(names).toEqual(["feature.json", "spec.md"]);
+  });
+
+  it("returns drift only for the artifact that changed when others are unchanged", () => {
+    makeFeatureDir();
+    approveSpec("# spec\n\nbody\n", '{"id":"F1"}');
+    const result = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      currentInputs: { "spec.md": "# spec\n\nbody\n", "feature.json": '{"id":"DIFFERENT"}' },
+      tddDir: tdd,
+    });
+    expect(result.status).toBe("drift");
+    if (result.status !== "drift") return;
+    expect(result.drifts.map((d) => d.artifact)).toEqual(["feature.json"]);
+  });
+});
+
+describe("verifyGateIntegrity: gate-not-approved verdicts", () => {
+  it("returns gate-not-approved when the gate is open", () => {
+    makeFeatureDir();
+    const result = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "plan",
+      currentInputs: { "plan.json": "{}" },
+      tddDir: tdd,
+    });
+    expect(result.status).toBe("gate-not-approved");
+    if (result.status !== "gate-not-approved") return;
+    expect(result.current_status).toBe("open");
+  });
+
+  it("returns gate-not-approved when the gate is withdrawn", () => {
+    makeFeatureDir();
+    const state = defaultGatesState(FEATURE_ID);
+    state.gates.plan = { status: "withdrawn", history: [] };
+    writeGates(state, { tddDir: tdd });
+    const result = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "plan",
+      currentInputs: { "plan.json": "{}" },
+      tddDir: tdd,
+    });
+    expect(result.status).toBe("gate-not-approved");
+    if (result.status !== "gate-not-approved") return;
+    expect(result.current_status).toBe("withdrawn");
+  });
+
+  it("returns gate-not-approved when the gate is superseded", () => {
+    makeFeatureDir();
+    const state = defaultGatesState(FEATURE_ID);
+    state.gates.spec = { status: "superseded", history: [] };
+    writeGates(state, { tddDir: tdd });
+    const result = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      currentInputs: { "spec.md": "x", "feature.json": "{}" },
+      tddDir: tdd,
+    });
+    expect(result.status).toBe("gate-not-approved");
+  });
+});
+
+describe("verifyGateIntegrity: artifact name mismatch refusal", () => {
+  it("throws when currentInputs is missing an artifact that was captured", () => {
+    makeFeatureDir();
+    approveSpec("# spec\n", '{"id":"F1"}');
+    expect(() =>
+      verifyGateIntegrity({
+        featureId: FEATURE_ID,
+        gate: "spec",
+        currentInputs: { "spec.md": "# spec\n" },
+        tddDir: tdd,
+      })
+    ).toThrow(/missing: feature\.json/);
+  });
+
+  it("throws when currentInputs contains an artifact that was NOT captured", () => {
+    makeFeatureDir();
+    approveSpec("# spec\n", '{"id":"F1"}');
+    expect(() =>
+      verifyGateIntegrity({
+        featureId: FEATURE_ID,
+        gate: "spec",
+        currentInputs: {
+          "spec.md": "# spec\n",
+          "feature.json": '{"id":"F1"}',
+          "extra.txt": "uninvited",
+        },
+        tddDir: tdd,
+      })
+    ).toThrow(/unexpected: extra\.txt/);
+  });
+});
+
+describe("verifyGateIntegrity: pure-read invariant", () => {
+  it("does NOT modify gates.json on an ok verification", () => {
+    const dir = makeFeatureDir();
+    approveSpec("# spec\n", '{"id":"F1"}');
+    const gatesPath = join(dir, "gates.json");
+    const before = readFileSync(gatesPath, "utf8");
+    const mtimeBefore = statSync(gatesPath).mtimeMs;
+    verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      currentInputs: { "spec.md": "# spec\n", "feature.json": '{"id":"F1"}' },
+      tddDir: tdd,
+    });
+    const after = readFileSync(gatesPath, "utf8");
+    expect(after).toBe(before);
+    expect(statSync(gatesPath).mtimeMs).toBe(mtimeBefore);
+  });
+
+  it("does NOT modify gates.json on a drift verdict", () => {
+    const dir = makeFeatureDir();
+    approveSpec("# spec\n", '{"id":"F1"}');
+    const gatesPath = join(dir, "gates.json");
+    const before = readFileSync(gatesPath, "utf8");
+    verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      currentInputs: { "spec.md": "# CHANGED\n", "feature.json": '{"id":"F1"}' },
+      tddDir: tdd,
+    });
+    expect(readFileSync(gatesPath, "utf8")).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

G4 of the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track. Pure read+compare counterpart to `approveGate` (G3); detects drift between approval-time hashes and current artifact content via G2 `hashArtifact`'s normalization.

## What ships

**`scripts/tdd/verify-gate-integrity.ts`** (75 lines):
- `verifyGateIntegrity({ featureId, gate, currentInputs, tddDir? })` returns a discriminated `VerifyGateIntegrityResult`:
  - `{ status: "ok", gate }` when every stored hash matches
  - `{ status: "gate-not-approved", gate, current_status }` when the gate is `open` / `withdrawn` / `superseded`
  - `{ status: "drift", gate, drifts: [{ artifact, expected, actual }] }` when any artifact hash differs
- Refuses on artifact-name mismatch: caller MUST pass exactly the same artifact names that were captured at approval (missing or extra both throw with a clear message)
- **Pure read**: never mutates `gates.json`. G8 orchestrator can call this before each cycle without state-change side effects.

**`tests/bdd/tdd-verify-gate-integrity.test.ts`** (12 tests, all green first run):
- **S5** no-drift: identical content -> `ok`; prettier-equivalent reformat (CRLF, trailing whitespace, extra blank lines) -> `ok` via G2 normalization
- **S5b** drift: single-artifact semantic edit -> `drift`, lists changed artifact + expected/actual hashes; multi-artifact changes all reported; only-changed-artifact reported when others are unchanged
- `gate-not-approved` verdicts: open / withdrawn / superseded all return that status with `current_status` set
- Artifact-name mismatch: missing or unexpected names throw with the diff in the message
- Pure-read invariant: `gates.json` contents + mtime unchanged on both `ok` and `drift` verdicts

## Verification

- `npm run typecheck` clean
- New tests: 12/12 pass first run
- `npm test`: 703 passed, 0 failed (was 691; +12 new)

## Composition

- Built on G1 ([FEIP-7358](https://databricks.atlassian.net/browse/FEIP-7358)) + G2 ([FEIP-7359](https://databricks.atlassian.net/browse/FEIP-7359)) + G3 ([FEIP-7360](https://databricks.atlassian.net/browse/FEIP-7360)).
- Consumed by G5 ([FEIP-7362](https://databricks.atlassian.net/browse/FEIP-7362)) `withdrawGate` (drift can drive auto-withdrawal in a future iteration).
- Consumed by G8 ([FEIP-7365](https://databricks.atlassian.net/browse/FEIP-7365)) orchestrator wiring as the gate-state read side.
- Consumed by FEIP-7213 (test-list immutability) to refuse mutations when the `test_list` gate has drifted.

## Test plan

- [x] Branch off main
- [x] Implement + test
- [x] Typecheck clean
- [x] All new tests pass
- [x] Full suite green
- [ ] Squash-merge

This pull request and its description were written by Isaac.