### PR TITLE
feat(tdd): withdrawGate + cascade-on-withdrawal (FEIP-7362)

### DIFF
--- a/scripts/tdd/withdraw-gate.ts
+++ b/scripts/tdd/withdraw-gate.ts
@@ -1,0 +1,179 @@
+// withdrawGate primitive: retract an approved gate + cascade to downstream
+// gates per ADR-0004's open question #3 (strict cascade).
+//
+// Tracker: FEIP-7357 (G5 / FEIP-7362).
+//
+// Cascade rules (named gates, not numbered):
+//   spec      withdraw -> plan + test_list also withdraw (if currently approved)
+//   plan      withdraw -> test_list also withdraws  (if currently approved)
+//   test_list withdraw -> leaf
+//   promote   withdraw -> leaf (independent gate)
+//
+// Cascaded gates record `withdrawal_reason: "cascade:<source-gate>"` so the
+// audit trail captures WHY a gate was withdrawn even when the user did not
+// explicitly retract it.
+//
+// Idempotent: withdrawing an already-withdrawn, open, or superseded gate is
+// a no-op (returns the unchanged state without throwing). Approveing back
+// is a separate operation (callers re-issue approveGate after the gate
+// returns to "open" via... TBD; for now, withdrawn is terminal until the
+// schema_version bump).
+
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import {
+  readGates,
+  writeGates,
+  type GateHistoryEntry,
+  type GateName,
+  type GateRecord,
+  type GatesState,
+} from "./gates";
+
+/**
+ * For each gate, the downstream gates that are auto-withdrawn when this
+ * gate is explicitly withdrawn. Order in the array preserves the natural
+ * upstream-to-downstream traversal used in history entries + selection log.
+ */
+const CASCADE_TARGETS: Record<GateName, GateName[]> = {
+  spec: ["plan", "test_list"],
+  plan: ["test_list"],
+  test_list: [],
+  promote: [],
+};
+
+export interface WithdrawGateArgs {
+  featureId: string;
+  gate: GateName;
+  approver: string;
+  reason: string;
+  tddDir?: string;
+  /** Test seam: deterministic clock. */
+  now?: () => Date;
+  /** Append a narrative entry to selection-log.md. Default: true. */
+  writeSelectionLog?: boolean;
+}
+
+export interface WithdrawGateResult {
+  state: GatesState;
+  /** Gates that transitioned to "withdrawn" on this call (source + cascades). */
+  withdrawn_gates: GateName[];
+  /** True when nothing changed (source gate was not approved). */
+  noop: boolean;
+}
+
+export function withdrawGate(args: WithdrawGateArgs): WithdrawGateResult {
+  if (args.approver.length === 0) {
+    throw new Error("withdrawGate: approver must not be empty");
+  }
+  if (args.reason.length === 0) {
+    throw new Error("withdrawGate: reason must not be empty");
+  }
+
+  const tddDir = args.tddDir ?? "./.tdd";
+  const now = args.now ?? (() => new Date());
+  const writeLog = args.writeSelectionLog ?? true;
+
+  const state = readGates(args.featureId, { tddDir });
+  const sourceRecord = state.gates[args.gate];
+
+  // Idempotent no-op: source gate is not currently approved.
+  if (sourceRecord.status !== "approved") {
+    return { state, withdrawn_gates: [], noop: true };
+  }
+
+  const ts = now().toISOString();
+  const withdrawn: GateName[] = [args.gate];
+  const nextGates: Record<GateName, GateRecord> = { ...state.gates };
+
+  nextGates[args.gate] = transitionToWithdrawn(
+    sourceRecord,
+    args.approver,
+    ts,
+    args.reason,
+    null
+  );
+
+  for (const target of CASCADE_TARGETS[args.gate]) {
+    const tgtRecord = state.gates[target];
+    if (tgtRecord.status === "approved") {
+      nextGates[target] = transitionToWithdrawn(
+        tgtRecord,
+        args.approver,
+        ts,
+        `cascade:${args.gate}`,
+        args.gate
+      );
+      withdrawn.push(target);
+    }
+  }
+
+  const updatedState: GatesState = { ...state, gates: nextGates };
+  writeGates(updatedState, { tddDir });
+
+  if (writeLog) {
+    appendSelectionLog(tddDir, {
+      ts,
+      featureId: args.featureId,
+      sourceGate: args.gate,
+      approver: args.approver,
+      reason: args.reason,
+      cascadedGates: withdrawn.slice(1),
+    });
+  }
+
+  return { state: updatedState, withdrawn_gates: withdrawn, noop: false };
+}
+
+function transitionToWithdrawn(
+  prior: GateRecord,
+  approver: string,
+  ts: string,
+  reason: string,
+  cascadeFrom: GateName | null
+): GateRecord {
+  const historyEntry: GateHistoryEntry = cascadeFrom
+    ? { action: "cascade-withdrawn", at: ts, approver, reason }
+    : { action: "withdrawn", at: ts, approver, reason };
+  return {
+    status: "withdrawn",
+    withdrawal_reason: reason,
+    history: [...prior.history, historyEntry],
+    // Preserve artifact_hashes + approver + approved_at from the prior
+    // approval; auditors may want to see what was previously approved.
+    approver: prior.approver,
+    approved_at: prior.approved_at,
+    artifact_hashes: prior.artifact_hashes,
+  };
+}
+
+interface SelectionLogEntry {
+  ts: string;
+  featureId: string;
+  sourceGate: GateName;
+  approver: string;
+  reason: string;
+  cascadedGates: GateName[];
+}
+
+function appendSelectionLog(tddDir: string, entry: SelectionLogEntry): void {
+  const logPath = join(tddDir, "selection-log.md");
+  const cascadeLine =
+    entry.cascadedGates.length > 0
+      ? `- **Cascade:** ${entry.cascadedGates.join(", ")}`
+      : `- **Cascade:** none`;
+  const lines = [
+    "",
+    `## ${entry.ts} – Withdraw ${entry.sourceGate} for ${entry.featureId}`,
+    `- **Withdrawn by:** ${entry.approver}`,
+    `- **Reason:** ${entry.reason}`,
+    cascadeLine,
+    "",
+  ];
+  const text = lines.join("\n");
+  if (existsSync(logPath)) {
+    writeFileSync(logPath, readFileSync(logPath, "utf8") + text);
+  } else {
+    writeFileSync(logPath, text);
+  }
+}

