### PR TITLE
feat(tdd): orchestrator wiring for gates.json reads (FEIP-7365)

### DIFF
--- a/scripts/tdd/feature-status.ts
+++ b/scripts/tdd/feature-status.ts
@@ -8,6 +8,7 @@ import {
   type ExperimentOutcomes,
 } from "./experiment";
 import { readSmellsLog, type SmellsLog } from "./smells";
+import { GATE_NAMES, readGates, type GateName, type GateStatus } from "./gates";
 
 export type TestListStatus = TestListItem["status"];
 
@@ -40,6 +41,14 @@ export interface WorkflowPointer {
   experiment_id: string | null;
 }
 
+export interface GateSummary {
+  status: GateStatus;
+  approver: string | null;
+  approved_at: string | null;
+}
+
+export type GatesSummary = Record<GateName, GateSummary>;
+
 export interface FeatureStatusSnapshot {
   feature_id: string;
   current_workflow_phase: string | null;
@@ -49,6 +58,13 @@ export interface FeatureStatusSnapshot {
   experiments: ExperimentStatusEntry[];
   selection_log_recent: SelectionLogEntry[];
   open_smells: SmellsLog["detected"];
+  /**
+   * Structured gate state surfaced from .tdd/features/<F>/gates.json
+   * (ADR-0004). null when the feature directory itself does not exist;
+   * default-open shape returned when the directory exists but no
+   * gates.json file has been written yet.
+   */
+  gates: GatesSummary | null;
 }
 
 const MAX_RECENT_LOG_ENTRIES = 5;
@@ -106,6 +122,27 @@ function readSelectionLogRecent(
     entries.push({ timestamp: match[1], title: match[2].trim() });
   }
   return entries.slice(-limit);
+}
+
+function readGatesSummary(tddDir: string, featureId: string): GatesSummary | null {
+  // readGates throws when the feature directory does not exist (a clean
+  // signal that no spec has been authored yet). Surface as null so the
+  // snapshot stays renderable for not-yet-started features.
+  try {
+    const state = readGates(featureId, { tddDir });
+    const out = {} as GatesSummary;
+    for (const name of GATE_NAMES) {
+      const rec = state.gates[name];
+      out[name] = {
+        status: rec.status,
+        approver: rec.approver ?? null,
+        approved_at: rec.approved_at ?? null,
+      };
+    }
+    return out;
+  } catch {
+    return null;
+  }
 }
 
 function readWorkflowState(tddDir: string): {
@@ -171,6 +208,7 @@ export function getFeatureStatus(
     experiments,
     selection_log_recent: readSelectionLogRecent(tddDir, MAX_RECENT_LOG_ENTRIES),
     open_smells: smells,
+    gates: readGatesSummary(tddDir, featureId),
   };
 }
 
@@ -235,11 +273,22 @@ export function renderFeatureStatus(snapshot: FeatureStatusSnapshot): string {
     lines.push(`Experiments: none cut yet`);
   }
 
+  if (snapshot.gates) {
+    lines.push(``);
+    lines.push(`Gates:`);
+    for (const name of GATE_NAMES) {
+      const g = snapshot.gates[name];
+      const when = g.approved_at ? ` @ ${g.approved_at}` : "";
+      const by = g.approver ? ` by ${g.approver}` : "";
+      lines.push(`  ${name.padEnd(10)} ${g.status}${when}${by}`);
+    }
+  }
+
   if (snapshot.selection_log_recent.length > 0) {
     lines.push(``);
     lines.push(`Recent decisions (${snapshot.selection_log_recent.length}):`);
     for (const entry of snapshot.selection_log_recent) {
-      lines.push(`  ${entry.timestamp} — ${entry.title}`);
+      lines.push(`  ${entry.timestamp} – ${entry.title}`);
     }
   }
 
