### PR TITLE
chore(release): v0.3.0-alpha.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.31",
+  "version": "0.3.0-alpha.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.31",
+      "version": "0.3.0-alpha.32",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.31",
+  "version": "0.3.0-alpha.32",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## Summary

Cuts `v0.3.0-alpha.32`, consolidating the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track (8 PRs since alpha.31).

## What landed

| Sub-task | PR | What it shipped |
|---|---|---|
| FEIP-7358 G1 | #74 | `gates.ts` types + `readGates` / `writeGates` substrate |
| FEIP-7359 G2 | #75 | `gate-hash.ts` normalization helper |
| FEIP-7360 G3 | #76 | `approveGate` primitive |
| FEIP-7361 G4 | #77 | `verifyGateIntegrity` primitive |
| FEIP-7362 G5 | #78 | `withdrawGate` + cascade-on-withdrawal |
| FEIP-7363 G6 | #79 | `migrateGatesFromSelectionLog` backfill |
| FEIP-7364 G7 | #80 | concurrent-write atomicity via gates lock |
| FEIP-7365 G8 | #81 | orchestrator wiring (`feature-status` + scrum-master prompt) |

## New consumer surface

- New module surface: `scripts/tdd/gates.ts`, `gate-hash.ts`, `approve-gate.ts`, `verify-gate-integrity.ts`, `withdraw-gate.ts`, `migrate-gates.ts`, `gates-lock.ts`
- `feature-status` snapshot gains a `gates` field; schema doc updated
- Scrum-Master agent prompt updated to call the gates substrate instead of regex-scanning `selection-log.md` (the substrate dual-writes the narrative for human readers)

No substrate function signatures changed for existing primitives. Downstream extension pin update is a `chore(deps)` catch-up.

## Verification

- 100 new tests across the gates track
- `npm test` green: 751 passed, 0 failed
- `npm run typecheck` clean
- `npm run build` clean
- ADR-0004 design document remains the canonical reference

## What's NOT in this release

The remaining FEIP-7357 sub-tasks (filed for follow-up):
- G9 ([FEIP-7366](https://databricks.atlassian.net/browse/FEIP-7366)) live e2e SCM test
- G10 ([FEIP-7367](https://databricks.atlassian.net/browse/FEIP-7367)) product + cross-cutting acceptance tests
- G11 ([FEIP-7368](https://databricks.atlassian.net/browse/FEIP-7368)) docs (SKILL.md + ADR amendments)

These ship in a later alpha once the test infrastructure + docs land against the now-stable primitive + orchestrator surface.

## Test plan

- [x] Branch off main
- [x] Bump `package.json` to `0.3.0-alpha.32` + regenerate `package-lock.json`
- [x] Full test suite green
- [ ] Squash-merge this PR
- [ ] Tag `v0.3.0-alpha.32` on main + push tag
- [ ] Open follow-up `chore(deps)` PR in `lakebase-scm-extension` pinning to the new tag

This pull request and its description were written by Isaac.