### PR TITLE
feat(tdd): mutateTestList primitive for test-list immutability (FEIP-7213)

### DIFF
--- a/scripts/tdd/mutate-test-list.ts
+++ b/scripts/tdd/mutate-test-list.ts
@@ -1,0 +1,173 @@
+// mutateTestList primitive: substrate-enforced test-list immutability.
+//
+// Tracker: FEIP-7213. Composes the FEIP-7357 gates state machine
+// (approveGate / verifyGateIntegrity / readGates / writeGates) with the
+// existing test-list IO so that once a test_list gate is approved the
+// test list cannot be silently rewritten.
+//
+// Background:
+//   writeMasterTestList (scripts/tdd/test-list.ts) is the original write
+//   surface. It is fine for INITIAL authoring (the Test Strategist agent
+//   writes the first version before the test_list gate is approved). It
+//   is NOT fine for post-approval edits: nothing stops a stray callsite
+//   from overwriting an approved test list and silently erasing the
+//   gate's integrity baseline.
+//
+// Design:
+//   mutateTestList is the post-approval write surface. It refuses to
+//   overwrite an approved test_list without an explicit hitlReapproved
+//   flag. With that flag set, it atomically supersedes the existing
+//   approval, writes the new content, and re-approves the gate with
+//   the new artifact hash. The whole supersede+write+approve cycle
+//   happens inside the gates lock so concurrent callers cannot race.
+//
+//   Open/withdrawn/superseded gates: write goes through cleanly (the
+//   gate isn't currently protecting anything).
+//
+// Open-question reconciliation with ADR-0004:
+//   The originating ticket name mentioned a "Gate 3 re-approval token";
+//   ADR-0004 open Q #1 settled on integrity-check rather than tokens.
+//   This implementation follows the ADR: no token round-trip, just a
+//   direct flag + atomic state transition.
+
+import { hashArtifact } from "./gate-hash";
+import { withGatesLock } from "./gates-lock";
+import {
+  readGates,
+  writeGates,
+  type GateRecord,
+  type GatesState,
+} from "./gates";
+import { writeMasterTestList, type TestList } from "./test-list";
+
+export class TestListImmutabilityError extends Error {
+  constructor(
+    public readonly featureId: string,
+    public readonly gateStatus: string
+  ) {
+    super(
+      `test-list for ${featureId} is immutable: the test_list gate is ${gateStatus} ` +
+        `and the caller did not pass hitlReapproved: true. ` +
+        `Use mutateTestList({ hitlReapproved: true, approver, ... }) to supersede + re-approve atomically.`
+    );
+    this.name = "TestListImmutabilityError";
+  }
+}
+
+export interface MutateTestListArgs {
+  featureId: string;
+  newTestList: TestList;
+  approver: string;
+  /**
+   * Set to true to supersede + re-approve the test_list gate as part of
+   * the same atomic operation. Required when the gate is currently
+   * "approved"; ignored when the gate is open / withdrawn / superseded
+   * (the write is unprotected in those states).
+   */
+  hitlReapproved: boolean;
+  tddDir?: string;
+  /** Test seam: deterministic clock. */
+  now?: () => Date;
+}
+
+export interface MutateTestListResult {
+  /** Resulting gates.json state (updated when the gate was approved+reapproved). */
+  state: GatesState;
+  /** Captured hash of the new test-list.json content. */
+  capturedHash: string;
+  /** True iff this call supersede+re-approved the test_list gate (vs. unprotected write). */
+  reapproved: boolean;
+}
+
+export function mutateTestList(args: MutateTestListArgs): MutateTestListResult {
+  if (args.approver.length === 0) {
+    throw new Error("mutateTestList: approver must not be empty");
+  }
+  if (args.featureId !== args.newTestList.feature_id) {
+    throw new Error(
+      `mutateTestList: featureId mismatch (args.featureId='${args.featureId}' but newTestList.feature_id='${args.newTestList.feature_id}')`
+    );
+  }
+
+  const tddDir = args.tddDir ?? "./.tdd";
+  const now = args.now ?? (() => new Date());
+
+  return withGatesLock(
+    args.featureId,
+    (): MutateTestListResult => {
+      const currentState = readGates(args.featureId, { tddDir });
+      const gateRecord = currentState.gates.test_list;
+      const newContent = JSON.stringify(args.newTestList, null, 2) + "\n";
+      const newHash = hashArtifact(newContent);
+
+      if (gateRecord.status === "approved") {
+        if (!args.hitlReapproved) {
+          throw new TestListImmutabilityError(args.featureId, gateRecord.status);
+        }
+        // Supersede + write + re-approve atomically. Build the new
+        // gates state directly (rather than calling withdrawGate +
+        // approveGate which would each take the lock; we're inside it
+        // already + want a single state transition for the audit).
+        const ts = now().toISOString();
+        const supersededRecord: GateRecord = {
+          status: "superseded",
+          approver: gateRecord.approver,
+          approved_at: gateRecord.approved_at,
+          artifact_hashes: gateRecord.artifact_hashes,
+          history: [
+            ...gateRecord.history,
+            {
+              action: "superseded",
+              at: ts,
+              approver: args.approver,
+              reason: "test-list mutation via mutateTestList",
+            },
+          ],
+        };
+        const newApprovedRecord: GateRecord = {
+          status: "approved",
+          approver: args.approver,
+          approved_at: ts,
+          artifact_hashes: { "test-list.json": newHash },
+          history: [
+            ...supersededRecord.history,
+            {
+              action: "approved",
+              at: ts,
+              approver: args.approver,
+              artifact_hashes: { "test-list.json": newHash },
+            },
+          ],
+        };
+        const updated: GatesState = {
+          ...currentState,
+          gates: { ...currentState.gates, test_list: newApprovedRecord },
+        };
+        writeMasterTestList(tddDir, args.newTestList);
+        writeGates(updated, { tddDir });
+        return { state: updated, capturedHash: newHash, reapproved: true };
+      }
+
+      // Unprotected states: open / withdrawn / superseded. Write goes
+      // through; gates state is unchanged.
+      writeMasterTestList(tddDir, args.newTestList);
+      return { state: currentState, capturedHash: newHash, reapproved: false };
+    },
+    { tddDir }
+  );
+}
+
+/**
+ * Convenience: predicate that callers can use to decide whether they
+ * need to pass hitlReapproved without running into the throw.
+ */
+export function isTestListProtected(featureId: string, opts: { tddDir?: string } = {}): boolean {
+  const tddDir = opts.tddDir ?? "./.tdd";
+  try {
+    const state = readGates(featureId, { tddDir });
+    return state.gates.test_list.status === "approved";
+  } catch {
+    return false;
+  }
+}
+

