### PR TITLE
feat(tdd): concurrent-write atomicity via gates lock (FEIP-7364)

### DIFF
--- a/scripts/tdd/approve-gate.ts
+++ b/scripts/tdd/approve-gate.ts
@@ -24,6 +24,7 @@
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { hashArtifact } from "./gate-hash";
+import { withGatesLock } from "./gates-lock";
 import {
   readGates,
   writeGates,
@@ -91,53 +92,61 @@ export function approveGate(args: ApproveGateArgs): ApproveGateResult {
   const now = args.now ?? (() => new Date());
   const writeLog = args.writeSelectionLog ?? true;
 
-  const state = readGates(args.featureId, { tddDir });
-  const record = state.gates[args.gate];
-  if (record.status !== "open") {
-    throw new GateAlreadyClosedError(args.gate, record.status);
-  }
+  // Lock the gates.json read-modify-write critical section so concurrent
+  // approveGate calls cannot lose either approval (G7 / FEIP-7364).
+  return withGatesLock(
+    args.featureId,
+    (): ApproveGateResult => {
+      const state = readGates(args.featureId, { tddDir });
+      const record = state.gates[args.gate];
+      if (record.status !== "open") {
+        throw new GateAlreadyClosedError(args.gate, record.status);
+      }
 
-  const capturedHashes: Record<string, string> = {};
-  for (const name of artifactNames) {
-    capturedHashes[name] = hashArtifact(args.artifactInputs[name]);
-  }
+      const capturedHashes: Record<string, string> = {};
+      for (const name of artifactNames) {
+        capturedHashes[name] = hashArtifact(args.artifactInputs[name]);
+      }
 
-  const ts = now().toISOString();
-  const updatedState: GatesState = {
-    ...state,
-    gates: {
-      ...state.gates,
-      [args.gate]: {
-        status: "approved",
-        approver: args.approver,
-        approved_at: ts,
-        artifact_hashes: capturedHashes,
-        history: [
-          ...record.history,
-          {
-            action: "approved",
-            at: ts,
+      const ts = now().toISOString();
+      const updatedState: GatesState = {
+        ...state,
+        gates: {
+          ...state.gates,
+          [args.gate]: {
+            status: "approved",
             approver: args.approver,
+            approved_at: ts,
             artifact_hashes: capturedHashes,
+            history: [
+              ...record.history,
+              {
+                action: "approved",
+                at: ts,
+                approver: args.approver,
+                artifact_hashes: capturedHashes,
+              },
+            ],
           },
-        ],
-      },
+        },
+      };
+
+      writeGates(updatedState, { tddDir });
+
+      if (writeLog) {
+        appendSelectionLog(tddDir, {
+          ts,
+          gate: args.gate,
+          featureId: args.featureId,
+          approver: args.approver,
+          capturedHashes,
+        });
+      }
+
+      return { state: updatedState, capturedHashes };
     },
-  };
-
-  writeGates(updatedState, { tddDir });
-
-  if (writeLog) {
-    appendSelectionLog(tddDir, {
-      ts,
-      gate: args.gate,
-      featureId: args.featureId,
-      approver: args.approver,
-      capturedHashes,
-    });
-  }
-
-  return { state: updatedState, capturedHashes };
+    { tddDir }
+  );
 }
 
 interface SelectionLogEntry {

--- a/scripts/tdd/gates-lock.ts
+++ b/scripts/tdd/gates-lock.ts
@@ -1,0 +1,162 @@
+// File-lock primitive for concurrent-safe gates.json mutations.
+//
+// Tracker: FEIP-7357 (G7 / FEIP-7364). Implements the lock approach from
+// ADR-0004 open question #2 (file lock via a sibling .gates.lock file).
+//
+// Why we need this:
+//   approveGate / withdrawGate are read-modify-write operations. Without
+//   serialization, two concurrent callers can both read the same state,
+//   both compute their next state independently, and the second write
+//   silently clobbers the first. The lock turns the read-modify-write
+//   into a critical section.
+//
+// Mechanism:
+//   fs.openSync(<lockPath>, "wx") fails with EEXIST when the file already
+//   exists. We use the lockfile's presence itself as the mutex. On EEXIST,
+//   the caller retries with exponential backoff. On a successful acquire,
+//   we hold the file descriptor + delete the file on release.
+//
+//   The wx flag is atomic on POSIX + Windows local filesystems (the kernel
+//   guarantees create-or-EEXIST without a TOCTOU window). Network mounts
+//   (NFS, SMB) may NOT guarantee this. Acceptable trade-off: substrate
+//   workflows run on the developer's local filesystem.
+//
+//   The on-disk lockfile contains the holding PID for forensics: if the
+//   holder crashes without releasing, the next caller sees "lock held by
+//   PID N" in the error message and can manually `rm .gates.lock` to
+//   recover.
+//
+// Retry budget:
+//   Default 5 retries with 20ms / 40ms / 80ms / 160ms / 320ms backoff
+//   (~620ms max wait). Exceeding the budget throws a clear error so the
+//   caller knows the workflow is wedged + can prompt the HITL.
+
+import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { GatesIoOpts } from "./gates";
+
+export interface WithGatesLockOpts extends GatesIoOpts {
+  /** Max retry attempts before giving up. Default 5. */
+  maxRetries?: number;
+  /** Initial backoff in milliseconds. Doubles each retry. Default 20. */
+  initialBackoffMs?: number;
+  /** Test seam: deterministic sleep replacement. */
+  sleep?: (ms: number) => void;
+}
+
+export class GatesLockBusyError extends Error {
+  constructor(
+    public readonly featureId: string,
+    public readonly heldByPid: number | null,
+    public readonly retries: number
+  ) {
+    super(
+      `gates.json lock for ${featureId} is held by PID ${
+        heldByPid ?? "unknown"
+      } after ${retries} retries. ` +
+        `If the holder has crashed, remove the lock file manually.`
+    );
+    this.name = "GatesLockBusyError";
+  }
+}
+
+/**
+ * Acquire the lock for a feature's gates.json, run fn, release the lock.
+ * Returns whatever fn returned. Throws GatesLockBusyError if the lock
+ * stays held past the retry budget.
+ *
+ * Re-entrant from the same process is NOT supported: a single process
+ * holding the lock cannot acquire it again. (Acceptable for the current
+ * usage pattern: approveGate / withdrawGate are leaf operations, not
+ * called from inside one another.)
+ */
+export function withGatesLock<T>(
+  featureId: string,
+  fn: () => T,
+  opts: WithGatesLockOpts = {}
+): T {
+  const tddDir = opts.tddDir ?? "./.tdd";
+  const maxRetries = opts.maxRetries ?? 5;
+  const initialBackoffMs = opts.initialBackoffMs ?? 20;
+  const sleep = opts.sleep ?? defaultSleep;
+
+  const lockPath = gatesLockFilePath(tddDir, featureId);
+  let acquired = false;
+  let attempts = 0;
+
+  while (!acquired && attempts <= maxRetries) {
+    try {
+      const fd = openSync(lockPath, "wx");
+      writeFileSync(fd, String(process.pid));
+      closeSync(fd);
+      acquired = true;
+    } catch (err) {
+      if (!isEexist(err)) throw err;
+      attempts += 1;
+      if (attempts > maxRetries) {
+        const heldByPid = readHeldByPid(lockPath);
+        throw new GatesLockBusyError(featureId, heldByPid, maxRetries);
+      }
+      sleep(initialBackoffMs * 2 ** (attempts - 1));
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // Best-effort cleanup; if the lockfile is already gone (e.g. another
+      // process force-recovered it) we don't want to mask the inner result.
+    }
+  }
+}
+
+function isEexist(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: string }).code === "EEXIST"
+  );
+}
+
+function readHeldByPid(lockPath: string): number | null {
+  try {
+    const text = readFileSync(lockPath, "utf8");
+    const n = Number(text.trim());
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function gatesLockFilePath(tddDir: string, featureId: string): string {
+  const dir = findFeatureDir(tddDir, featureId);
+  // Ensure the feature dir exists for the lockfile placement; gates.ts
+  // also enforces this for the gates.json path. We mirror that behavior
+  // so the lock can be acquired even on a fresh feature.
+  mkdirSync(dir, { recursive: true });
+  return join(dir, ".gates.lock");
+}
+
+function findFeatureDir(tddDir: string, featureId: string): string {
+  const featuresDir = join(tddDir, "features");
+  if (!existsSync(featuresDir)) {
+    throw new Error(`${featuresDir} does not exist`);
+  }
+  const candidates = readdirSync(featuresDir).filter((d) => d.startsWith(featureId));
+  if (candidates.length === 0) {
+    throw new Error(`feature ${featureId} not found under ${featuresDir}`);
+  }
+  return join(featuresDir, candidates[0]);
+}
+
+function defaultSleep(ms: number): void {
+  // Synchronous sleep via Atomics.wait on a fresh Int32Array. Avoids the
+  // performance hit of a spin loop while keeping the API synchronous so
+  // existing callers (approveGate / withdrawGate are sync) don't have to
+  // become async.
+  const buf = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(buf, 0, 0, ms);
+}

--- a/scripts/tdd/withdraw-gate.ts
+++ b/scripts/tdd/withdraw-gate.ts
@@ -21,6 +21,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
+import { withGatesLock } from "./gates-lock";
 import {
   readGates,
   writeGates,
@@ -74,55 +75,63 @@ export function withdrawGate(args: WithdrawGateArgs): WithdrawGateResult {
   const now = args.now ?? (() => new Date());
   const writeLog = args.writeSelectionLog ?? true;
 
-  const state = readGates(args.featureId, { tddDir });
-  const sourceRecord = state.gates[args.gate];
+  // Lock the gates.json read-modify-write critical section so concurrent
+  // withdrawGate + approveGate calls do not race (G7 / FEIP-7364).
+  return withGatesLock(
+    args.featureId,
+    (): WithdrawGateResult => {
+      const state = readGates(args.featureId, { tddDir });
+      const sourceRecord = state.gates[args.gate];
 
-  // Idempotent no-op: source gate is not currently approved.
-  if (sourceRecord.status !== "approved") {
-    return { state, withdrawn_gates: [], noop: true };
-  }
+      // Idempotent no-op: source gate is not currently approved.
+      if (sourceRecord.status !== "approved") {
+        return { state, withdrawn_gates: [], noop: true };
+      }
 
-  const ts = now().toISOString();
-  const withdrawn: GateName[] = [args.gate];
-  const nextGates: Record<GateName, GateRecord> = { ...state.gates };
+      const ts = now().toISOString();
+      const withdrawn: GateName[] = [args.gate];
+      const nextGates: Record<GateName, GateRecord> = { ...state.gates };
 
-  nextGates[args.gate] = transitionToWithdrawn(
-    sourceRecord,
-    args.approver,
-    ts,
-    args.reason,
-    null
-  );
-
-  for (const target of CASCADE_TARGETS[args.gate]) {
-    const tgtRecord = state.gates[target];
-    if (tgtRecord.status === "approved") {
-      nextGates[target] = transitionToWithdrawn(
-        tgtRecord,
+      nextGates[args.gate] = transitionToWithdrawn(
+        sourceRecord,
         args.approver,
         ts,
-        `cascade:${args.gate}`,
-        args.gate
+        args.reason,
+        null
       );
-      withdrawn.push(target);
-    }
-  }
 
-  const updatedState: GatesState = { ...state, gates: nextGates };
-  writeGates(updatedState, { tddDir });
+      for (const target of CASCADE_TARGETS[args.gate]) {
+        const tgtRecord = state.gates[target];
+        if (tgtRecord.status === "approved") {
+          nextGates[target] = transitionToWithdrawn(
+            tgtRecord,
+            args.approver,
+            ts,
+            `cascade:${args.gate}`,
+            args.gate
+          );
+          withdrawn.push(target);
+        }
+      }
 
-  if (writeLog) {
-    appendSelectionLog(tddDir, {
-      ts,
-      featureId: args.featureId,
-      sourceGate: args.gate,
-      approver: args.approver,
-      reason: args.reason,
-      cascadedGates: withdrawn.slice(1),
-    });
-  }
+      const updatedState: GatesState = { ...state, gates: nextGates };
+      writeGates(updatedState, { tddDir });
 
-  return { state: updatedState, withdrawn_gates: withdrawn, noop: false };
+      if (writeLog) {
+        appendSelectionLog(tddDir, {
+          ts,
+          featureId: args.featureId,
+          sourceGate: args.gate,
+          approver: args.approver,
+          reason: args.reason,
+          cascadedGates: withdrawn.slice(1),
+        });
+      }
+
+      return { state: updatedState, withdrawn_gates: withdrawn, noop: false };
+    },
+    { tddDir }
+  );
 }
 
 function transitionToWithdrawn(

--- a/tests/bdd/tdd-gates-lock.test.ts
+++ b/tests/bdd/tdd-gates-lock.test.ts
@@ -1,0 +1,282 @@
+// G7 (FEIP-7364): concurrent-write atomicity via a file lock.
+//
+// Covers ADR-0004 test plan scenario S8 (two-process concurrent approveGate
+// on different gates) via in-process simulation of the wx-flag lock contract.
+// Also asserts the retry-budget exhaustion path + the lockfile-PID forensics.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { GatesLockBusyError, withGatesLock } from "../../scripts/tdd/gates-lock";
+import { approveGate } from "../../scripts/tdd/approve-gate";
+import { withdrawGate } from "../../scripts/tdd/withdraw-gate";
+import { readGates } from "../../scripts/tdd/gates";
+
+let tdd: string;
+const FEATURE_ID = "F1-checkout";
+const APPROVER = "kevin.hartman@databricks.com";
+const FIXED_NOW = () => new Date("2026-05-31T20:00:00Z");
+
+function makeFeatureDir(): string {
+  const dir = join(tdd, "features", FEATURE_ID);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function lockPath(): string {
+  return join(tdd, "features", FEATURE_ID, ".gates.lock");
+}
+
+beforeEach(() => {
+  tdd = mkdtempSync(join(tmpdir(), "tdd-gates-lock-"));
+});
+
+afterEach(() => {
+  rmSync(tdd, { recursive: true, force: true });
+});
+
+describe("withGatesLock: acquire + release semantics", () => {
+  it("creates the .gates.lock file while fn is running, removes it on exit", () => {
+    makeFeatureDir();
+    let observedDuringFn = false;
+    withGatesLock(
+      FEATURE_ID,
+      () => {
+        observedDuringFn = existsSync(lockPath());
+        return null;
+      },
+      { tddDir: tdd }
+    );
+    expect(observedDuringFn).toBe(true);
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  it("returns the fn's return value", () => {
+    makeFeatureDir();
+    const result = withGatesLock(
+      FEATURE_ID,
+      () => 42,
+      { tddDir: tdd }
+    );
+    expect(result).toBe(42);
+  });
+
+  it("writes the holding process's PID into the lockfile", () => {
+    makeFeatureDir();
+    let pidOnDisk: string | null = null;
+    withGatesLock(
+      FEATURE_ID,
+      () => {
+        pidOnDisk = readFileSync(lockPath(), "utf8");
+        return null;
+      },
+      { tddDir: tdd }
+    );
+    expect(pidOnDisk).toBe(String(process.pid));
+  });
+
+  it("releases the lock even when fn throws", () => {
+    makeFeatureDir();
+    expect(() =>
+      withGatesLock(
+        FEATURE_ID,
+        () => {
+          throw new Error("inner failure");
+        },
+        { tddDir: tdd }
+      )
+    ).toThrow(/inner failure/);
+    expect(existsSync(lockPath())).toBe(false);
+  });
+});
+
+describe("withGatesLock: lock-busy retry + exhaustion", () => {
+  it("retries on EEXIST and succeeds when the lock is released mid-wait", () => {
+    makeFeatureDir();
+    // Pre-create the lock to simulate a holder.
+    writeFileSync(lockPath(), "999999");
+    let releasedOnAttempt = 2;
+    let attempts = 0;
+    const sleep = (_ms: number): void => {
+      attempts += 1;
+      if (attempts === releasedOnAttempt) rmSync(lockPath());
+    };
+    const result = withGatesLock(
+      FEATURE_ID,
+      () => "acquired",
+      { tddDir: tdd, sleep, maxRetries: 5, initialBackoffMs: 1 }
+    );
+    expect(result).toBe("acquired");
+    expect(attempts).toBeGreaterThanOrEqual(releasedOnAttempt);
+  });
+
+  it("throws GatesLockBusyError after maxRetries with the holding PID in the message", () => {
+    makeFeatureDir();
+    writeFileSync(lockPath(), "12345");
+    const sleep = (_ms: number): void => {
+      // No-op; lock stays held.
+    };
+    let thrown: unknown = null;
+    try {
+      withGatesLock(FEATURE_ID, () => null, {
+        tddDir: tdd,
+        maxRetries: 2,
+        initialBackoffMs: 1,
+        sleep,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(GatesLockBusyError);
+    expect((thrown as GatesLockBusyError).heldByPid).toBe(12345);
+    expect((thrown as GatesLockBusyError).retries).toBe(2);
+    expect((thrown as Error).message).toMatch(/12345/);
+  });
+
+  it("reports heldByPid as null when the lockfile is empty or unreadable", () => {
+    makeFeatureDir();
+    writeFileSync(lockPath(), "not a number");
+    const sleep = (_ms: number): void => {};
+    let thrown: GatesLockBusyError | null = null;
+    try {
+      withGatesLock(FEATURE_ID, () => null, {
+        tddDir: tdd,
+        maxRetries: 1,
+        initialBackoffMs: 1,
+        sleep,
+      });
+    } catch (err) {
+      thrown = err as GatesLockBusyError;
+    }
+    expect(thrown).not.toBeNull();
+    expect(thrown!.heldByPid).toBeNull();
+  });
+});
+
+describe("withGatesLock: approveGate + withdrawGate retrofit", () => {
+  it("approveGate releases the lock after a successful approval", () => {
+    makeFeatureDir();
+    approveGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      hitlApproved: true,
+      artifactInputs: { "spec.md": "x", "feature.json": "{}" },
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  it("approveGate releases the lock even when re-approval throws", () => {
+    makeFeatureDir();
+    approveGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      hitlApproved: true,
+      artifactInputs: { "spec.md": "x", "feature.json": "{}" },
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    expect(() =>
+      approveGate({
+        featureId: FEATURE_ID,
+        gate: "spec",
+        approver: APPROVER,
+        hitlApproved: true,
+        artifactInputs: { "spec.md": "y", "feature.json": "{}" },
+        tddDir: tdd,
+        now: FIXED_NOW,
+        writeSelectionLog: false,
+      })
+    ).toThrow(/not open/);
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  it("withdrawGate releases the lock after a successful withdrawal", () => {
+    makeFeatureDir();
+    approveGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      hitlApproved: true,
+      artifactInputs: { "spec.md": "x", "feature.json": "{}" },
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    withdrawGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      reason: "rescope",
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    expect(existsSync(lockPath())).toBe(false);
+  });
+});
+
+describe("withGatesLock: S8 concurrent-call mutual exclusion", () => {
+  it("a second caller blocks until the first releases (in-process simulation)", () => {
+    makeFeatureDir();
+    let secondCallerStartedDuringFirst = false;
+    let firstReleased = false;
+    // Pre-acquire by writing the lock manually; simulate a competing
+    // holder that releases on the second sleep tick.
+    writeFileSync(lockPath(), "999999");
+    let sleeps = 0;
+    const sleep = (_ms: number): void => {
+      sleeps += 1;
+      if (sleeps === 2) {
+        rmSync(lockPath());
+        firstReleased = true;
+      }
+    };
+    const result = withGatesLock(
+      FEATURE_ID,
+      () => {
+        secondCallerStartedDuringFirst = !firstReleased;
+        return "second-acquired";
+      },
+      { tddDir: tdd, maxRetries: 5, initialBackoffMs: 1, sleep }
+    );
+    expect(result).toBe("second-acquired");
+    // Inner fn must NOT have started while the lockfile still existed.
+    expect(secondCallerStartedDuringFirst).toBe(false);
+  });
+
+  it("end-to-end: spec + plan can both land when serialized through the lock", () => {
+    makeFeatureDir();
+    // Approve both gates back-to-back through the lock. Each call acquires
+    // + releases independently; we verify state contains both approvals.
+    approveGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: APPROVER,
+      hitlApproved: true,
+      artifactInputs: { "spec.md": "x", "feature.json": "{}" },
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    approveGate({
+      featureId: FEATURE_ID,
+      gate: "plan",
+      approver: APPROVER,
+      hitlApproved: true,
+      artifactInputs: { "plan.json": "{}" },
+      tddDir: tdd,
+      now: FIXED_NOW,
+      writeSelectionLog: false,
+    });
+    const back = readGates(FEATURE_ID, { tddDir: tdd });
+    expect(back.gates.spec.status).toBe("approved");
+    expect(back.gates.plan.status).toBe("approved");
+  });
+});


### PR DESCRIPTION
## Summary

G7 of the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track. Adds the `withGatesLock` primitive (ADR-0004 open question #2 recommendation) and retrofits `approveGate` + `withdrawGate` to serialize their read-modify-write cycles through it. Two callers can no longer silently overwrite each other.

## What ships

**`scripts/tdd/gates-lock.ts`** (134 lines):
- `withGatesLock(featureId, fn, opts)` acquires `.gates.lock` via `fs.openSync(wx)` (atomic create-or-EEXIST), runs `fn`, releases on exit (even on throw)
- Retry budget: default 5 retries with exponential backoff (20/40/80/160/320 ms, ~620ms total). Sleep via `Atomics.wait` so the API can stay synchronous (existing `approveGate` / `withdrawGate` are sync)
- Throws `GatesLockBusyError` after exhaustion with `heldByPid` extracted from the lockfile for forensics
- Lockfile contains the holding PID so a crashed holder leaves an obvious recovery trail
- Re-entrancy from the same process is NOT supported (acceptable: approve/withdraw are leaf operations)

**`scripts/tdd/approve-gate.ts` + `scripts/tdd/withdraw-gate.ts`** (retrofit):
- Wrap the entire read-modify-write (+ selection-log dual-write) in `withGatesLock`. Two concurrent `approveGate` calls on different gates of the same feature can no longer race; the second one reads the state AFTER the first lands and either approves cleanly (different gate) or throws `GateAlreadyClosedError` (same gate)

**`tests/bdd/tdd-gates-lock.test.ts`** (12 tests, all green first run):
- Acquire/release: lockfile present during fn, removed on exit; return value forwarded; PID written to lockfile; released even when fn throws
- Lock-busy retry: pre-held lock released on a later sleep tick -> caller eventually acquires; budget exhaustion throws `GatesLockBusyError` with PID + retries
- `heldByPid` extraction: malformed PID text -> `heldByPid: null`
- approveGate + withdrawGate retrofit: lockfile cleaned up after both success and error paths
- **S8** mutual exclusion: in-process simulation; inner fn does NOT start while the lockfile exists; sequential approveGate calls (spec + plan) both land successfully

## Verification

- `npm run typecheck` clean
- New tests: 12/12 pass first run
- `npm test`: 745 passed, 0 failed (was 733; +12 new). Retrofitted approveGate (14 tests) + withdrawGate (16 tests) still pass unchanged.

## Multi-process testing note

The wx-flag lock is real across PIDs (kernel-atomic on local POSIX + Windows filesystems). These unit tests use in-process simulation via the `opts.sleep` test seam to avoid the complexity of spawning child processes. Real multi-process coverage will be exercised by G9 ([FEIP-7366](https://databricks.atlassian.net/browse/FEIP-7366)) end-to-end SCM test where parallel agents genuinely race the gate machine.

## Composition

- Built on G1 + G3 + G5.
- Closes the **G1-G7 primitive layer**. G8 ([FEIP-7365](https://databricks.atlassian.net/browse/FEIP-7365)) orchestrator wiring is next: replace selection-log regex scans with `readGates` + wire `verifyGateIntegrity` into the test-list immutability check.

## Test plan

- [x] Branch off main
- [x] Implement + test
- [x] Typecheck clean
- [x] All new tests pass
- [x] Full suite green (no regression in retrofitted ops)
- [ ] Squash-merge

This pull request and its description were written by Isaac.