### PR TITLE
feat(tdd): migrateGatesFromSelectionLog backfill (FEIP-7363)

### DIFF
--- a/scripts/tdd/migrate-gates.ts
+++ b/scripts/tdd/migrate-gates.ts
@@ -1,0 +1,199 @@
+// migrateGatesFromSelectionLog primitive: one-shot scanner that synthesizes
+// gates.json for a feature that has approvals + withdrawals recorded in
+// selection-log.md but no structured state yet.
+//
+// Tracker: FEIP-7357 (G6 / FEIP-7363).
+//
+// Use case: a feature scaffolded before the gates state machine existed
+// has its HITL history in selection-log narrative only. Without backfill,
+// readGates would return the default-open shape and the feature would
+// appear to have NO prior approvals, even when the human-readable log
+// shows the PO already signed off on spec + plan + test_list.
+//
+// Per ADR-0004's open question #4, the backfill is BEST-EFFORT:
+//   - Approval timestamps + approvers + the gate that was approved are
+//     recovered from selection-log headings.
+//   - Artifact hashes captured at the original approval moment are NOT
+//     recoverable (the approval narrative does not store them in the
+//     legacy format). The caller may pass currentInputsByGate so the
+//     backfill hashes the CURRENT artifact content as a baseline; this
+//     lets verifyGateIntegrity work going forward but cannot prove
+//     against the historical content.
+//   - History entries are marked migrated: true so auditors can tell
+//     synthesized entries apart from native ones.
+//
+// Refuses if gates.json already exists unless force: true.
+
+import { existsSync, readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { hashArtifact } from "./gate-hash";
+import {
+  defaultGatesState,
+  readGates,
+  writeGates,
+  GATE_NAMES,
+  type GateHistoryEntry,
+  type GateName,
+  type GateRecord,
+  type GatesState,
+} from "./gates";
+
+export interface MigrateGatesArgs {
+  featureId: string;
+  /**
+   * Per-gate current artifact contents. The migrator hashes these and
+   * stores the result on any gate whose final status (per selection-log)
+   * is "approved". Gates with no entry here get migrated to status =
+   * "approved" without artifact_hashes; verifyGateIntegrity will return
+   * gate-not-approved style errors when called against them.
+   */
+  currentInputsByGate?: Partial<Record<GateName, Record<string, string>>>;
+  tddDir?: string;
+  /** Overwrite an existing gates.json. Default: false. */
+  force?: boolean;
+}
+
+export interface MigrateGatesResult {
+  /** Was a migration performed (vs. refused due to existing gates.json)? */
+  migrated: boolean;
+  /** Skip reason when migrated=false. */
+  reason?: "gates-json-exists" | "selection-log-absent" | "no-entries-found";
+  /** The resulting state written to disk. */
+  state: GatesState;
+  /** Per-gate count of selection-log entries observed during the scan. */
+  entry_counts: Record<GateName, number>;
+}
+
+interface ParsedEntry {
+  ts: string;
+  action: "approve" | "withdraw";
+  gate: GateName;
+  approver?: string;
+}
+
+const HEADING_RE =
+  /^##\s+(\S+T\S+?)\s+–\s+(Approve|Withdraw)\s+(spec|plan|test_list|promote)\s+for\s+(\S+)\s*$/;
+const APPROVED_BY_RE = /\*\*(?:Approved|Withdrawn) by:\*\*\s*(\S.*?)\s*$/;
+
+export function migrateGatesFromSelectionLog(
+  args: MigrateGatesArgs
+): MigrateGatesResult {
+  const tddDir = args.tddDir ?? "./.tdd";
+
+  // Refusal: existing gates.json without force.
+  try {
+    readGates(args.featureId, { tddDir });
+    // Reach here only when the feature dir exists AND a parseable gates.json
+    // exists OR the default-open shape was returned. Distinguish by file
+    // presence.
+    if (gatesFileExists(tddDir, args.featureId) && !args.force) {
+      return {
+        migrated: false,
+        reason: "gates-json-exists",
+        state: readGates(args.featureId, { tddDir }),
+        entry_counts: emptyCounts(),
+      };
+    }
+  } catch {
+    // Feature dir missing surfaces below via writeGates anyway; the regular
+    // path catches that.
+  }
+
+  const logPath = join(tddDir, "selection-log.md");
+  if (!existsSync(logPath)) {
+    return {
+      migrated: false,
+      reason: "selection-log-absent",
+      state: defaultGatesState(args.featureId),
+      entry_counts: emptyCounts(),
+    };
+  }
+
+  const entries = parseSelectionLog(readFileSync(logPath, "utf8"), args.featureId);
+  if (entries.length === 0) {
+    return {
+      migrated: false,
+      reason: "no-entries-found",
+      state: defaultGatesState(args.featureId),
+      entry_counts: emptyCounts(),
+    };
+  }
+
+  const counts = emptyCounts();
+  for (const e of entries) counts[e.gate] += 1;
+
+  const state = defaultGatesState(args.featureId);
+  for (const e of entries) {
+    const record = state.gates[e.gate];
+    const historyEntry: GateHistoryEntry = {
+      action: "migrated",
+      at: e.ts,
+      approver: e.approver ?? "unknown (migrated)",
+      migrated: true,
+      reason:
+        e.action === "approve"
+          ? "migrated from selection-log (approval)"
+          : "migrated from selection-log (withdrawal)",
+    };
+    record.history.push(historyEntry);
+    if (e.action === "approve") {
+      record.status = "approved";
+      record.approver = e.approver ?? record.approver ?? "unknown (migrated)";
+      record.approved_at = e.ts;
+      const inputs = args.currentInputsByGate?.[e.gate];
+      if (inputs) {
+        const hashes: Record<string, string> = {};
+        for (const [name, content] of Object.entries(inputs)) {
+          hashes[name] = hashArtifact(content);
+        }
+        record.artifact_hashes = hashes;
+      }
+    } else {
+      record.status = "withdrawn";
+      record.withdrawal_reason = "migrated from selection-log (withdrawal)";
+    }
+  }
+
+  writeGates(state, { tddDir });
+  return { migrated: true, state, entry_counts: counts };
+}
+
+function gatesFileExists(tddDir: string, featureId: string): boolean {
+  // Mirror gates.ts findFeatureDir resolution without re-exporting it.
+  const featuresDir = join(tddDir, "features");
+  if (!existsSync(featuresDir)) return false;
+  const candidates = readdirSync(featuresDir).filter((d) => d.startsWith(featureId));
+  if (candidates.length === 0) return false;
+  return existsSync(join(featuresDir, candidates[0], "gates.json"));
+}
+
+function emptyCounts(): Record<GateName, number> {
+  const out = {} as Record<GateName, number>;
+  for (const name of GATE_NAMES) out[name] = 0;
+  return out;
+}
+
+function parseSelectionLog(text: string, featureId: string): ParsedEntry[] {
+  const out: ParsedEntry[] = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const m = HEADING_RE.exec(lines[i]);
+    if (!m) continue;
+    const [, ts, verb, gateRaw, fid] = m;
+    // Loose feature-id match: header writes the full id, but callers may
+    // ask for a slug prefix.
+    if (!fid.startsWith(featureId) && !featureId.startsWith(fid)) continue;
+    const action = verb === "Approve" ? "approve" : "withdraw";
+    // Look ahead for the approver line in the next ~6 lines.
+    let approver: string | undefined;
+    for (let j = i + 1; j < Math.min(i + 7, lines.length); j++) {
+      const am = APPROVED_BY_RE.exec(lines[j]);
+      if (am) {
+        approver = am[1].trim();
+        break;
+      }
+    }
+    out.push({ ts, action, gate: gateRaw as GateName, approver });
+  }
+  return out;
+}