--- a/tests/bdd/tdd-withdraw-gate.test.ts
+++ b/tests/bdd/tdd-withdraw-gate.test.ts
@@ -1,0 +1,366 @@
+// G5 (FEIP-7362): withdrawGate + cascade-on-withdrawal.
+//
+// Covers ADR-0004 test plan scenarios S6 (cascade on spec withdraw) +
+// S6b (cascade on plan withdraw), plus the leaf-gate (test_list, promote)
+// + idempotent-no-op + history + selection-log behaviors.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { approveGate } from "../../scripts/tdd/approve-gate";
+import { withdrawGate } from "../../scripts/tdd/withdraw-gate";
+import { defaultGatesState, readGates, writeGates, type GateName } from "../../scripts/tdd/gates";
+
+let tdd: string;
+const FEATURE_ID = "F1-checkout";
+const APPROVER = "kevin.hartman@databricks.com";
+const FIXED_NOW = () => new Date("2026-05-31T20:00:00Z");
+
+function makeFeatureDir(): string {
+  const dir = join(tdd, "features", FEATURE_ID);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function approve(gate: GateName, inputs: Record<string, string>): void {
+  approveGate({
+    featureId: FEATURE_ID,
+    gate,
+    approver: APPROVER,
+    hitlApproved: true,
+    artifactInputs: inputs,
+    tddDir: tdd,
+    now: FIXED_NOW,
+    writeSelectionLog: false,
+  });
+}
+
+beforeEach(() => {
+  tdd = mkdtempSync(join(tmpdir(), "tdd-withdraw-gate-"));
+});
+
+afterEach(() => {
+  rmSync(tdd, { recursive: true, force: true });
+});
+
+describe("withdrawGate: argument validation", () => {
+  it("throws on empty approver", () => {
+    makeFeatureDir();
+    expect(() =>
+      withdrawGate({
+        featureId: FEATURE_ID,
+        gate: "spec",
+        approver: "",
+        reason: "test",
+        tddDir: tdd,
+      })
+    ).toThrow(/approver/);
+  });
+
+  it("throws on empty reason", () => {
+    makeFeatureDir();
+    expect(() =>
+      withdrawGate({
+        featureId: FEATURE_ID,
+        gate: "spec",
+        approver: APPROVER,
+        reason: "",
+        tddDir: tdd,
+      })
+    ).toThrow(/reason/);
+  });
+});
+
+describe("withdrawGate: S6 spec withdraw cascades to plan + test_list", () => {
+  it("withdraws all three when spec, plan, test_list are all approved", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    approve("plan", { "plan.json": "{}" });
+    approve("test_list", { "test-list.json": "{}" });
+
+    const result = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "scope rewrite",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+
+    expect(result.noop).toBe(false);
+    expect(result.withdrawn_gates.sort()).toEqual(["plan", "spec", "test_list"]);
+    expect(result.state.gates.spec.status).toBe("withdrawn");
+    expect(result.state.gates.plan.status).toBe("withdrawn");
+    expect(result.state.gates.test_list.status).toBe("withdrawn");
+  });
+
+  it("does NOT cascade to a gate that was never approved", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    // plan + test_list left open
+
+    const result = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "scope rewrite",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+
+    expect(result.withdrawn_gates).toEqual(["spec"]);
+    expect(result.state.gates.plan.status).toBe("open");
+    expect(result.state.gates.test_list.status).toBe("open");
+  });
+
+  it("cascaded gates record withdrawal_reason = 'cascade:<source>'", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    approve("plan", { "plan.json": "{}" });
+    approve("test_list", { "test-list.json": "{}" });
+
+    const result = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "rescope",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+
+    expect(result.state.gates.spec.withdrawal_reason).toBe("rescope");
+    expect(result.state.gates.plan.withdrawal_reason).toBe("cascade:spec");
+    expect(result.state.gates.test_list.withdrawal_reason).toBe("cascade:spec");
+  });
+
+  it("history records cascade-withdrawn action on cascaded gates", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    approve("plan", { "plan.json": "{}" });
+
+    const result = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "rescope",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+
+    const specHistory = result.state.gates.spec.history;
+    const planHistory = result.state.gates.plan.history;
+    expect(specHistory[specHistory.length - 1].action).toBe("withdrawn");
+    expect(planHistory[planHistory.length - 1].action).toBe("cascade-withdrawn");
+  });
+
+  it("preserves the prior approver + approved_at + artifact_hashes on withdrawn gates", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    const beforeApprover = readGates(FEATURE_ID, { tddDir: tdd }).gates.spec.approver;
+    const beforeHashes = readGates(FEATURE_ID, { tddDir: tdd }).gates.spec.artifact_hashes;
+
+    withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "rescope",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+
+    const after = readGates(FEATURE_ID, { tddDir: tdd }).gates.spec;
+    expect(after.approver).toBe(beforeApprover);
+    expect(after.artifact_hashes).toEqual(beforeHashes);
+  });
+});
+
+describe("withdrawGate: S6b plan withdraw cascades to test_list only", () => {
+  it("withdraws plan + test_list, leaves spec approved", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    approve("plan", { "plan.json": "{}" });
+    approve("test_list", { "test-list.json": "{}" });
+
+    const result = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "plan",
+      approver: APPROVER,
+      reason: "plan rewrite",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+
+    expect(result.withdrawn_gates.sort()).toEqual(["plan", "test_list"]);
+    expect(result.state.gates.spec.status).toBe("approved");
+    expect(result.state.gates.plan.status).toBe("withdrawn");
+    expect(result.state.gates.test_list.status).toBe("withdrawn");
+    expect(result.state.gates.test_list.withdrawal_reason).toBe("cascade:plan");
+  });
+});
+
+describe("withdrawGate: leaf gates do not cascade", () => {
+  it("test_list withdraw does not affect any other gate", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    approve("plan", { "plan.json": "{}" });
+    approve("test_list", { "test-list.json": "{}" });
+
+    const result = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "test_list",
+      approver: APPROVER,
+      reason: "test rewrite",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+
+    expect(result.withdrawn_gates).toEqual(["test_list"]);
+    expect(result.state.gates.spec.status).toBe("approved");
+    expect(result.state.gates.plan.status).toBe("approved");
+  });
+
+  it("promote withdraw is independent of all upstream gates", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    approve("plan", { "plan.json": "{}" });
+    approve("test_list", { "test-list.json": "{}" });
+    approve("promote", { promote_ref: "exp-a:br-a" });
+
+    const result = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "promote",
+      approver: APPROVER,
+      reason: "wrong winner picked",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+
+    expect(result.withdrawn_gates).toEqual(["promote"]);
+    expect(result.state.gates.spec.status).toBe("approved");
+    expect(result.state.gates.plan.status).toBe("approved");
+    expect(result.state.gates.test_list.status).toBe("approved");
+  });
+});
+
+describe("withdrawGate: idempotent no-op semantics", () => {
+  it("returns noop=true when the source gate is open", () => {
+    makeFeatureDir();
+    const result = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "test",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    expect(result.noop).toBe(true);
+    expect(result.withdrawn_gates).toEqual([]);
+  });
+
+  it("returns noop=true when the source gate is already withdrawn", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "first",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    const second = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "second",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    expect(second.noop).toBe(true);
+  });
+
+  it("returns noop=true when the source gate is superseded", () => {
+    makeFeatureDir();
+    const state = defaultGatesState(FEATURE_ID);
+    state.gates.spec = { status: "superseded", history: [] };
+    writeGates(state, { tddDir: tdd });
+    const result = withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "test",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    expect(result.noop).toBe(true);
+  });
+});
+
+describe("withdrawGate: selection-log dual-write", () => {
+  it("appends a narrative entry naming the source gate and cascaded targets", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    approve("plan", { "plan.json": "{}" });
+
+    withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "rescope",
+      tddDir: tdd,
+      now: FIXED_NOW,
+    });
+
+    const logPath = join(tdd, "selection-log.md");
+    expect(existsSync(logPath)).toBe(true);
+    const log = readFileSync(logPath, "utf8");
+    expect(log).toContain(`## 2026-05-31T20:00:00.000Z – Withdraw spec for ${FEATURE_ID}`);
+    expect(log).toContain("**Withdrawn by:**");
+    expect(log).toContain("**Reason:** rescope");
+    expect(log).toContain("**Cascade:** plan");
+  });
+
+  it("uses 'Cascade: none' wording for a leaf-gate withdraw", () => {
+    makeFeatureDir();
+    approve("spec", { "spec.md": "x", "feature.json": "{}" });
+    approve("test_list", { "test-list.json": "{}" });
+
+    withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "test_list",
+      approver: APPROVER,
+      reason: "test rewrite",
+      tddDir: tdd,
+      now: FIXED_NOW,
+    });
+
+    const log = readFileSync(join(tdd, "selection-log.md"), "utf8");
+    expect(log).toContain("**Cascade:** none");
+  });
+
+  it("does NOT write to selection-log on a noop call", () => {
+    makeFeatureDir();
+    withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "test",
+      tddDir: tdd,
+      now: FIXED_NOW,
+    });
+    expect(existsSync(join(tdd, "selection-log.md"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

G5 of the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track. Implements ADR-0004's strict-cascade rule: withdrawing an upstream gate auto-withdraws all downstream gates currently approved.

## What ships

**`scripts/tdd/withdraw-gate.ts`** (141 lines):
- `withdrawGate({ featureId, gate, approver, reason, ... }) -> { state, withdrawn_gates, noop }`
- Cascade map:
  - `spec` -> `plan` + `test_list`
  - `plan` -> `test_list`
  - `test_list` -> leaf
  - `promote` -> leaf (independent of upstream)
- **Idempotent**: returns `noop: true` when source gate is `open` / `withdrawn` / `superseded`; no state mutation, no narrative entry
- Cascaded gates record `withdrawal_reason: "cascade:<source>"` so the audit trail makes the cause obvious
- History action distinguishes `withdrawn` (explicit) from `cascade-withdrawn` (auto) for downstream consumers
- Preserves the prior `approver` / `approved_at` / `artifact_hashes` on withdrawn gates so auditors can still see what WAS approved
- Selection-log entry names the source + cascade list

**`tests/bdd/tdd-withdraw-gate.test.ts`** (16 tests, all green first run):
- Validation: empty approver / empty reason both throw
- **S6** spec withdraw: cascades to plan + test_list when approved; skips never-approved downstream; cascade reasons recorded; history distinguishes withdrawn vs cascade-withdrawn; prior approver/hashes preserved
- **S6b** plan withdraw: cascades to test_list, leaves spec approved
- Leaf gates: test_list withdraw isolated; promote withdraw independent of all upstream
- Idempotent no-op: open / withdrawn / superseded source -> `noop: true`, `withdrawn_gates: []`
- Selection-log dual-write: source + cascade list in entry; "Cascade: none" wording for leaf; no log on noop

## Verification

- `npm run typecheck` clean
- New tests: 16/16 pass first run
- `npm test`: 719 passed, 0 failed (was 703; +16 new)

## Composition

- Built on G1 ([FEIP-7358](https://databricks.atlassian.net/browse/FEIP-7358)) + G3 ([FEIP-7360](https://databricks.atlassian.net/browse/FEIP-7360)).
- Consumed by G6 ([FEIP-7363](https://databricks.atlassian.net/browse/FEIP-7363)) migration backfill (populates history entries so legacy features can cascade correctly).
- Consumed by G8 ([FEIP-7365](https://databricks.atlassian.net/browse/FEIP-7365)) scrum-master orchestrator when artifact drift forces a gate retract.

## Test plan

- [x] Branch off main
- [x] Implement + test
- [x] Typecheck clean
- [x] All new tests pass
- [x] Full suite green
- [ ] Squash-merge

This pull request and its description were written by Isaac.