### PR TITLE
feat(lakebase): MigrationAdapter interface + registry skeleton (FEIP-7210 slice 1)

### DIFF
--- a/scripts/lakebase/migration-adapter.ts
+++ b/scripts/lakebase/migration-adapter.ts
@@ -1,0 +1,221 @@
+// Migration adapter interface + registry skeleton (FEIP-7210 slice 1).
+//
+// Design: ADR-0005 (~/code/docs/adr/ADR-0005-schema-migrate-adapter.md).
+//
+// Today, scripts/lakebase/migrate.ts hardcodes a Flyway-first dispatch
+// against a known set of language markers (pom.xml + Maven, alembic.ini +
+// Python, knexfile.{js,ts} + Node). Adding a new migration tool means
+// touching that dispatch. The adapter pattern inverts the dependency:
+// each tool ships a MigrationAdapter that implements the contract; the
+// dispatcher just routes by detection.
+//
+// This slice ships types only. No behavior changes. The existing
+// migrate.ts surface continues to work unchanged; subsequent slices
+// will port its internals into FlywayAdapter / AlembicAdapter /
+// KnexAdapter implementations.
+//
+// Sub-tasks (per ADR-0005 implementation sequencing):
+//   slice 1 (this PR): types + registry skeleton
+//   slice 2: port Flyway out of migrate.ts into FlywayAdapter
+//   slice 3: port Alembic + Knex (list-only)
+//   slice 4: ship lakebase-schema-migrate CLI + deprecation alias for
+//            lakebase-migrate
+//   slice 5+: doctor checks, optional Knex completion, Liquibase,
+//             custom path-based adapter
+
+import type {
+  AppliedMigration,
+  MigrationFile,
+  MigrationLanguage,
+  MigrationToolName,
+  PendingMigration,
+} from "./migrate";
+
+/**
+ * Adapter id. Stable; matches `project.yaml#migration_tool` override.
+ * "custom" is reserved for path-based loading via
+ * `project.yaml#migration_tool_module` (slice 5+).
+ */
+export type MigrationAdapterId = MigrationToolName | "custom";
+
+export interface ApplyArgs {
+  instance: string;
+  branch: string;
+  projectDir: string;
+  database?: string;
+  endpointName?: string;
+}
+
+export interface ApplyResult {
+  applied_migrations: AppliedMigration[];
+  status: "ok" | "noop" | "error";
+  error?: string;
+  /**
+   * Tool-specific fields outside the cross-tool contract. Adapters MAY
+   * populate (e.g. Flyway's installed_rank); callers MUST treat as
+   * opaque + tool-aware.
+   */
+  tool_specific?: Record<string, unknown>;
+}
+
+export interface RollbackArgs {
+  instance: string;
+  branch: string;
+  projectDir: string;
+  /** Adapter-specific target: revision id or relative step like "-1". */
+  target: string;
+  database?: string;
+  endpointName?: string;
+}
+
+export interface RollbackResult {
+  rolled_back: AppliedMigration[];
+  status: "ok" | "noop" | "error" | "unsupported";
+  error?: string;
+  tool_specific?: Record<string, unknown>;
+}
+
+export interface StatusArgs {
+  instance: string;
+  branch: string;
+  projectDir: string;
+  database?: string;
+  endpointName?: string;
+}
+
+export interface StatusResult {
+  applied_version: string | null;
+  pending: PendingMigration[];
+  applied: AppliedMigration[];
+  status: "ok" | "error";
+  error?: string;
+  tool_specific?: Record<string, unknown>;
+}
+
+export interface ListArgs {
+  projectDir: string;
+}
+
+export interface ListResult {
+  files: MigrationFile[];
+}
+
+export interface BaselineArgs {
+  instance: string;
+  branch: string;
+  projectDir: string;
+  version: string;
+  description?: string;
+  database?: string;
+  endpointName?: string;
+}
+
+export interface BaselineResult {
+  status: "ok" | "error" | "unsupported";
+  baseline_version: string | null;
+  error?: string;
+  tool_specific?: Record<string, unknown>;
+}
+
+/**
+ * Cross-tool migration adapter contract. Every adapter exposes the same
+ * surface; tool-specific fields ride on `tool_specific` so the contract
+ * stays uniform.
+ */
+export interface MigrationAdapter {
+  readonly id: MigrationAdapterId;
+  /** Languages this adapter claims. Used by auto-detection. */
+  readonly languages: ReadonlyArray<MigrationLanguage>;
+
+  /**
+   * Auto-detect: does this adapter own the given project? Adapters
+   * inspect marker files (pom.xml + flyway-maven-plugin for Flyway,
+   * alembic.ini for Alembic, knexfile for Knex, ...).
+   */
+  detect(projectDir: string): boolean;
+
+  apply(args: ApplyArgs): Promise<ApplyResult>;
+
+  /**
+   * Roll back to a target version. OPTIONAL: Flyway Community Edition
+   * does not support rollback; adapters omit this property when the
+   * underlying tool lacks the capability.
+   */
+  rollback?(args: RollbackArgs): Promise<RollbackResult>;
+
+  status(args: StatusArgs): Promise<StatusResult>;
+
+  list(args: ListArgs): Promise<ListResult>;
+
+  /**
+   * Apply Flyway-style baseline marker to an existing schema. OPTIONAL.
+   */
+  baseline?(args: BaselineArgs): Promise<BaselineResult>;
+}
+
+/**
+ * In-memory adapter registry. Built-in adapters register here on import;
+ * resolveAdapter walks the registry by detect() for auto-routing.
+ *
+ * Slice 1 ships an empty registry skeleton. Slices 2-3 register the
+ * built-in Flyway / Alembic / Knex adapters as they land.
+ */
+const REGISTRY = new Map<MigrationAdapterId, MigrationAdapter>();
+
+export function registerAdapter(adapter: MigrationAdapter): void {
+  REGISTRY.set(adapter.id, adapter);
+}
+
+export function getAdapter(id: MigrationAdapterId): MigrationAdapter | undefined {
+  return REGISTRY.get(id);
+}
+
+export function listAdapters(): MigrationAdapter[] {
+  return [...REGISTRY.values()];
+}
+
+/**
+ * Resolution rules:
+ *   1. Explicit override -> getAdapter(override); throws when not registered.
+ *   2. Auto-detect -> first registered adapter whose detect() returns true.
+ *   3. None match -> throws UnresolvedAdapterError with a hint.
+ */
+export function resolveAdapter(
+  projectDir: string,
+  override?: MigrationAdapterId
+): MigrationAdapter {
+  if (override) {
+    const a = REGISTRY.get(override);
+    if (!a) {
+      throw new UnresolvedAdapterError(
+        `migration_tool=${override} is not a registered adapter. Registered: ${
+          [...REGISTRY.keys()].join(", ") || "(none)"
+        }`
+      );
+    }
+    return a;
+  }
+  for (const adapter of REGISTRY.values()) {
+    if (adapter.detect(projectDir)) return adapter;
+  }
+  throw new UnresolvedAdapterError(
+    `Cannot resolve migration tool for ${projectDir}. ` +
+      `Set project.yaml#migration_tool to one of: ${[...REGISTRY.keys()].join(", ") || "(none)"}.`
+  );
+}
+
+export class UnresolvedAdapterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnresolvedAdapterError";
+  }
+}
+
+/**
+ * Test seam: clear the registry. Production code never calls this;
+ * tests use it to isolate from any auto-registered adapters that may
+ * land in subsequent slices.
+ */
+export function _clearRegistryForTests(): void {
+  REGISTRY.clear();
+}