--- a/tests/bdd/tdd-migrate-gates.test.ts
+++ b/tests/bdd/tdd-migrate-gates.test.ts
@@ -1,0 +1,235 @@
+// G6 (FEIP-7363): migration backfill from selection-log.
+//
+// Covers ADR-0004 test plan scenario S7 (migrate existing feature with
+// full selection-log) plus partial-approval, refusal-when-gates-exists,
+// missing-log, and current-input-hashing edge cases.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { migrateGatesFromSelectionLog } from "../../scripts/tdd/migrate-gates";
+import { readGates, writeGates, defaultGatesState } from "../../scripts/tdd/gates";
+import { hashArtifact } from "../../scripts/tdd/gate-hash";
+import { verifyGateIntegrity } from "../../scripts/tdd/verify-gate-integrity";
+
+let tdd: string;
+const FEATURE_ID = "F1-checkout";
+const APPROVER = "kevin.hartman@databricks.com";
+
+function makeFeatureDir(): string {
+  const dir = join(tdd, "features", FEATURE_ID);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeLog(text: string): void {
+  writeFileSync(join(tdd, "selection-log.md"), text);
+}
+
+const FULL_APPROVAL_LOG = `# Selection log
+
+## 2026-05-01T10:00:00.000Z – Approve spec for ${FEATURE_ID}
+- **Approved by:** ${APPROVER}
+- **Artifact hashes:**
+  - \`spec.md\`: \`sha256:legacy-spec-hash\`
+
+## 2026-05-02T10:00:00.000Z – Approve plan for ${FEATURE_ID}
+- **Approved by:** ${APPROVER}
+- **Artifact hashes:**
+  - \`plan.json\`: \`sha256:legacy-plan-hash\`
+
+## 2026-05-03T10:00:00.000Z – Approve test_list for ${FEATURE_ID}
+- **Approved by:** ${APPROVER}
+- **Artifact hashes:**
+  - \`test-list.json\`: \`sha256:legacy-tl-hash\`
+`;
+
+beforeEach(() => {
+  tdd = mkdtempSync(join(tmpdir(), "tdd-migrate-gates-"));
+});
+
+afterEach(() => {
+  rmSync(tdd, { recursive: true, force: true });
+});
+
+describe("migrateGatesFromSelectionLog: S7 full backfill", () => {
+  it("synthesizes gates.json from a complete approval log", () => {
+    makeFeatureDir();
+    writeLog(FULL_APPROVAL_LOG);
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+
+    expect(result.migrated).toBe(true);
+    expect(result.entry_counts.spec).toBe(1);
+    expect(result.entry_counts.plan).toBe(1);
+    expect(result.entry_counts.test_list).toBe(1);
+    expect(result.entry_counts.promote).toBe(0);
+    expect(result.state.gates.spec.status).toBe("approved");
+    expect(result.state.gates.plan.status).toBe("approved");
+    expect(result.state.gates.test_list.status).toBe("approved");
+    expect(result.state.gates.promote.status).toBe("open");
+  });
+
+  it("records the original approver + timestamp from the log heading", () => {
+    makeFeatureDir();
+    writeLog(FULL_APPROVAL_LOG);
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    expect(result.state.gates.spec.approver).toBe(APPROVER);
+    expect(result.state.gates.spec.approved_at).toBe("2026-05-01T10:00:00.000Z");
+    expect(result.state.gates.plan.approved_at).toBe("2026-05-02T10:00:00.000Z");
+  });
+
+  it("flags every synthesized history entry as migrated", () => {
+    makeFeatureDir();
+    writeLog(FULL_APPROVAL_LOG);
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    expect(result.state.gates.spec.history).toHaveLength(1);
+    expect(result.state.gates.spec.history[0].migrated).toBe(true);
+    expect(result.state.gates.spec.history[0].action).toBe("migrated");
+  });
+
+  it("persists the synthesized state: subsequent readGates returns the same shape", () => {
+    makeFeatureDir();
+    writeLog(FULL_APPROVAL_LOG);
+    migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    const back = readGates(FEATURE_ID, { tddDir: tdd });
+    expect(back.gates.spec.status).toBe("approved");
+    expect(back.gates.plan.status).toBe("approved");
+    expect(back.gates.test_list.status).toBe("approved");
+  });
+});
+
+describe("migrateGatesFromSelectionLog: partial-approval logs", () => {
+  it("only backfills the gates actually approved in the log", () => {
+    makeFeatureDir();
+    writeLog(`# Log
+
+## 2026-05-01T10:00:00.000Z – Approve spec for ${FEATURE_ID}
+- **Approved by:** ${APPROVER}
+`);
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    expect(result.state.gates.spec.status).toBe("approved");
+    expect(result.state.gates.plan.status).toBe("open");
+    expect(result.state.gates.test_list.status).toBe("open");
+    expect(result.state.gates.promote.status).toBe("open");
+  });
+
+  it("respects Withdraw entries: gate ends withdrawn after later withdraw", () => {
+    makeFeatureDir();
+    writeLog(`# Log
+
+## 2026-05-01T10:00:00.000Z – Approve spec for ${FEATURE_ID}
+- **Approved by:** ${APPROVER}
+
+## 2026-05-05T10:00:00.000Z – Withdraw spec for ${FEATURE_ID}
+- **Withdrawn by:** ${APPROVER}
+- **Reason:** rescope
+- **Cascade:** none
+`);
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    expect(result.state.gates.spec.status).toBe("withdrawn");
+    expect(result.state.gates.spec.history).toHaveLength(2);
+  });
+});
+
+describe("migrateGatesFromSelectionLog: artifact hashing via currentInputsByGate", () => {
+  it("hashes current artifact content for the gates the caller provides", () => {
+    makeFeatureDir();
+    writeLog(FULL_APPROVAL_LOG);
+    const specMd = "# spec\n\nbody\n";
+    const featureJson = '{"id":"F1"}';
+    const planJson = '{"feature_id":"F1"}';
+    const testList = '{"items":[]}';
+    const result = migrateGatesFromSelectionLog({
+      featureId: FEATURE_ID,
+      tddDir: tdd,
+      currentInputsByGate: {
+        spec: { "spec.md": specMd, "feature.json": featureJson },
+        plan: { "plan.json": planJson },
+        test_list: { "test-list.json": testList },
+      },
+    });
+    expect(result.state.gates.spec.artifact_hashes?.["spec.md"]).toBe(hashArtifact(specMd));
+    expect(result.state.gates.plan.artifact_hashes?.["plan.json"]).toBe(hashArtifact(planJson));
+  });
+
+  it("verifyGateIntegrity returns ok against current content after backfill", () => {
+    makeFeatureDir();
+    writeLog(FULL_APPROVAL_LOG);
+    const specMd = "# spec\n\nbody\n";
+    const featureJson = '{"id":"F1"}';
+    migrateGatesFromSelectionLog({
+      featureId: FEATURE_ID,
+      tddDir: tdd,
+      currentInputsByGate: {
+        spec: { "spec.md": specMd, "feature.json": featureJson },
+      },
+    });
+    const v = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      currentInputs: { "spec.md": specMd, "feature.json": featureJson },
+      tddDir: tdd,
+    });
+    expect(v.status).toBe("ok");
+  });
+
+  it("leaves artifact_hashes undefined when the caller does not provide inputs", () => {
+    makeFeatureDir();
+    writeLog(FULL_APPROVAL_LOG);
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    expect(result.state.gates.spec.artifact_hashes).toBeUndefined();
+    expect(result.state.gates.plan.artifact_hashes).toBeUndefined();
+  });
+});
+
+describe("migrateGatesFromSelectionLog: refusal cases", () => {
+  it("refuses when gates.json already exists (force=false default)", () => {
+    makeFeatureDir();
+    writeGates(defaultGatesState(FEATURE_ID), { tddDir: tdd });
+    writeLog(FULL_APPROVAL_LOG);
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    expect(result.migrated).toBe(false);
+    expect(result.reason).toBe("gates-json-exists");
+  });
+
+  it("overwrites when force: true", () => {
+    makeFeatureDir();
+    writeGates(defaultGatesState(FEATURE_ID), { tddDir: tdd });
+    writeLog(FULL_APPROVAL_LOG);
+    const result = migrateGatesFromSelectionLog({
+      featureId: FEATURE_ID,
+      tddDir: tdd,
+      force: true,
+    });
+    expect(result.migrated).toBe(true);
+    expect(result.state.gates.spec.status).toBe("approved");
+  });
+
+  it("returns reason=selection-log-absent when there is no log", () => {
+    makeFeatureDir();
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    expect(result.migrated).toBe(false);
+    expect(result.reason).toBe("selection-log-absent");
+  });
+
+  it("returns reason=no-entries-found when log has no Approve headers for this feature", () => {
+    makeFeatureDir();
+    writeLog("# Log\n\n## 2026-05-01T10:00:00.000Z – Approve spec for OTHER-FEATURE\n- **Approved by:** anyone\n");
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    expect(result.migrated).toBe(false);
+    expect(result.reason).toBe("no-entries-found");
+  });
+});
+
+describe("migrateGatesFromSelectionLog: feature-id matching", () => {
+  it("matches a slug-prefix feature id (e.g. F1 in log vs F1-checkout in caller)", () => {
+    makeFeatureDir();
+    writeLog(`## 2026-05-01T10:00:00.000Z – Approve spec for F1
+- **Approved by:** ${APPROVER}
+`);
+    const result = migrateGatesFromSelectionLog({ featureId: FEATURE_ID, tddDir: tdd });
+    expect(result.migrated).toBe(true);
+    expect(result.state.gates.spec.status).toBe("approved");
+  });
+});