--- a/tests/bdd/tdd-mutate-test-list.test.ts
+++ b/tests/bdd/tdd-mutate-test-list.test.ts
@@ -1,0 +1,301 @@
+// FEIP-7213: substrate-enforced test-list immutability via mutateTestList.
+//
+// Exercises the four states the test_list gate can be in (open / approved
+// / withdrawn / superseded) + the refusal contract + the atomic
+// supersede + re-approve flow.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { approveGate } from "../../scripts/tdd/approve-gate";
+import { hashArtifact } from "../../scripts/tdd/gate-hash";
+import { defaultGatesState, readGates, writeGates } from "../../scripts/tdd/gates";
+import {
+  isTestListProtected,
+  mutateTestList,
+  TestListImmutabilityError,
+} from "../../scripts/tdd/mutate-test-list";
+import {
+  readMasterTestList,
+  writeMasterTestList,
+  type TestList,
+} from "../../scripts/tdd/test-list";
+import { verifyGateIntegrity } from "../../scripts/tdd/verify-gate-integrity";
+
+let tdd: string;
+const FEATURE_ID = "F1-checkout";
+const APPROVER = "po@example.com";
+const ORIGINAL_APPROVER = "first.po@example.com";
+const FIXED_NOW = () => new Date("2026-05-31T20:00:00Z");
+const RE_APPROVE_NOW = () => new Date("2026-06-01T10:00:00Z");
+
+const BASE_LIST: TestList = {
+  feature_id: FEATURE_ID,
+  ordered_for: "design-momentum",
+  items: [
+    { id: "T1", description: "POST /orders returns 201 on valid cart", ac_id: "AC1", status: "pending" },
+    { id: "T2", description: "POST /orders rejects empty cart with 400", ac_id: "AC1", status: "pending" },
+  ],
+};
+
+function makeFeatureDir(): string {
+  const dir = join(tdd, "features", FEATURE_ID);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function approveTestListGate(list: TestList): void {
+  const content = JSON.stringify(list, null, 2) + "\n";
+  approveGate({
+    featureId: FEATURE_ID,
+    gate: "test_list",
+    approver: ORIGINAL_APPROVER,
+    hitlApproved: true,
+    artifactInputs: { "test-list.json": content },
+    tddDir: tdd,
+    now: FIXED_NOW,
+    writeSelectionLog: false,
+  });
+}
+
+beforeEach(() => {
+  tdd = mkdtempSync(join(tmpdir(), "tdd-mutate-tl-"));
+});
+
+afterEach(() => {
+  rmSync(tdd, { recursive: true, force: true });
+});
+
+describe("mutateTestList: argument validation", () => {
+  it("rejects empty approver", () => {
+    makeFeatureDir();
+    expect(() =>
+      mutateTestList({
+        featureId: FEATURE_ID,
+        newTestList: BASE_LIST,
+        approver: "",
+        hitlReapproved: false,
+        tddDir: tdd,
+      })
+    ).toThrow(/approver/);
+  });
+
+  it("rejects featureId mismatch", () => {
+    makeFeatureDir();
+    expect(() =>
+      mutateTestList({
+        featureId: FEATURE_ID,
+        newTestList: { ...BASE_LIST, feature_id: "F-OTHER" },
+        approver: APPROVER,
+        hitlReapproved: false,
+        tddDir: tdd,
+      })
+    ).toThrow(/featureId mismatch/);
+  });
+});
+
+describe("mutateTestList: unprotected states (write goes through)", () => {
+  it("open gate: writes without re-approval, returns reapproved=false", () => {
+    makeFeatureDir();
+    const result = mutateTestList({
+      featureId: FEATURE_ID,
+      newTestList: BASE_LIST,
+      approver: APPROVER,
+      hitlReapproved: false,
+      tddDir: tdd,
+    });
+    expect(result.reapproved).toBe(false);
+    const back = readMasterTestList(tdd, FEATURE_ID);
+    expect(back.items).toHaveLength(2);
+  });
+
+  it("withdrawn gate: writes without re-approval", () => {
+    makeFeatureDir();
+    const state = defaultGatesState(FEATURE_ID);
+    state.gates.test_list = { status: "withdrawn", history: [] };
+    writeGates(state, { tddDir: tdd });
+    const result = mutateTestList({
+      featureId: FEATURE_ID,
+      newTestList: BASE_LIST,
+      approver: APPROVER,
+      hitlReapproved: false,
+      tddDir: tdd,
+    });
+    expect(result.reapproved).toBe(false);
+  });
+
+  it("superseded gate: writes without re-approval", () => {
+    makeFeatureDir();
+    const state = defaultGatesState(FEATURE_ID);
+    state.gates.test_list = { status: "superseded", history: [] };
+    writeGates(state, { tddDir: tdd });
+    const result = mutateTestList({
+      featureId: FEATURE_ID,
+      newTestList: BASE_LIST,
+      approver: APPROVER,
+      hitlReapproved: false,
+      tddDir: tdd,
+    });
+    expect(result.reapproved).toBe(false);
+  });
+});
+
+describe("mutateTestList: approved gate refusal + re-approval", () => {
+  it("throws TestListImmutabilityError when gate is approved + hitlReapproved=false", () => {
+    makeFeatureDir();
+    writeMasterTestList(tdd, BASE_LIST);
+    approveTestListGate(BASE_LIST);
+
+    const mutated: TestList = { ...BASE_LIST, items: BASE_LIST.items.slice(0, 1) };
+    expect(() =>
+      mutateTestList({
+        featureId: FEATURE_ID,
+        newTestList: mutated,
+        approver: APPROVER,
+        hitlReapproved: false,
+        tddDir: tdd,
+      })
+    ).toThrow(TestListImmutabilityError);
+  });
+
+  it("does NOT mutate on-disk test-list.json on refusal", () => {
+    makeFeatureDir();
+    writeMasterTestList(tdd, BASE_LIST);
+    approveTestListGate(BASE_LIST);
+    const before = readFileSync(join(tdd, "features", FEATURE_ID, "test-list.json"), "utf8");
+
+    try {
+      mutateTestList({
+        featureId: FEATURE_ID,
+        newTestList: { ...BASE_LIST, items: [] },
+        approver: APPROVER,
+        hitlReapproved: false,
+        tddDir: tdd,
+      });
+    } catch {
+      // expected
+    }
+
+    const after = readFileSync(join(tdd, "features", FEATURE_ID, "test-list.json"), "utf8");
+    expect(after).toBe(before);
+  });
+
+  it("supersedes + re-approves atomically when hitlReapproved=true", () => {
+    makeFeatureDir();
+    writeMasterTestList(tdd, BASE_LIST);
+    approveTestListGate(BASE_LIST);
+
+    const mutated: TestList = {
+      ...BASE_LIST,
+      items: [
+        ...BASE_LIST.items,
+        { id: "T3", description: "POST /orders handles concurrent submits", ac_id: "AC1", status: "pending" },
+      ],
+    };
+
+    const result = mutateTestList({
+      featureId: FEATURE_ID,
+      newTestList: mutated,
+      approver: APPROVER,
+      hitlReapproved: true,
+      tddDir: tdd,
+      now: RE_APPROVE_NOW,
+    });
+
+    expect(result.reapproved).toBe(true);
+    const expectedHash = hashArtifact(JSON.stringify(mutated, null, 2) + "\n");
+    expect(result.capturedHash).toBe(expectedHash);
+
+    const back = readGates(FEATURE_ID, { tddDir: tdd });
+    expect(back.gates.test_list.status).toBe("approved");
+    expect(back.gates.test_list.approver).toBe(APPROVER);
+    expect(back.gates.test_list.approved_at).toBe("2026-06-01T10:00:00.000Z");
+    expect(back.gates.test_list.artifact_hashes?.["test-list.json"]).toBe(expectedHash);
+  });
+
+  it("history accumulates: prior approval + superseded + new approval (3 entries)", () => {
+    makeFeatureDir();
+    writeMasterTestList(tdd, BASE_LIST);
+    approveTestListGate(BASE_LIST);
+
+    mutateTestList({
+      featureId: FEATURE_ID,
+      newTestList: { ...BASE_LIST, items: BASE_LIST.items.slice(0, 1) },
+      approver: APPROVER,
+      hitlReapproved: true,
+      tddDir: tdd,
+      now: RE_APPROVE_NOW,
+    });
+
+    const back = readGates(FEATURE_ID, { tddDir: tdd });
+    const history = back.gates.test_list.history;
+    expect(history).toHaveLength(3);
+    expect(history[0].action).toBe("approved");
+    expect(history[0].approver).toBe(ORIGINAL_APPROVER);
+    expect(history[1].action).toBe("superseded");
+    expect(history[1].approver).toBe(APPROVER);
+    expect(history[1].reason).toMatch(/mutation/);
+    expect(history[2].action).toBe("approved");
+    expect(history[2].approver).toBe(APPROVER);
+  });
+
+  it("verifyGateIntegrity reports ok after re-approval (the new content matches the new hash)", () => {
+    makeFeatureDir();
+    writeMasterTestList(tdd, BASE_LIST);
+    approveTestListGate(BASE_LIST);
+
+    const mutated: TestList = {
+      ...BASE_LIST,
+      items: [...BASE_LIST.items, { id: "T3", description: "added", ac_id: "AC1", status: "pending" }],
+    };
+    mutateTestList({
+      featureId: FEATURE_ID,
+      newTestList: mutated,
+      approver: APPROVER,
+      hitlReapproved: true,
+      tddDir: tdd,
+      now: RE_APPROVE_NOW,
+    });
+
+    // Re-read the file from disk + verify integrity.
+    const currentContent = readFileSync(
+      join(tdd, "features", FEATURE_ID, "test-list.json"),
+      "utf8"
+    );
+    const v = verifyGateIntegrity({
+      featureId: FEATURE_ID,
+      gate: "test_list",
+      currentInputs: { "test-list.json": currentContent },
+      tddDir: tdd,
+    });
+    expect(v.status).toBe("ok");
+  });
+});
+
+describe("mutateTestList: isTestListProtected predicate", () => {
+  it("returns false when the feature does not exist", () => {
+    expect(isTestListProtected(FEATURE_ID, { tddDir: tdd })).toBe(false);
+  });
+
+  it("returns false when the gate is open", () => {
+    makeFeatureDir();
+    expect(isTestListProtected(FEATURE_ID, { tddDir: tdd })).toBe(false);
+  });
+
+  it("returns true when the gate is approved", () => {
+    makeFeatureDir();
+    writeMasterTestList(tdd, BASE_LIST);
+    approveTestListGate(BASE_LIST);
+    expect(isTestListProtected(FEATURE_ID, { tddDir: tdd })).toBe(true);
+  });
+
+  it("returns false when the gate is withdrawn", () => {
+    makeFeatureDir();
+    const state = defaultGatesState(FEATURE_ID);
+    state.gates.test_list = { status: "withdrawn", history: [] };
+    writeGates(state, { tddDir: tdd });
+    expect(isTestListProtected(FEATURE_ID, { tddDir: tdd })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Composes the [FEIP-7357](https://databricks.atlassian.net/browse/FEIP-7357) gates state machine with the existing test-list IO so that once a `test_list` gate is approved the test list cannot be silently rewritten. The Test Strategist still uses `writeMasterTestList` for INITIAL authoring; orchestrator-side post-approval edits go through `mutateTestList`.

## What ships

**`scripts/tdd/mutate-test-list.ts`**:
- `mutateTestList({ featureId, newTestList, approver, hitlReapproved, ... }) -> { state, capturedHash, reapproved }`
- Refuses to overwrite an approved `test_list` without `hitlReapproved: true` (throws `TestListImmutabilityError`)
- When `hitlReapproved: true`: atomically **supersedes** the prior approval, writes the new `test-list.json`, and re-approves with the new artifact hash. The whole supersede+write+approve cycle happens inside the gates lock so concurrent callers cannot race.
- Open / withdrawn / superseded gates: write goes through cleanly (`reapproved: false`). Each of those is "not currently protecting anything," so the immutability rule does not apply.
- Bonus `isTestListProtected(featureId)` predicate for callers that want to decide upfront whether they need the flag.

**`tests/bdd/tdd-mutate-test-list.test.ts`** (14 tests, all green first run):
- Validation: empty approver, featureId mismatch
- Unprotected states (open / withdrawn / superseded): write succeeds with `reapproved: false`
- Approved gate refusal: throws `TestListImmutabilityError` + on-disk file unchanged
- With `hitlReapproved: true`: supersedes + re-approves atomically; new hash matches what `writeMasterTestList` produces on disk; approver + approved_at + artifact_hashes reflect the new approval
- History accumulates: prior approval + superseded + new approval (3 entries with correct actions + approvers)
- `verifyGateIntegrity` returns `ok` against the re-approved content
- `isTestListProtected` predicate returns the right state per gate status

## ADR-0004 reconciliation

The ticket name mentioned a "Gate 3 re-approval token"; [ADR-0004 open Q #1](~/code/docs/adr/ADR-0004-tdd-gates-state-machine.md) settled on integrity-check rather than tokens. This implementation follows the ADR: no token round-trip, just an explicit flag + atomic state transition.

## Verification

- `npm run typecheck` clean
- New tests: 14/14 pass first run
- `npm test`: 772 passed, 0 failed (was 758; +14 new)

## Composition

- Built on G1-G11 of FEIP-7357.
- The gates substrate's contract surface is now consumed by a real downstream primitive that enforces the test-list-immutability rule end-to-end. This validates the substrate's design at a real consumer.

## Test plan

- [x] Branch off main
- [x] Implement + test
- [x] Typecheck clean
- [x] All new tests pass
- [x] Full suite green
- [ ] Squash-merge

This pull request and its description were written by Isaac.