### PR TITLE
chore(release): v0.3.0-alpha.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.32",
+  "version": "0.3.0-alpha.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.32",
+      "version": "0.3.0-alpha.33",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.32",
+  "version": "0.3.0-alpha.33",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## Summary

Cuts `v0.3.0-alpha.33`, closing the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine track + shipping hygiene tooling. No substrate signature changes since alpha.32; this is an **additive** release covering tests + docs + commit-time tooling.

## What landed since alpha.32

| Sub-task | PR | What it shipped |
|---|---|---|
| FEIP-7366 G9 | #84 | Live e2e SCM workflow (9 stages, verified 9/9 green against `fevm-serverless-stable-ecparr`) |
| FEIP-7367 G10 | #85 | Cross-cutting acceptance tests (smells, coverage, gate integrity vs test-list mutation) |
| FEIP-7368 G11 | #86 | Gates state machine section in SKILL.md + ADR-0004 implementation-notes amendments |
| (hygiene) | #83 | Husky pre-commit hook refusing commits on `main` / `master` / `production` |

## Track closure

[FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) + [FEIP-7217](https://databricks.atlassian.net/browse/FEIP-7217) (originating backlog idea) transitioned to Done. All 11 sub-tasks (G1-G11) shipped.

## Compatibility

No substrate function signatures changed. Downstream extension pin update is a `chore(deps)` catch-up; extension's own version stays unchanged.

## Verification

- `npm run typecheck` clean
- `npm test`: 758 passed, 0 failed (113 new tests across the gates track)
- `gates-state-machine-e2e-live.test.ts`: 9/9 green against real Lakebase + GitHub (G9 commissioning)
- Other 7 live tests not re-run in this cycle since changes since alpha.30 are all additive; existing CLI/MCP surface unchanged

## Test plan

- [x] Branch off main
- [x] Bump `package.json` to `0.3.0-alpha.33` + regenerate `package-lock.json`
- [ ] Squash-merge this PR
- [ ] Tag `v0.3.0-alpha.33` on main + push tag
- [ ] Open follow-up `chore(deps)` PR in `lakebase-scm-extension` pinning to the new tag

This pull request and its description were written by Isaac.