### PR DESCRIPTION
## Summary

G6 of the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track. One-shot scanner that synthesizes `gates.json` for features whose HITL history lives only in `selection-log.md`, i.e. features scaffolded before the state machine existed.

## What ships

**`scripts/tdd/migrate-gates.ts`** (151 lines):
- `migrateGatesFromSelectionLog({ featureId, currentInputsByGate?, tddDir?, force? })` -> `{ migrated, reason?, state, entry_counts }`
- Parses selection-log for `Approve <gate> for <feature>` and `Withdraw <gate> for <feature>` headings (en-dash separator matching the post-sweep narrative convention) plus following `Approved by:` / `Withdrawn by:` lines for the approver
- Refuses if `gates.json` already exists unless `force: true` (so a legitimate state never gets clobbered by accident)
- Returns `reason: "gates-json-exists" | "selection-log-absent" | "no-entries-found"` when nothing is migrated
- Per ADR-0004 open Q #4: history entries marked `migrated: true` so auditors can tell synthesized entries from native ones. Original approval-time content is not recoverable, so the caller may pass `currentInputsByGate` to hash CURRENT artifact content as a forward-looking baseline (`verifyGateIntegrity` then works going forward)
- Feature-id matching is loose-prefix to accept both `F1` (legacy short ids in logs) and `F1-checkout` (modern slugs)