--- a/tests/bdd/migration-adapter.test.ts
+++ b/tests/bdd/migration-adapter.test.ts
@@ -1,0 +1,171 @@
+// FEIP-7210 slice 1: MigrationAdapter interface + registry contract.
+//
+// Types-only PR. Tests assert the registry shape + resolution logic so
+// later slices that register concrete adapters (Flyway / Alembic / Knex)
+// inherit the contract guarantees.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _clearRegistryForTests,
+  getAdapter,
+  listAdapters,
+  registerAdapter,
+  resolveAdapter,
+  UnresolvedAdapterError,
+  type ApplyResult,
+  type BaselineResult,
+  type ListResult,
+  type MigrationAdapter,
+  type RollbackResult,
+  type StatusResult,
+} from "../../scripts/lakebase/migration-adapter";
+
+function fakeAdapter(
+  id: MigrationAdapter["id"],
+  detect: (projectDir: string) => boolean = () => false
+): MigrationAdapter {
+  return {
+    id,
+    languages: [],
+    detect,
+    apply: async (): Promise<ApplyResult> => ({ applied_migrations: [], status: "ok" }),
+    status: async (): Promise<StatusResult> => ({
+      applied_version: null,
+      pending: [],
+      applied: [],
+      status: "ok",
+    }),
+    list: async (): Promise<ListResult> => ({ files: [] }),
+  };
+}
+
+beforeEach(() => {
+  _clearRegistryForTests();
+});
+
+afterEach(() => {
+  _clearRegistryForTests();
+});
+
+describe("migration-adapter: registry shape", () => {
+  it("starts empty", () => {
+    expect(listAdapters()).toEqual([]);
+  });
+
+  it("register + get + list roundtrip", () => {
+    const flyway = fakeAdapter("flyway");
+    registerAdapter(flyway);
+    expect(getAdapter("flyway")).toBe(flyway);
+    expect(listAdapters()).toEqual([flyway]);
+  });
+
+  it("re-registering an id overwrites the prior adapter (last write wins)", () => {
+    const a = fakeAdapter("flyway");
+    const b = fakeAdapter("flyway");
+    registerAdapter(a);
+    registerAdapter(b);
+    expect(getAdapter("flyway")).toBe(b);
+    expect(listAdapters()).toHaveLength(1);
+  });
+
+  it("supports the four canonical ids: flyway, alembic, knex, custom", () => {
+    registerAdapter(fakeAdapter("flyway"));
+    registerAdapter(fakeAdapter("alembic"));
+    registerAdapter(fakeAdapter("knex"));
+    registerAdapter(fakeAdapter("custom"));
+    expect(listAdapters().map((a) => a.id).sort()).toEqual([
+      "alembic",
+      "custom",
+      "flyway",
+      "knex",
+    ]);
+  });
+});
+
+describe("migration-adapter: resolveAdapter explicit override", () => {
+  it("returns the registered adapter when the override matches", () => {
+    const flyway = fakeAdapter("flyway");
+    registerAdapter(flyway);
+    expect(resolveAdapter("/any", "flyway")).toBe(flyway);
+  });
+
+  it("throws UnresolvedAdapterError when the override is not registered", () => {
+    registerAdapter(fakeAdapter("flyway"));
+    expect(() => resolveAdapter("/any", "alembic")).toThrow(UnresolvedAdapterError);
+    expect(() => resolveAdapter("/any", "alembic")).toThrow(/not a registered adapter/);
+  });
+
+  it("the error message lists the registered ids", () => {
+    registerAdapter(fakeAdapter("flyway"));
+    registerAdapter(fakeAdapter("alembic"));
+    try {
+      resolveAdapter("/any", "knex");
+    } catch (err) {
+      expect((err as Error).message).toMatch(/flyway/);
+      expect((err as Error).message).toMatch(/alembic/);
+    }
+  });
+});
+
+describe("migration-adapter: resolveAdapter auto-detect", () => {
+  it("returns the first adapter whose detect() returns true", () => {
+    const flyway = fakeAdapter("flyway", () => false);
+    const alembic = fakeAdapter("alembic", () => true);
+    registerAdapter(flyway);
+    registerAdapter(alembic);
+    expect(resolveAdapter("/any")).toBe(alembic);
+  });
+
+  it("returns the first match in registration order (stable for tie-breaks)", () => {
+    const flyway = fakeAdapter("flyway", () => true);
+    const alembic = fakeAdapter("alembic", () => true);
+    registerAdapter(flyway);
+    registerAdapter(alembic);
+    expect(resolveAdapter("/any")).toBe(flyway);
+  });
+
+  it("throws UnresolvedAdapterError when no adapter detects + no override", () => {
+    registerAdapter(fakeAdapter("flyway", () => false));
+    expect(() => resolveAdapter("/any")).toThrow(UnresolvedAdapterError);
+    expect(() => resolveAdapter("/any")).toThrow(/Cannot resolve migration tool/);
+  });
+
+  it("error hint enumerates the registered adapters", () => {
+    registerAdapter(fakeAdapter("flyway", () => false));
+    registerAdapter(fakeAdapter("knex", () => false));
+    try {
+      resolveAdapter("/any");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/migration_tool/);
+      expect(msg).toMatch(/flyway/);
+      expect(msg).toMatch(/knex/);
+    }
+  });
+});
+
+describe("migration-adapter: optional capability protocol", () => {
+  it("rollback + baseline are optional; absence is observable via property check", () => {
+    const minimal = fakeAdapter("flyway"); // no rollback, no baseline
+    registerAdapter(minimal);
+    expect(typeof minimal.rollback).toBe("undefined");
+    expect(typeof minimal.baseline).toBe("undefined");
+  });
+
+  it("adapters can opt into rollback + baseline", () => {
+    const full: MigrationAdapter = {
+      ...fakeAdapter("alembic"),
+      rollback: async (): Promise<RollbackResult> => ({
+        rolled_back: [],
+        status: "ok",
+      }),
+      baseline: async (): Promise<BaselineResult> => ({
+        status: "ok",
+        baseline_version: "0",
+      }),
+    };
+    registerAdapter(full);
+    expect(typeof full.rollback).toBe("function");
+    expect(typeof full.baseline).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

Slice 1 of the [FEIP-7210](https://databricks.atlassian.net/browse/FEIP-7210) schema-migrate adapter track ([ADR-0005](~/code/docs/adr/ADR-0005-schema-migrate-adapter.md)). **Types-only**; no behavior changes. The existing `scripts/lakebase/migrate.ts` continues to work unchanged. Subsequent slices port its internals into per-tool adapters that register here.

## What ships

**`scripts/lakebase/migration-adapter.ts`** (~180 lines):
- `MigrationAdapter` interface with the cross-tool surface from ADR-0005: `apply` / `status` / `list` (required) + `rollback` / `baseline` (optional; Flyway Community Edition lacks rollback, so adapters omit the method rather than throw inside it)
- Uniform result shapes (`ApplyResult` / `RollbackResult` / `StatusResult` / `ListResult` / `BaselineResult`) with a `tool_specific` escape hatch for fields outside the cross-tool contract (e.g. Flyway's `installed_rank`)
- `MigrationAdapterId = "flyway" | "alembic" | "knex" | "custom"`
- In-memory `ADAPTERS` registry: `registerAdapter` / `getAdapter` / `listAdapters`
- `resolveAdapter(projectDir, override?)`: explicit override wins; else first registered adapter whose `detect()` returns true; else throws `UnresolvedAdapterError` with a hint that lists the registered ids
- `_clearRegistryForTests` helper for test isolation

**`tests/bdd/migration-adapter.test.ts`** (13 tests, all green first run):
- Registry: empty by default; register + get + list roundtrip; last-write-wins; all four canonical ids supported
- Resolution (override): returns the registered adapter; throws on unknown id; error message enumerates the available ids
- Resolution (auto-detect): first matching `detect()` wins; ties broken by registration order; throws on no match with a clear hint
- Optional capabilities: `rollback` + `baseline` absent on minimal adapters + present on full adapters (property-check protocol)

## Verification

- `npm run typecheck` clean
- New tests: 13/13 pass first run
- `npm test`: 785 passed, 0 failed (was 772; +13 new)

## Subsequent slices (filed against FEIP-7210)

- **slice 2**: port Flyway out of `migrate.ts` into `FlywayAdapter`
- **slice 3**: port Alembic + Knex (list-only)
- **slice 4**: ship `lakebase-schema-migrate` CLI bin + deprecation alias for `lakebase-migrate`
- **slice 5+**: doctor checks, Knex completion, Liquibase, path-based custom adapter

## Test plan

- [x] Branch off main
- [x] Define interface + registry
- [x] Typecheck clean
- [x] All new tests pass
- [x] Full suite green
- [ ] Squash-merge

This pull request and its description were written by Isaac.