@@ -247,7 +296,7 @@ export function renderFeatureStatus(snapshot: FeatureStatusSnapshot): string {
   if (snapshot.open_smells.length > 0) {
     lines.push(`Open smells (${snapshot.open_smells.length}):`);
     for (const hit of snapshot.open_smells) {
-      lines.push(`  ${hit.smell} — ${hit.detail}`);
+      lines.push(`  ${hit.smell} – ${hit.detail}`);
     }
   } else {
     lines.push(`Open smells: none`);

--- a/skills/lakebase-tdd-workflows/agents/scrum-master.md
+++ b/skills/lakebase-tdd-workflows/agents/scrum-master.md
@@ -7,7 +7,8 @@ You facilitate. You do not decide. You run phase transitions, spawn experiments 
 - `.tdd/workflow-state.json` – current phase + locus.
 - `.tdd/features/<F>/...` – approved spec + test list.
 - `.tdd/features/<F>/plan.json` – design-spec gate output (Gate 4 signed off).
-- `scripts/tdd/*.ts` primitives – experiment / cycle / smells / compare / promote / synthesis / budget.
+- `.tdd/features/<F>/gates.json` – structured HITL gate state (ADR-0004). Read via `readGates()`; never regex-scan `selection-log.md` for "has the PO approved gate X?". The structured state is the source of truth; the narrative log is for humans.
+- `scripts/tdd/*.ts` primitives – experiment / cycle / smells / compare / promote / synthesis / budget / gates.
 
 ## Outputs
 
@@ -15,7 +16,7 @@ You facilitate. You do not decide. You run phase transitions, spawn experiments 
 - Spawned experiment branches per the plan, respecting budget.
 - Cycle artifacts (delegated to Navigator + Driver pair).
 - `smells.json` entries written when detectors fire.
-- Appended `selection-log.md` entries at every HITL gate decision.
+- Updates to `gates.json` via `approveGate()` / `withdrawGate()` at every HITL gate transition (the primitive writes `selection-log.md` narrative as a dual-write, so you never need to touch the log directly).
 - Synthesized spec subtree or promoted feature, per HITL choice.
 
 ## Method
@@ -24,25 +25,25 @@ You facilitate. You do not decide. You run phase transitions, spawn experiments 
 
 1. Read `workflow-state.json`. If phase != "discovery", do not regress.
 2. Confirm draft spec artifacts exist for the active feature: `feature.{md,json}` + one or more stories with their ACs.
-3. Surface to PO: Gate 1 confirmation.
-4. On approval: transition phase → "architectural-review". Hand off to Architect Reviewer (`agents/architect-reviewer.md`).
+3. Surface to PO: spec gate confirmation.
+4. On approval: call `approveGate({ featureId, gate: "spec", approver, hitlApproved: true, artifactInputs: { "spec.md": <content>, "feature.json": <content> } })`. Transition phase → "architectural-review". Hand off to Architect Reviewer (`agents/architect-reviewer.md`).
 
 ### Phase 1 → 2 – Architectural review → Test-list construction
 
 5. Wait for Architect Reviewer to populate `layer`, `architectural_notes`, `nfrs[]` and produce `architecture.md`.
-6. Surface to PO: Gate 2 confirmation.
-7. On approval: transition phase → "test-list-construction". Hand off to Test Strategist (`agents/test-strategist.md`).
+6. Surface to PO: architecture gate confirmation (architectural lens applied; spec layer + notes complete).
+7. On approval: transition phase → "test-list-construction". The architecture review does not have its own gate in `gates.json`; it lives between the `spec` and `plan` gates. Hand off to Test Strategist (`agents/test-strategist.md`).
 
 ### Phase 2 → 3 – Test-list construction → Design-spec gate
 
 8. Wait for Test Strategist to produce ordered `test-list.{md,json}` + per-AC views.
-9. Surface to PO: Gate 3 confirmation.
-10. On approval: transition phase → "design-spec-gate". Run `scripts/tdd/design-spec-gate.ts analyzeForGate()`.
+9. Surface to PO: test_list gate confirmation.
+10. On approval: call `approveGate({ featureId, gate: "test_list", approver, hitlApproved: true, artifactInputs: { "test-list.json": <content> } })`. Transition phase → "design-spec-gate". Run `scripts/tdd/design-spec-gate.ts analyzeForGate()`.
 
 ### Phase 3 → 4 – Design-spec gate → Implementation
 
 11. Show PO the proposed plan (N=1 vs N≥2, strategies, budget).
-12. On Gate 4 approval: `writePlan()` + `recordPlan(approverEmail)`. Transition phase → "implementation".
+12. On plan gate approval: call `approveGate({ featureId, gate: "plan", approver, hitlApproved: true, artifactInputs: { "plan.json": <content> } })`, then `writePlan()` + `recordPlan(approverEmail)`. Transition phase → "implementation".
 13. Spawn experiments per plan, respecting `canCutAnotherExperiment()` from `scripts/tdd/budget.ts`.
 
 ### Phase 4 – Implementation loop
@@ -63,11 +64,19 @@ N=1:
 N≥2:
 21. When experiments converge, run `compareExperiments()`. Show the report to PO.
 22. PO chooses:
-    - **promote** → call `promoteExperiment({hitlApproved: true, approverEmail})`.
-    - **synthesize** → call `synthesizeExperiments({hitlApproved: true, picks, ...})`; spec is renegotiated; transition phase back to "test-list-construction" with the new tree.
+    - **promote** → call `promoteExperiment({hitlApproved: true, approverEmail})`, then `approveGate({ featureId, gate: "promote", approver, hitlApproved: true, artifactInputs: { promote_ref: "<winner-slug>:<branch_id>" } })`.
+    - **synthesize** → call `synthesizeExperiments({hitlApproved: true, picks, ...})`; spec is renegotiated; transition phase back to "test-list-construction" with the new tree. Call `withdrawGate({ featureId, gate: "spec", approver, reason: "synthesis renegotiation" })` to cascade-withdraw plan + test_list so the next iteration re-runs the gate flow on the new tree.
     - **continue** → resume cycles.
     - **abandon-all** → archive everything; re-run design-spec gate.
-23. Append the decision to `selection-log.md` with approverEmail.
+23. `approveGate` / `withdrawGate` write the `selection-log.md` narrative for you. Do not append to the log directly.
+
+### Drift detection (any phase)
+
+24. Before resuming cycles after any pause, call `verifyGateIntegrity()` on each approved gate to confirm no artifact has been edited outside the substrate. A `drift` verdict means: surface to PO + propose `withdrawGate` for the affected gate (which will cascade to downstream gates). Do not silently re-approve.
+
+### Brownfield adoption (no gates.json yet)
+
+25. If `readGates()` returns the default-open shape for a feature that has historical approvals in `selection-log.md`, call `migrateGatesFromSelectionLog({ featureId, currentInputsByGate })` to backfill. Pass current artifact contents per gate so the synthesized state has hashes that future `verifyGateIntegrity()` calls can match against. History entries from migration are flagged `migrated: true` for auditors.
 
 ## Adapter status-sync
 

--- a/skills/lakebase-tdd-workflows/references/feature-status-schema.md
+++ b/skills/lakebase-tdd-workflows/references/feature-status-schema.md
@@ -16,6 +16,7 @@ interface FeatureStatusSnapshot {
   experiments: ExperimentStatusEntry[];
   selection_log_recent: SelectionLogEntry[];
   open_smells: SmellHit[];
+  gates: GatesSummary | null;
 }
 ```
 
@@ -29,6 +30,7 @@ interface FeatureStatusSnapshot {
 | `experiments` | array | One entry per directory under `.tdd/experiments/<F>/`. Empty when no experiments have been cut. |
 | `selection_log_recent` | array | Up to the last 5 entries from `.tdd/selection-log.md`, oldest-first. |
 | `open_smells` | array | Unresolved entries from `.tdd/smells.json` (entries with no `resolution` field). Global to the `.tdd/` tree; not filtered per feature in this version. |
+| `gates` | object \| null | Compact view of `.tdd/features/<F>/gates.json` (ADR-0004 structured HITL state). `null` when the feature directory does not exist. Default-open shape (all four gates `status: "open"`) returned when the directory exists but no `gates.json` file has been written yet. Use `scripts/tdd/gates.readGates()` for the full state including history + artifact_hashes. |
 
 ## Nested types
 
@@ -102,6 +104,23 @@ interface SelectionLogEntry {
 }
 ```
 
+### GatesSummary
+
+```ts
+type GateName = "spec" | "plan" | "test_list" | "promote";
+type GateStatus = "open" | "approved" | "superseded" | "withdrawn";
+
+interface GateSummary {
+  status: GateStatus;
+  approver: string | null;     // last approver; null when never approved
+  approved_at: string | null;  // ISO 8601 of last approval; null when never approved
+}
+
+type GatesSummary = Record<GateName, GateSummary>;
+```
+
+The summary is a compact projection of `gates.json`. For full history, withdrawal reasons, or artifact_hashes, call `readGates()` from `scripts/tdd/gates.ts` directly.
+
 ### SmellHit
 
 See `scripts/tdd/smells.ts`. Each open smell entry also carries `detected_at: string` from the on-disk log.
@@ -156,7 +175,13 @@ interface SmellHit {
   "selection_log_recent": [
     { "timestamp": "2026-05-27T10:00:00Z", "title": "Experiment plan for F1-checkout" }
   ],
-  "open_smells": []
+  "open_smells": [],
+  "gates": {
+    "spec": { "status": "approved", "approver": "po@example.com", "approved_at": "2026-05-31T20:00:00.000Z" },
+    "plan": { "status": "approved", "approver": "po@example.com", "approved_at": "2026-05-31T21:00:00.000Z" },
+    "test_list": { "status": "open", "approver": null, "approved_at": null },
+    "promote": { "status": "open", "approver": null, "approved_at": null }
+  }
 }
 ```
 

--- a/tests/bdd/tdd-feature-status.test.ts
+++ b/tests/bdd/tdd-feature-status.test.ts
@@ -163,7 +163,11 @@ const TOP_LEVEL_KEYS = [
   "experiments",
   "selection_log_recent",
   "open_smells",
+  "gates",
 ] as const;
+
+const GATE_NAMES = ["spec", "plan", "test_list", "promote"] as const;
+const GATE_SUMMARY_KEYS = ["status", "approver", "approved_at"] as const;
 
 const POINTER_KEYS = [
   "feature_id",
@@ -358,5 +362,82 @@ describe("feature-status N≥2 race snapshot", () => {
     for (const exp of s.experiments) {
       expect(Object.keys(exp).sort()).toEqual([...EXPERIMENT_KEYS].sort());
     }
+  });
+});
+
+describe("feature-status gates field (G8 / FEIP-7365)", () => {
+  it("returns null gates when the feature directory does not exist", () => {
+    // Fresh tdd dir with no feature subtree at all.
+    const s = getFeatureStatus(tdd, "F-NEVER-AUTHORED");
+    expect(s.gates).toBeNull();
+  });
+
+  it("returns the default-open shape when the feature dir exists but gates.json does not", () => {
+    stageN1Fixture();
+    const s = getFeatureStatus(tdd, FEATURE_ID);
+    expect(s.gates).not.toBeNull();
+    for (const name of GATE_NAMES) {
+      expect(s.gates![name].status).toBe("open");
+      expect(s.gates![name].approver).toBeNull();
+      expect(s.gates![name].approved_at).toBeNull();
+    }
+  });
+
+  it("surfaces approved gate state when approveGate has been called", async () => {
+    stageN1Fixture();
+    const { approveGate } = await import("../../scripts/tdd/approve-gate");
+    approveGate({
+      featureId: FEATURE_ID,
+      gate: "spec",
+      approver: "po@example.com",
+      hitlApproved: true,
+      artifactInputs: { "spec.md": "x", "feature.json": "{}" },
+      tddDir: tdd,
+      now: () => new Date("2026-05-31T20:00:00Z"),
+      writeSelectionLog: false,
+    });
+    const s = getFeatureStatus(tdd, FEATURE_ID);
+    expect(s.gates!.spec.status).toBe("approved");
+    expect(s.gates!.spec.approver).toBe("po@example.com");
+    expect(s.gates!.spec.approved_at).toBe("2026-05-31T20:00:00.000Z");
+    expect(s.gates!.plan.status).toBe("open");
+  });
+
+  it("each gate summary entry has exactly the documented keys", () => {
+    stageN1Fixture();
+    const s = getFeatureStatus(tdd, FEATURE_ID);
+    expect(s.gates).not.toBeNull();
+    for (const name of GATE_NAMES) {
+      expect(Object.keys(s.gates![name]).sort()).toEqual(
+        [...GATE_SUMMARY_KEYS].sort()
+      );
+    }
+  });
+
+  it("renders a Gates section listing all four gates", () => {
+    stageN1Fixture();
+    const text = renderFeatureStatus(getFeatureStatus(tdd, FEATURE_ID));
+    expect(text).toMatch(/Gates:/);
+    expect(text).toMatch(/spec\s+open/);
+    expect(text).toMatch(/plan\s+open/);
+    expect(text).toMatch(/test_list\s+open/);
+    expect(text).toMatch(/promote\s+open/);
+  });
+
+  it("renders approver + approved_at when a gate is approved", async () => {
+    stageN1Fixture();
+    const { approveGate } = await import("../../scripts/tdd/approve-gate");
+    approveGate({
+      featureId: FEATURE_ID,
+      gate: "plan",
+      approver: "po@example.com",
+      hitlApproved: true,
+      artifactInputs: { "plan.json": "{}" },
+      tddDir: tdd,
+      now: () => new Date("2026-05-31T21:00:00Z"),
+      writeSelectionLog: false,
+    });
+    const text = renderFeatureStatus(getFeatureStatus(tdd, FEATURE_ID));
+    expect(text).toMatch(/plan\s+approved @ 2026-05-31T21:00:00\.000Z by po@example\.com/);
   });
 });

--- a/tests/mcp-server/tools-feature-status.test.ts
+++ b/tests/mcp-server/tools-feature-status.test.ts
@@ -115,6 +115,7 @@ describe("MCP tool: lakebase_feature_status", () => {
         "current_workflow_pointer",
         "experiments",
         "feature_id",
+        "gates",
         "open_smells",
         "plan",
         "selection_log_recent",


### PR DESCRIPTION
## Summary

G8 of the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track. Surfaces the structured gate state through `feature-status` + redirects the scrum-master agent prompt away from selection-log regex-scanning toward the gates substrate. Closes the orchestrator-wiring layer.

## What ships

### Substrate

**`scripts/tdd/feature-status.ts`**:
- New `GatesSummary` + `GateSummary` types: compact per-gate projection of `gates.json` (status, last approver, last approved_at). Full state via `readGates()` directly.
- `FeatureStatusSnapshot` gains `gates: GatesSummary | null`. `null` when the feature dir does not exist; default-open shape when the dir exists but `gates.json` has not been written.
- `renderFeatureStatus` prints a `Gates:` section listing all four gates with status (and approver + timestamp when approved).
- Carryover em-dash fix in the renderer (selection_log_recent + open_smells lines), matching the post-sweep en-dash convention.

### Agent prompt

**`skills/lakebase-tdd-workflows/agents/scrum-master.md`**:
- Inputs section calls out `gates.json` as the structured source of truth; agent must read via `readGates()` rather than regex-scanning the selection log
- Outputs section reframes "Appended selection-log entries" as "Updates to gates.json via `approveGate` / `withdrawGate`" (the primitive handles the dual-write)
- Each phase transition step now names the specific `approveGate` call with the per-gate `artifactInputs` scope from ADR-0004
- New step 24 (drift detection): `verifyGateIntegrity` before resuming cycles; drift -> surface to PO + propose `withdrawGate`
- New step 25 (brownfield adoption): `migrateGatesFromSelectionLog` pattern for features that pre-date the state machine

### Schema doc

**`skills/lakebase-tdd-workflows/references/feature-status-schema.md`**: documented `GatesSummary` type + new top-level `gates` field; example payload extended with a gates block.

### Tests

**`tests/bdd/tdd-feature-status.test.ts`** (6 new tests):
- `gates` is `null` for never-authored feature
- `gates` returns default-open shape when feature dir exists but `gates.json` does not
- `gates` surfaces approved status + approver + ts after `approveGate`
- Each gate summary entry has exactly the documented keys
- `renderFeatureStatus` emits a `Gates:` section
- Approved gate renders approver + approved_at on its line
- TOP_LEVEL_KEYS schema-stability assertion updated to include `gates`

**`tests/mcp-server/tools-feature-status.test.ts`**: MCP handler shape assertion updated to include `gates`.

## Verification

- `npm run typecheck` clean
- `npm test`: 751 passed, 0 failed (was 745; +6 new gates-field tests)
- handshake.test.ts still green (MCP tool registry unchanged)
- All G1-G7 unit tests + retrofit tests still pass

## Out of scope (filed as follow-up)

- [FEIP-7213](https://databricks.atlassian.net/browse/FEIP-7213) (test-list immutability) wiring: that ticket is "NOT STARTED"; `verifyGateIntegrity` is ready to be consumed by its `mutateTestList` primitive when FEIP-7213 lands. G8 prepares the substrate side; the consumer side ships with FEIP-7213 itself.

## Composition

- Built on G1-G7 (all 7 primitives now consumed).
- Next: G9 ([FEIP-7366](https://databricks.atlassian.net/browse/FEIP-7366)) live e2e SCM test + G10 ([FEIP-7367](https://databricks.atlassian.net/browse/FEIP-7367)) product/cross-cutting acceptance + G11 ([FEIP-7368](https://databricks.atlassian.net/browse/FEIP-7368)) docs.

## Test plan

- [x] Branch off main
- [x] Implement + test
- [x] Typecheck clean
- [x] All new tests pass
- [x] Full suite green
- [ ] Squash-merge

This pull request and its description were written by Isaac.