### PR TITLE
feat(lakebase): FlywayAdapter (FEIP-7210 slice 2)

### DIFF
--- a/scripts/lakebase/adapters/flyway-adapter.ts
+++ b/scripts/lakebase/adapters/flyway-adapter.ts
@@ -1,0 +1,148 @@
+// FlywayAdapter: MigrationAdapter implementation for Java/Kotlin projects
+// using flyway-maven-plugin. FEIP-7210 slice 2.
+//
+// Wraps the existing scripts/lakebase/migrate-runners/flyway.ts runner
+// in the cross-tool adapter contract from ADR-0005. The runner's
+// underlying behavior is unchanged; this is a contract adapter, not a
+// reimplementation.
+//
+// Note: Flyway Community Edition does NOT support rollback. The adapter
+// omits the `rollback` method per the ADR-0005 optional-capability
+// protocol; callers MUST property-check before invoking.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getConnection } from "../get-connection.js";
+import {
+  applyFlyway,
+  statusFlyway,
+} from "../migrate-runners/flyway.js";
+import type { AppliedMigration, MigrationFile, PendingMigration } from "../migrate.js";
+import {
+  registerAdapter,
+  type ApplyArgs,
+  type ApplyResult,
+  type ListArgs,
+  type ListResult,
+  type MigrationAdapter,
+  type StatusArgs,
+  type StatusResult,
+} from "../migration-adapter.js";
+
+async function buildDsn(args: {
+  instance: string;
+  branch: string;
+  database?: string;
+  endpointName?: string;
+}): Promise<string> {
+  const result = await getConnection({
+    output: "dsn",
+    instance: args.instance,
+    branch: args.branch,
+    database: args.database,
+    endpointName: args.endpointName,
+  });
+  return result.url;
+}
+
+function listFlywayFiles(projectDir: string): MigrationFile[] {
+  // Flyway convention: src/main/resources/db/migration/V<n>__<desc>.sql
+  const dir = path.join(projectDir, "src", "main", "resources", "db", "migration");
+  if (!fs.existsSync(dir)) return [];
+  const files = fs.readdirSync(dir).filter((f) => /^V\d+(\.\d+)*__.+\.sql$/.test(f));
+  return files
+    .map((filename) => {
+      const m = filename.match(/^V(\d+(?:\.\d+)*)__(.+)\.sql$/);
+      const version = m![1];
+      const description = m![2].replace(/_/g, " ");
+      return { version, filename, description, type: "SQL" as const, tool: "flyway" as const };
+    })
+    .sort((a, b) => versionCompare(a.version, b.version));
+}
+
+function versionCompare(a: string, b: string): number {
+  const ax = a.split(".").map(Number);
+  const bx = b.split(".").map(Number);
+  const len = Math.max(ax.length, bx.length);
+  for (let i = 0; i < len; i++) {
+    const av = ax[i] ?? 0;
+    const bv = bx[i] ?? 0;
+    if (av !== bv) return av - bv;
+  }
+  return 0;
+}
+
+export const FlywayAdapter: MigrationAdapter = {
+  id: "flyway",
+  languages: ["java", "kotlin"],
+
+  detect(projectDir: string): boolean {
+    return fs.existsSync(path.join(projectDir, "pom.xml"));
+  },
+
+  async apply(args: ApplyArgs): Promise<ApplyResult> {
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await applyFlyway({ projectDir: args.projectDir, dsn });
+      return {
+        applied_migrations: legacy.applied as AppliedMigration[],
+        status: legacy.alreadyAtLatest ? "noop" : "ok",
+        tool_specific: {
+          alreadyAtLatest: legacy.alreadyAtLatest,
+          tool: legacy.tool,
+        },
+      };
+    } catch (err) {
+      return {
+        applied_migrations: [],
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+
+  // rollback intentionally absent: Flyway Community Edition does not
+  // support it. Callers MUST property-check (`adapter.rollback?` /
+  // `if (adapter.rollback)`) before invoking.
+
+  async status(args: StatusArgs): Promise<StatusResult> {
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await statusFlyway({ projectDir: args.projectDir, dsn });
+      return {
+        applied_version: legacy.current ?? null,
+        pending: legacy.pending as PendingMigration[],
+        // Legacy statusFlyway does not return the applied history; we
+        // surface only the currently-applied version + pending. Adapters
+        // that complete this (Alembic, future Knex) MAY populate.
+        applied: [],
+        status: "ok",
+        tool_specific: { tool: legacy.tool },
+      };
+    } catch (err) {
+      return {
+        applied_version: null,
+        pending: [],
+        applied: [],
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+
+  async list(args: ListArgs): Promise<ListResult> {
+    return { files: listFlywayFiles(args.projectDir) };
+  },
+
+  // baseline intentionally absent. Flyway DOES support baseline at the
+  // tool level, but exposing it cleanly requires plumbing flags into the
+  // existing runner. Deferred to a follow-up slice; the adapter's
+  // optional-protocol shape makes this additive.
+};
+
+// Auto-register on import. Consumers that import this module get the
+// adapter visible to resolveAdapter; consumers that don't import it
+// see no adapter (the registry stays empty and resolveAdapter throws
+// the helpful UnresolvedAdapterError).
+registerAdapter(FlywayAdapter);

--- a/tests/bdd/flyway-adapter.test.ts
+++ b/tests/bdd/flyway-adapter.test.ts
@@ -1,0 +1,137 @@
+// FEIP-7210 slice 2: FlywayAdapter contract tests.
+//
+// Tests assert the adapter's static surface (id, languages, detect, list,
+// optional-capability protocol) without invoking the live Maven runner.
+// apply + status are exercised against real Lakebase + Flyway in
+// tests/bdd/migrate-live-flyway.test.ts (env-gated).
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  _clearRegistryForTests,
+  getAdapter,
+  registerAdapter,
+} from "../../scripts/lakebase/migration-adapter";
+// Import the adapter module SECOND so we can isolate registration.
+// In production this auto-registers on first import; tests reset the
+// registry beforeEach then re-register explicitly to assert behavior.
+import { FlywayAdapter } from "../../scripts/lakebase/adapters/flyway-adapter";
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "flyway-adapter-"));
+  _clearRegistryForTests();
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  _clearRegistryForTests();
+});
+
+describe("FlywayAdapter: static surface", () => {
+  it("has id='flyway' + languages=['java', 'kotlin']", () => {
+    expect(FlywayAdapter.id).toBe("flyway");
+    expect(FlywayAdapter.languages).toEqual(["java", "kotlin"]);
+  });
+
+  it("omits rollback (Flyway Community Edition lacks the capability)", () => {
+    expect(typeof FlywayAdapter.rollback).toBe("undefined");
+  });
+
+  it("omits baseline in slice 2 (deferred to a follow-up)", () => {
+    expect(typeof FlywayAdapter.baseline).toBe("undefined");
+  });
+
+  it("apply + status + list are all functions", () => {
+    expect(typeof FlywayAdapter.apply).toBe("function");
+    expect(typeof FlywayAdapter.status).toBe("function");
+    expect(typeof FlywayAdapter.list).toBe("function");
+  });
+});
+
+describe("FlywayAdapter: detect", () => {
+  it("returns false for an empty project directory", () => {
+    expect(FlywayAdapter.detect(projectDir)).toBe(false);
+  });
+
+  it("returns true when pom.xml exists at the project root", () => {
+    writeFileSync(join(projectDir, "pom.xml"), "<project></project>");
+    expect(FlywayAdapter.detect(projectDir)).toBe(true);
+  });
+
+  it("does NOT detect on pom.xml in a subdirectory (root-only marker)", () => {
+    mkdirSync(join(projectDir, "subdir"));
+    writeFileSync(join(projectDir, "subdir", "pom.xml"), "<project></project>");
+    expect(FlywayAdapter.detect(projectDir)).toBe(false);
+  });
+
+  it("does NOT detect when alembic.ini is present without pom.xml", () => {
+    writeFileSync(join(projectDir, "alembic.ini"), "[alembic]");
+    expect(FlywayAdapter.detect(projectDir)).toBe(false);
+  });
+});
+
+describe("FlywayAdapter: list (pure file-scan, no DB)", () => {
+  function makeMigrationsDir(): string {
+    const dir = join(projectDir, "src", "main", "resources", "db", "migration");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  it("returns an empty array when the migrations directory does not exist", async () => {
+    const r = await FlywayAdapter.list({ projectDir });
+    expect(r.files).toEqual([]);
+  });
+
+  it("enumerates V<n>__<desc>.sql files with parsed version + description", async () => {
+    const dir = makeMigrationsDir();
+    writeFileSync(join(dir, "V1__create_orders.sql"), "create table orders ();");
+    writeFileSync(join(dir, "V2__add_audit_log.sql"), "create table audit ();");
+    const r = await FlywayAdapter.list({ projectDir });
+    expect(r.files).toHaveLength(2);
+    expect(r.files[0].version).toBe("1");
+    expect(r.files[0].description).toBe("create orders");
+    expect(r.files[0].type).toBe("SQL");
+    expect(r.files[0].tool).toBe("flyway");
+    expect(r.files[1].version).toBe("2");
+  });
+
+  it("sorts by Flyway version order (1, 2, 10), not lexicographic (1, 10, 2)", async () => {
+    const dir = makeMigrationsDir();
+    writeFileSync(join(dir, "V10__ten.sql"), "");
+    writeFileSync(join(dir, "V2__two.sql"), "");
+    writeFileSync(join(dir, "V1__one.sql"), "");
+    const r = await FlywayAdapter.list({ projectDir });
+    expect(r.files.map((f) => f.version)).toEqual(["1", "2", "10"]);
+  });
+
+  it("ignores files that do not match V<n>__<desc>.sql", async () => {
+    const dir = makeMigrationsDir();
+    writeFileSync(join(dir, "V1__valid.sql"), "");
+    writeFileSync(join(dir, "README.md"), "docs");
+    writeFileSync(join(dir, "U1__undo.sql"), "");
+    writeFileSync(join(dir, "V__missing_version.sql"), "");
+    const r = await FlywayAdapter.list({ projectDir });
+    expect(r.files.map((f) => f.filename)).toEqual(["V1__valid.sql"]);
+  });
+
+  it("handles multi-component versions like V1.2.3__patch.sql", async () => {
+    const dir = makeMigrationsDir();
+    writeFileSync(join(dir, "V1.2.3__patch.sql"), "");
+    writeFileSync(join(dir, "V1.2__minor.sql"), "");
+    writeFileSync(join(dir, "V1__major.sql"), "");
+    const r = await FlywayAdapter.list({ projectDir });
+    expect(r.files.map((f) => f.version)).toEqual(["1", "1.2", "1.2.3"]);
+  });
+});
+
+describe("FlywayAdapter: registry integration", () => {
+  it("registerAdapter + getAdapter('flyway') roundtrip returns the same instance", () => {
+    registerAdapter(FlywayAdapter);
+    expect(getAdapter("flyway")).toBe(FlywayAdapter);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2 of the [FEIP-7210](https://databricks.atlassian.net/browse/FEIP-7210) schema-migrate adapter track ([ADR-0005](~/code/docs/adr/ADR-0005-schema-migrate-adapter.md)). Implements the `MigrationAdapter` contract for Flyway-based projects (Java + Kotlin via `flyway-maven-plugin`) by wrapping the existing `scripts/lakebase/migrate-runners/flyway.ts` runner.

## What ships

**`scripts/lakebase/adapters/flyway-adapter.ts`** (140 lines):
- `MigrationAdapter` impl with `id: "flyway"` + `languages: ["java", "kotlin"]`
- `detect()`: checks for `pom.xml` at project root
- `apply()`: builds DSN via `getConnection`, delegates to `applyFlyway`, translates legacy `{applied, alreadyAtLatest, tool}` into the cross-tool `ApplyResult` shape with `status: "ok" | "noop"` + `tool_specific` carrying the legacy fields
- `status()`: same wrapping pattern around `statusFlyway`
- `list()`: pure file-scan for `V<n>__<desc>.sql` under `src/main/resources/db/migration`; sorts by Flyway version order (1, 2, 10) not lex (1, 10, 2)
- `rollback`: **intentionally absent** (Flyway Community Edition lacks the capability; callers MUST property-check per ADR-0005 optional-capability protocol)
- `baseline`: intentionally absent for slice 2; deferred to follow-up
- Auto-registers via `registerAdapter` on module import

**`tests/bdd/flyway-adapter.test.ts`** (14 tests, all green first run):
- Static surface
- `detect`: empty dir / pom.xml at root / pom.xml in subdir / alembic.ini without pom.xml
- `list`: empty / V1+V2 / version ordering / non-matching files ignored / multi-component versions
- Registry integration

## Back-compat

The existing `scripts/lakebase/migrate.ts` continues to dispatch via the legacy switch-on-tool path; this slice ships the adapter **alongside**, not replacing. Existing tests pass unchanged. Slice 4 will swap `migrate.ts`'s internals over to `resolveAdapter` and ship the new `lakebase-schema-migrate` CLI.

## Verification

- `npm run typecheck` clean
- New tests: 14/14 pass first run
- `npm test`: 799 passed, 0 failed (was 785; +14 new)

## Workflow note

The husky pre-commit hook from PR #83 fired during this slice when I started committing on `main` after slice 1 merged. Hook did exactly what it was designed to do: refused the commit, recovery was a single `git checkout -b`, no resets needed. The hook is paying for itself.

## Test plan

- [x] Branch off main
- [x] Wrap existing runner in adapter contract
- [x] Typecheck clean
- [x] All new tests pass
- [x] Full suite green
- [ ] Squash-merge

This pull request and its description were written by Isaac.