### PR TITLE
docs(tdd): gates state machine section in SKILL.md (FEIP-7368)

### DIFF
--- a/skills/lakebase-tdd-workflows/SKILL.md
+++ b/skills/lakebase-tdd-workflows/SKILL.md
@@ -257,6 +257,96 @@ writePerAcViews(".tdd", "F1", list);
 // Emits .tdd/features/<F>/stories/<S>/test-list-per-ac.json under each story dir.
 ```
 
+### Gates state machine (structured HITL approvals)
+
+Design: [ADR-0004](../../../docs/adr/ADR-0004-tdd-gates-state-machine.md). Implementation: FEIP-7357.
+
+`.tdd/features/<F>/gates.json` is the substrate's authoritative gate state. `selection-log.md` stays as the human-readable narrative-of-record; the substrate dual-writes it at every state change. **Agents read `gates.json`; humans read the log.** Never regex-scan the log for state.
+
+Named gates: `spec` / `plan` / `test_list` / `promote`. Statuses: `open` / `approved` / `superseded` / `withdrawn`. Each gate's record carries the approver, timestamp, captured artifact hashes (sha256 of normalized content), and a `history[]` log of every action.
+
+```ts
+import {
+  readGates,
+  writeGates,
+  defaultGatesState,
+} from "@databricks-solutions/lakebase-app-dev-kit/tdd/gates";
+import { approveGate } from "@databricks-solutions/lakebase-app-dev-kit/tdd/approve-gate";
+import { verifyGateIntegrity } from "@databricks-solutions/lakebase-app-dev-kit/tdd/verify-gate-integrity";
+import { withdrawGate } from "@databricks-solutions/lakebase-app-dev-kit/tdd/withdraw-gate";
+
+// Read current state (returns default-open shape when gates.json absent).
+const state = readGates("F1", { tddDir: ".tdd" });
+
+// Approve a gate (HITL-gated at the function boundary).
+approveGate({
+  featureId: "F1",
+  gate: "spec",
+  approver: "po@example.com",
+  hitlApproved: true,
+  artifactInputs: { "spec.md": specContent, "feature.json": featureJsonContent },
+  tddDir: ".tdd",
+});
+
+// Verify integrity: did the artifact change since approval?
+const v = verifyGateIntegrity({
+  featureId: "F1",
+  gate: "spec",
+  currentInputs: { "spec.md": currentSpec, "feature.json": currentFeatureJson },
+  tddDir: ".tdd",
+});
+// v.status: "ok" | "drift" | "gate-not-approved"
+// Hash normalization survives CRLF/LF + trailing-whitespace + blank-line edits;
+// semantic edits flip the verdict to "drift".
+
+// Withdraw with cascade: spec withdraw -> plan + test_list also withdrawn.
+withdrawGate({
+  featureId: "F1",
+  gate: "spec",
+  approver: "po@example.com",
+  reason: "scope rewrite",
+  tddDir: ".tdd",
+});
+```
+
+**Per-gate artifact scope (convention enforced at the orchestrator call site, not in the substrate):**
+
+| Gate | artifactInputs keys |
+|---|---|
+| `spec` | `spec.md`, `feature.json` |
+| `plan` | `plan.json` |
+| `test_list` | `test-list.json` |
+| `promote` | `promote_ref` (synthesized string: `<winner-slug>:<branch_id>`) |
+
+**Concurrent-safe:** `approveGate` and `withdrawGate` serialize through a `.gates.lock` file (`fs.openSync` with `wx` flag). Two callers cannot lose either approval. Override: `HUSKY=0` not applicable here; the lock is mandatory.
+
+#### Brownfield adoption
+
+For features that pre-date the gates state machine (approvals only in `selection-log.md`):
+
+```ts
+import { migrateGatesFromSelectionLog } from "@databricks-solutions/lakebase-app-dev-kit/tdd/migrate-gates";
+
+migrateGatesFromSelectionLog({
+  featureId: "F1",
+  tddDir: ".tdd",
+  // Optional: pass current artifact content so the synthesized state has
+  // hashes that future verifyGateIntegrity() calls can match against.
+  currentInputsByGate: {
+    spec: { "spec.md": readFileSync("...spec.md", "utf8"), "feature.json": readFileSync("...feature.json", "utf8") },
+    plan: { "plan.json": readFileSync("...plan.json", "utf8") },
+    test_list: { "test-list.json": readFileSync("...test-list.json", "utf8") },
+  },
+});
+// History entries flagged migrated: true so auditors can tell synthesized
+// entries apart from native ones. Refuses if gates.json already exists
+// unless force: true.
+```
+
+#### Feature-status integration
+
+`feature-status` surfaces the compact gates view via the `gates` field of `FeatureStatusSnapshot`. See [`references/feature-status-schema.md`](references/feature-status-schema.md). For full state including history + artifact_hashes, call `readGates()` directly.
+
 ## Flow patterns
 
 End-to-end orchestrator patterns the Scrum-Master agent runs in response to `/design` and `/build`. Each flow is what the agent assembles from the primitives above; the human-facing prompts that trigger each flow live in [`README.md`](README.md).


### PR DESCRIPTION
## Summary

G11 of the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track. Final sub-task. Adds the substrate-surface reference for the gates state machine alongside the other operational primitives in `lakebase-tdd-workflows/SKILL.md`.

**Closes the FEIP-7357 track (G1 through G11 all shipped).**

## What ships

**`skills/lakebase-tdd-workflows/SKILL.md`** new "Gates state machine (structured HITL approvals)" section between "Test list transformation" and "Flow patterns":

- The dual-write contract: agents read `gates.json`, humans read `selection-log.md`; agents NEVER regex-scan the log for state
- Named gates (`spec`/`plan`/`test_list`/`promote`) + statuses (`open`/`approved`/`superseded`/`withdrawn`)
- Code examples for `readGates` / `approveGate` / `verifyGateIntegrity` / `withdrawGate` matching the shipped substrate signatures
- Per-gate artifact-scope **convention** (spec hashes `spec.md` + `feature.json`, plan hashes `plan.json`, test_list hashes `test-list.json`, promote hashes a synthesized `promote_ref` string)
- Concurrent-safe semantics (lock-based serialization via `withGatesLock`)
- Brownfield adoption pattern (`migrateGatesFromSelectionLog` with `currentInputsByGate` for forward-looking hashes)
- Cross-reference to `feature-status`'s `gates` field for downstream consumers

## ADR-0004 amendments (separate doc tree)

The ADR lives in `~/code/docs/adr/` (a local doc store, not this repo). Amendments captured there:

- **Trailing-only whitespace stripping**: Rule 2 ships as trailing-only, not "leading + trailing" as originally written. Leading whitespace is semantic in markdown.
- **Caller-owned artifact I/O**: `approveGate` / `verifyGateIntegrity` / `migrateGatesFromSelectionLog` take artifact contents in args; substrate stays file-I/O-free for the artifact side.
- **Lock chosen over optimistic retry** (open Q #2): `fs.openSync(wx)` lockfile + `Atomics.wait` for sync sleep.
- **History action `cascade-withdrawn`** distinguishes auto-cascade from explicit user withdrawal.
- **No separate architectural-review gate**: that phase lives between `spec` and `plan` gates but shares `spec`'s hash baseline.
- **Brownfield backfill is best-effort**: original approval-time content not recoverable; caller passes current artifacts.
- **Sanitized git branch names** from `createPairedBranch`: consumers must use `.gitBranch` field, not raw feature-id.

## Verification

- `npm run typecheck` clean (docs-only change)
- `npm test`: 758 passed, 0 failed (no regression)

## Composition

- Built on G1-G10. Closes the FEIP-7357 implementation track entirely.
- Originating backlog idea: [FEIP-7217](https://databricks.atlassian.net/browse/FEIP-7217) can now transition to Done.

## Test plan

- [x] Branch off main
- [x] Add gates section to SKILL.md
- [x] Amend ADR-0004 with implementation notes (local doc tree)
- [x] Typecheck + full suite clean
- [ ] Squash-merge

This pull request and its description were written by Isaac.