### PR TITLE
chore(husky): pre-commit guard against commits on protected branches

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# Refuse commits on protected branches. Belt-and-braces with GitHub branch
+# protection (server-side); this hook catches the bad commit BEFORE it
+# even lands locally so there is nothing to revert + cherry-pick.
+#
+# Protected branches (case-sensitive):
+#   main / master / production
+#
+# Escape hatch: HUSKY=0 git commit   (skips this hook entirely)
+# Use only when you genuinely intend to commit on a protected branch
+# (e.g. an emergency hotfix where branch protection has been disabled
+# by an admin for a known recovery window).
+
+set -e
+
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+case "$BRANCH" in
+  main|master|production)
+    echo ""
+    echo "✗ husky/pre-commit: refusing commit on protected branch '$BRANCH'."
+    echo ""
+    echo "  Create a feature branch first:"
+    echo "    git checkout -b kevin.hartman/<topic>"
+    echo "    git commit ..."
+    echo ""
+    echo "  Override (use sparingly): HUSKY=0 git commit ..."
+    echo ""
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
## Summary

Adds a husky `pre-commit` hook that refuses commits on `main` / `master` / `production` with a clear message pointing to the branch-first workflow.

## Why

Belt-and-braces enforcement of the existing branch-before-commit rule. Even a memory record + written rule isn't enough to prevent "forgot to branch" accidents under context fatigue (the rule was violated twice in one long session). A pre-commit hook makes the bad path mechanically impossible without an explicit override, which is the right shape: easy when intended, hard by accident.

Pairs with (future) GitHub branch protection rules. The hook catches the bad commit BEFORE it lands locally, so there's nothing to revert + cherry-pick.

## Behavior

- Exits 1 with a helpful message when `HEAD` points to `main` / `master` / `production`
- Exits 0 on any other branch
- `HUSKY=0 git commit ...` escape hatch documented inline for genuine emergency overrides (broken hook, deliberate hotfix during a maintenance window, etc.)

## Verification

- Manually tested both paths against this repo's working tree:
  - On a feature branch -> `exit=0`
  - With branch mocked to `main` -> the helpful refusal message + `exit=1`
- 33 lines of POSIX shell; no Node deps

## Test plan

- [x] Add `.husky/pre-commit` + `chmod +x`
- [x] Verify pass path
- [x] Verify refusal path
- [ ] Squash-merge
- [ ] (Companion PR) Same hook on `lakebase-scm-extension`

This pull request and its description were written by Isaac.