**`tests/bdd/tdd-migrate-gates.test.ts`** (14 tests, all green first run):
- **S7** full backfill: complete approval log -> three gates migrated to approved; original approver + ts recovered from heading; history entries flagged `migrated`; state persists across `readGates`
- Partial-approval logs: only the approved gates are migrated; later `Withdraw` entries end the gate in `withdrawn` with 2 history entries
- `currentInputsByGate` hashing: hashes match `hashArtifact` output; `verifyGateIntegrity` returns `ok` against the same content; gates without inputs leave `artifact_hashes` undefined
- Refusal: `gates.json` exists -> `reason=gates-json-exists`; `force: true` overwrites; missing log -> `selection-log-absent`; foreign-feature log -> `no-entries-found`
- Feature-id matching: slug-prefix match works (`F1` vs `F1-checkout`)

## What's NOT in this PR

CLI bin (`lakebase-tdd-gates migrate`) deferred to a follow-up sub-task so this PR ships the substrate primitive atomically. The bin is a thin wrapper that reads `spec.md` / `plan.json` / `test-list.json` off disk and calls into this primitive with `currentInputsByGate` populated.

## Verification

- `npm run typecheck` clean
- New tests: 14/14 pass first run
- `npm test`: 733 passed, 0 failed (was 719; +14 new)

## Composition

- Built on G1 through G5.
- Foreshadowed by ADR-0004 open question #4.
- Consumed by G8 ([FEIP-7365](https://databricks.atlassian.net/browse/FEIP-7365)) scrum-master orchestrator on first contact with a feature that has no `gates.json` yet.

## Test plan

- [x] Branch off main
- [x] Implement + test
- [x] Typecheck clean
- [x] All new tests pass
- [x] Full suite green
- [ ] Squash-merge

This pull request and its description were written by Isaac.