### PR TITLE
feat(lakebase): AlembicAdapter + KnexAdapter + Knex runner (FEIP-7210 slice 3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Thanks for your interest in contributing to `lakebase-app-dev-kit`. This is a [D
 - **GitHub CLI (`gh`)** authenticated to your GitHub account, for the FEIP-7138 self-hosted-runner suite. The live driver defaults to running it; pass `--no-github-runner` to opt out (see "Live testing" below).
 - **JDK 17+ and the Flyway CLI** for `migrate-live-flyway.test.ts`. The live driver downloads Flyway Community CLI from `${LAKEBASE_KIT_REGISTRY_MAVEN_CENTRAL}` on first run if `flyway` is not already on PATH; pre-installing via `brew install flyway` is fine.
 - A Python venv with **alembic + sqlalchemy + psycopg2-binary** for `migrate-live.test.ts`. The live driver auto-provisions `.venv-live-tests/` on first run.
+- **Node.js** with `npm` and `npx` on PATH for `migrate-live-knex.test.ts`. The suite self-installs `knex` + `pg` into a scratch project directory in its `beforeAll()`; no script-level provisioning needed.
 
 ### One-time setup
 
@@ -134,7 +135,7 @@ Older runner that supports `--read-only` and `--all` modes. Use when you only ne
 
 | Mode | Required env + tools | What runs | Creates resources? |
 |---|---|---|---|
-| default (migrate) | `DATABRICKS_HOST`, `LAKEBASE_TEST_E2E=1`, authenticated `databricks` CLI, `python3`, `java`, `flyway` | `tests/bdd/migrate-live.test.ts` (alembic) + `tests/bdd/migrate-live-flyway.test.ts` | Yes: `migrate-7091-<ts>` + `migrate-7098-<ts>` Lakebase projects, each deleted in their suite's `afterAll()` |
+| default (migrate) | `DATABRICKS_HOST`, `LAKEBASE_TEST_E2E=1`, authenticated `databricks` CLI, `python3`, `java`, `flyway`, `npm` | `tests/bdd/migrate-live.test.ts` (alembic) + `tests/bdd/migrate-live-flyway.test.ts` + `tests/bdd/migrate-live-knex.test.ts` | Yes: `migrate-7091-<ts>` + `migrate-7098-<ts>` + `migrate-7099-<ts>` Lakebase projects, each deleted in their suite's `afterAll()` |
 | `--read-only` | `LAKEBASE_TEST_INSTANCE`, `LAKEBASE_TEST_BRANCH` | Read-only schema / endpoint / DSN suites against the configured branch | No |
 | `--all` | both of the above | Everything vitest discovers when gating env is satisfied | Yes (default mode) |
 

--- a/apps/mcp-server/tools.ts
+++ b/apps/mcp-server/tools.ts
@@ -241,7 +241,7 @@ export const TOOLS: ToolDefinition[] = [
   {
     name: "lakebase_apply_migrations",
     description:
-      "Apply pending forward migrations against a Lakebase branch. Python/Alembic supported today; Java+Kotlin/Flyway (FEIP-7098) and Node/Knex (FEIP-7099) error with a clear pointer until those runners land.",
+      "Apply pending forward migrations against a Lakebase branch. Supports Python/Alembic, Java+Kotlin/Flyway, and Node/Knex. Auto-detects the language from project markers (alembic.ini, pom.xml, knexfile.{js,ts}).",
     inputSchema: {
       type: "object",
       properties: {
@@ -273,7 +273,7 @@ export const TOOLS: ToolDefinition[] = [
   {
     name: "lakebase_rollback_migration",
     description:
-      "Roll back applied migrations on a Lakebase branch down to a target version. Python/Alembic only today (Flyway Community does not support rollback; Node/Knex via FEIP-7099). For Alembic, 'target' can be a revision id or a relative step like '-1'.",
+      "Roll back applied migrations on a Lakebase branch down to a target version. Supported for Python/Alembic + Node/Knex; NOT supported for Java+Kotlin/Flyway (Flyway Community Edition has no `undo`). For Alembic, 'target' can be a revision id or a relative step like '-1'. For Knex, use 'all' or '0' for full rollback; other values roll back the last batch.",
     inputSchema: {
       type: "object",
       properties: {

--- a/scripts/lakebase/adapters/alembic-adapter.ts
+++ b/scripts/lakebase/adapters/alembic-adapter.ts
@@ -1,0 +1,189 @@
+// AlembicAdapter: MigrationAdapter implementation for Python projects
+// using Alembic. FEIP-7210 slice 3.
+//
+// Wraps the existing scripts/lakebase/migrate-runners/alembic.ts runner
+// in the cross-tool adapter contract from ADR-0005. The runner's
+// underlying behavior is unchanged; this is a contract adapter, not a
+// reimplementation.
+//
+// Alembic supports rollback natively (downgrade), so this adapter
+// implements the optional rollback method. baseline is deferred to a
+// follow-up slice; Alembic's `stamp` command is the equivalent, but
+// wiring it through cleanly requires runner changes.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getConnection } from "../get-connection.js";
+import {
+  applyAlembic,
+  rollbackAlembic,
+  statusAlembic,
+} from "../migrate-runners/alembic.js";
+import type { AppliedMigration, MigrationFile, PendingMigration } from "../migrate.js";
+import {
+  registerAdapter,
+  type ApplyArgs,
+  type ApplyResult,
+  type ListArgs,
+  type ListResult,
+  type MigrationAdapter,
+  type RollbackArgs,
+  type RollbackResult,
+  type StatusArgs,
+  type StatusResult,
+} from "../migration-adapter.js";
+
+async function buildDsn(args: {
+  instance: string;
+  branch: string;
+  database?: string;
+  endpointName?: string;
+}): Promise<string> {
+  const result = await getConnection({
+    output: "dsn",
+    instance: args.instance,
+    branch: args.branch,
+    database: args.database,
+    endpointName: args.endpointName,
+  });
+  return result.url;
+}
+
+/**
+ * Locate the Alembic versions directory. Convention: either
+ * `migrations/versions/` (alembic.ini `script_location = migrations`) or
+ * `alembic/versions/` (the default `alembic init` layout).
+ */
+function findVersionsDir(projectDir: string): string | undefined {
+  const candidates = [
+    path.join(projectDir, "migrations", "versions"),
+    path.join(projectDir, "alembic", "versions"),
+  ];
+  return candidates.find((p) => fs.existsSync(p));
+}
+
+function listAlembicFiles(projectDir: string): MigrationFile[] {
+  const dir = findVersionsDir(projectDir);
+  if (!dir) return [];
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith(".py") && !f.startsWith("__"));
+  // Alembic file convention: <revid>_<slug>.py. True apply order requires
+  // walking the down_revision DAG, which Alembic itself enforces at apply
+  // time. For pure listing purposes, lexicographic by filename matches
+  // common revid schemes (zero-padded sequences, timestamps).
+  return files
+    .map((filename) => {
+      const stem = filename.replace(/\.py$/, "");
+      const sep = stem.indexOf("_");
+      const version = sep === -1 ? stem : stem.slice(0, sep);
+      const description = sep === -1 ? "" : stem.slice(sep + 1).replace(/_/g, " ");
+      return {
+        version,
+        filename,
+        description,
+        type: "Python" as const,
+        tool: "alembic" as const,
+      };
+    })
+    .sort((a, b) => a.filename.localeCompare(b.filename));
+}
+
+export const AlembicAdapter: MigrationAdapter = {
+  id: "alembic",
+  languages: ["python"],
+
+  /**
+   * Detect Alembic-specifically rather than Python-broadly. A project
+   * with pyproject.toml but no alembic.ini and no env.py is a Python
+   * project that hasn't (yet) adopted Alembic, and should NOT auto-route
+   * here. Callers can still force-select via project.yaml#migration_tool.
+   */
+  detect(projectDir: string): boolean {
+    if (fs.existsSync(path.join(projectDir, "alembic.ini"))) return true;
+    if (fs.existsSync(path.join(projectDir, "migrations", "env.py"))) return true;
+    if (fs.existsSync(path.join(projectDir, "alembic", "env.py"))) return true;
+    return false;
+  },
+
+  async apply(args: ApplyArgs): Promise<ApplyResult> {
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await applyAlembic({ projectDir: args.projectDir, dsn });
+      return {
+        applied_migrations: legacy.applied as AppliedMigration[],
+        status: legacy.alreadyAtLatest ? "noop" : "ok",
+        tool_specific: {
+          alreadyAtLatest: legacy.alreadyAtLatest,
+          tool: legacy.tool,
+        },
+      };
+    } catch (err) {
+      return {
+        applied_migrations: [],
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+
+  async rollback(args: RollbackArgs): Promise<RollbackResult> {
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await rollbackAlembic({
+        projectDir: args.projectDir,
+        dsn,
+        target: args.target,
+      });
+      return {
+        rolled_back: legacy.rolledBack as AppliedMigration[],
+        status: legacy.rolledBack.length === 0 ? "noop" : "ok",
+        tool_specific: { tool: legacy.tool },
+      };
+    } catch (err) {
+      return {
+        rolled_back: [],
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+
+  async status(args: StatusArgs): Promise<StatusResult> {
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await statusAlembic({ projectDir: args.projectDir, dsn });
+      return {
+        applied_version: legacy.current ?? null,
+        pending: legacy.pending as PendingMigration[],
+        // The legacy statusAlembic returns current + pending, not the
+        // full applied history. Surface what we have. Backfilling the
+        // applied list requires an extra `alembic history -r base:current`
+        // call; deferred to a follow-up so this slice stays a pure port.
+        applied: [],
+        status: "ok",
+        tool_specific: { tool: legacy.tool },
+      };
+    } catch (err) {
+      return {
+        applied_version: null,
+        pending: [],
+        applied: [],
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+
+  async list(args: ListArgs): Promise<ListResult> {
+    return { files: listAlembicFiles(args.projectDir) };
+  },
+
+  // baseline intentionally absent in slice 3. Alembic exposes `stamp`
+  // as the equivalent operation; deferred to a follow-up.
+};
+
+// Auto-register on import. Consumers that import this module get the
+// adapter visible to resolveAdapter; consumers that don't import it
+// see no adapter (the registry stays empty and resolveAdapter throws
+// the helpful UnresolvedAdapterError).
+registerAdapter(AlembicAdapter);

--- a/scripts/lakebase/adapters/knex-adapter.ts
+++ b/scripts/lakebase/adapters/knex-adapter.ts
@@ -1,0 +1,159 @@
+// KnexAdapter: MigrationAdapter implementation for Node.js projects
+// using Knex. FEIP-7210 slice 3.
+//
+// Wraps scripts/lakebase/migrate-runners/knex.ts, which shells out to
+// `npx knex` and derives results via before/after `migrate:status`
+// state diff. rollback is implemented because Knex supports it
+// natively. baseline is omitted: Knex has no native baseline concept.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getConnection } from "../get-connection.js";
+import {
+  applyKnex,
+  rollbackKnex,
+  statusKnex,
+} from "../migrate-runners/knex.js";
+import type { AppliedMigration, MigrationFile, PendingMigration } from "../migrate.js";
+import {
+  registerAdapter,
+  type ApplyArgs,
+  type ApplyResult,
+  type ListArgs,
+  type ListResult,
+  type MigrationAdapter,
+  type RollbackArgs,
+  type RollbackResult,
+  type StatusArgs,
+  type StatusResult,
+} from "../migration-adapter.js";
+
+async function buildDsn(args: {
+  instance: string;
+  branch: string;
+  database?: string;
+  endpointName?: string;
+}): Promise<string> {
+  const result = await getConnection({
+    output: "dsn",
+    instance: args.instance,
+    branch: args.branch,
+    database: args.database,
+    endpointName: args.endpointName,
+  });
+  return result.url;
+}
+
+const KNEXFILE_VARIANTS = ["knexfile.js", "knexfile.ts", "knexfile.mjs", "knexfile.cjs"];
+
+function listKnexFiles(projectDir: string): MigrationFile[] {
+  // Knex convention: ./migrations/*.{js,ts} with a numeric timestamp
+  // prefix that doubles as the version identifier.
+  const dir = path.join(projectDir, "migrations");
+  if (!fs.existsSync(dir)) return [];
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => (f.endsWith(".js") || f.endsWith(".ts")) && !f.startsWith("."));
+  return files
+    .map((filename) => {
+      const stem = filename.replace(/\.(js|ts)$/, "");
+      const m = stem.match(/^(\d{14})_(.+)$/);
+      const version = m ? m[1] : stem;
+      const description = m ? m[2].replace(/[_-]/g, " ") : stem;
+      const type = filename.endsWith(".ts") ? ("TypeScript" as const) : ("JavaScript" as const);
+      return { version, filename, description, type, tool: "knex" as const };
+    })
+    .sort((a, b) => a.version.localeCompare(b.version));
+}
+
+export const KnexAdapter: MigrationAdapter = {
+  id: "knex",
+  languages: ["nodejs"],
+
+  /**
+   * A knexfile at the project root is the canonical Knex marker. A bare
+   * package.json with no knexfile means "Node.js project, but not Knex"
+   * and should NOT auto-route here. Callers can still force-select via
+   * project.yaml#migration_tool.
+   */
+  detect(projectDir: string): boolean {
+    return KNEXFILE_VARIANTS.some((name) => fs.existsSync(path.join(projectDir, name)));
+  },
+
+  async apply(args: ApplyArgs): Promise<ApplyResult> {
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await applyKnex({ projectDir: args.projectDir, dsn });
+      return {
+        applied_migrations: legacy.applied as AppliedMigration[],
+        status: legacy.alreadyAtLatest ? "noop" : "ok",
+        tool_specific: {
+          alreadyAtLatest: legacy.alreadyAtLatest,
+          tool: legacy.tool,
+        },
+      };
+    } catch (err) {
+      return {
+        applied_migrations: [],
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+
+  async rollback(args: RollbackArgs): Promise<RollbackResult> {
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await rollbackKnex({
+        projectDir: args.projectDir,
+        dsn,
+        target: args.target,
+      });
+      return {
+        rolled_back: legacy.rolledBack as AppliedMigration[],
+        status: legacy.rolledBack.length === 0 ? "noop" : "ok",
+        tool_specific: { tool: legacy.tool },
+      };
+    } catch (err) {
+      return {
+        rolled_back: [],
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+
+  async status(args: StatusArgs): Promise<StatusResult> {
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await statusKnex({ projectDir: args.projectDir, dsn });
+      return {
+        applied_version: legacy.current ?? null,
+        pending: legacy.pending as PendingMigration[],
+        applied: [],
+        status: "ok",
+        tool_specific: { tool: legacy.tool },
+      };
+    } catch (err) {
+      return {
+        applied_version: null,
+        pending: [],
+        applied: [],
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+
+  async list(args: ListArgs): Promise<ListResult> {
+    return { files: listKnexFiles(args.projectDir) };
+  },
+
+  // baseline intentionally absent. Knex has no native baseline concept;
+  // omitting it advertises that correctly via the optional-capability
+  // protocol so callers won't attempt the operation.
+};
+
+// Auto-register on import.
+registerAdapter(KnexAdapter);

--- a/scripts/lakebase/migrate-runners/flyway.ts
+++ b/scripts/lakebase/migrate-runners/flyway.ts
@@ -1,4 +1,5 @@
-// Flyway runner for Java + Kotlin projects (FEIP-7098).
+// Flyway runner for Java + Kotlin projects (part of the FEIP-7091
+// primitives lift).
 //
 // Shells to the standalone Flyway Community Edition CLI in JSON output
 // mode. The runner reads the project's migration files from

--- a/scripts/lakebase/migrate-runners/knex.ts
+++ b/scripts/lakebase/migrate-runners/knex.ts
@@ -1,35 +1,201 @@
-// Knex runner for Node.js projects. Stub for FEIP-7099.
+// Knex runner for Node.js projects. Completed alongside FEIP-7210
+// slice 3; the original primitives lift (FEIP-7091) shipped this file
+// as a stub that threw "not yet implemented".
 //
-// Listing migrations from disk already works via listMigrations() in
-// migrate.ts which scans ./migrations/*.{js,ts}. Applying, rolling
-// back, and reading status against a real Lakebase branch is deferred
-// to FEIP-7099.
+// Mirrors the alembic.ts approach: shell out to `npx knex`, derive the
+// result by comparing `migrate:status` before + after the mutating call.
+// We do NOT parse the mutating-call's stdout, which keeps the runner
+// robust to formatting drift between Knex minor versions.
+//
+// Caveats vs Alembic:
+//   1. Knex has no "target revision" rollback in the core CLI. We map
+//      target="all" or "0" to `migrate:rollback --all`; any other target
+//      value rolls back the most recent batch (Knex's default).
+//   2. Knex applies in batches, not individual revisions. The "applied"
+//      list is derived from filename diff before/after, so each call
+//      reports what was newly completed regardless of batch grouping.
 
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import {
   MigrationError,
   type ApplyMigrationsResult,
   type RollbackMigrationResult,
   type MigrationStatusResult,
+  type AppliedMigration,
+  type PendingMigration,
 } from "../migrate.js";
-
-const NOT_IMPLEMENTED =
-  "Knex runner not yet implemented in the kit primitive. " +
-  "Shell out to `npx knex migrate:latest` / `migrate:rollback` / `migrate:status` " +
-  "directly against the branch DSN for now. Tracking ticket: FEIP-7099.";
 
 interface KnexCtx {
   projectDir: string;
   dsn: string;
 }
 
-export async function applyKnex(_ctx: KnexCtx): Promise<ApplyMigrationsResult> {
-  throw new MigrationError(NOT_IMPLEMENTED);
+const KNEXFILE_VARIANTS = ["knexfile.js", "knexfile.ts", "knexfile.mjs", "knexfile.cjs"];
+
+/** Locate the project's knexfile. Returns the absolute path or undefined. */
+export function findKnexfile(projectDir: string): string | undefined {
+  for (const name of KNEXFILE_VARIANTS) {
+    const p = path.join(projectDir, name);
+    if (fs.existsSync(p)) return p;
+  }
+  return undefined;
 }
 
-export async function rollbackKnex(_ctx: KnexCtx & { target: string }): Promise<RollbackMigrationResult> {
-  throw new MigrationError(NOT_IMPLEMENTED);
+function runKnex(ctx: KnexCtx, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const knexfile = findKnexfile(ctx.projectDir);
+    if (!knexfile) {
+      reject(
+        new MigrationError(
+          `No knexfile found in ${ctx.projectDir}. ` +
+            `Expected one of: ${KNEXFILE_VARIANTS.join(", ")}.`
+        )
+      );
+      return;
+    }
+    // `npx --no-install knex` prefers node_modules/.bin/knex without
+    // auto-installing; failure here means the consumer hasn't installed
+    // knex locally, which is a user-fixable error.
+    const child = spawn("npx", ["--no-install", "knex", "--knexfile", knexfile, ...args], {
+      cwd: ctx.projectDir,
+      env: { ...process.env, DATABASE_URL: ctx.dsn },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (err) => {
+      reject(
+        new MigrationError(
+          `Could not spawn knex via npx. Is Node installed and is 'knex' in the project's node_modules? ${err.message}`,
+          err
+        )
+      );
+    });
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(
+          new MigrationError(
+            `knex ${args.join(" ")} exited with code ${code}.\nstdout: ${stdout}\nstderr: ${stderr}`
+          )
+        );
+      }
+    });
+  });
 }
 
-export async function statusKnex(_ctx: KnexCtx): Promise<MigrationStatusResult> {
-  throw new MigrationError(NOT_IMPLEMENTED);
+/**
+ * Parse `knex migrate:status` output. Knex 3.x emits:
+ *   Found N Completed Migration file/files.
+ *   <filename>
+ *   ...
+ *   Found M Pending Migration file/files.   (or)   No Pending Migration files Found.
+ *   <filename>
+ *   ...
+ * Exported for unit testing.
+ */
+export function parseKnexStatus(stdout: string): { completed: string[]; pending: string[] } {
+  const completed: string[] = [];
+  const pending: string[] = [];
+  let mode: "completed" | "pending" | null = null;
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (/^Found\s+\d+\s+Completed\s+Migration/i.test(line)) {
+      mode = "completed";
+      continue;
+    }
+    if (/^Found\s+\d+\s+Pending\s+Migration/i.test(line)) {
+      mode = "pending";
+      continue;
+    }
+    if (/^No\s+Pending\s+Migration\s+files\s+Found/i.test(line)) {
+      mode = null;
+      continue;
+    }
+    if (!line) continue;
+    // Knex prefixes some informational lines with "Using environment:" and
+    // similar. Filter to anything that looks like a migration filename.
+    if (!/\.(js|ts|mjs|cjs)$/.test(line)) continue;
+    if (mode === "completed") completed.push(line);
+    if (mode === "pending") pending.push(line);
+  }
+  return { completed, pending };
+}
+
+function parseKnexFilename(filename: string): { version: string; description: string } {
+  const stem = filename.replace(/\.(js|ts|mjs|cjs)$/, "");
+  const m = stem.match(/^(\d{14})_(.+)$/);
+  const version = m ? m[1] : stem;
+  const description = m ? m[2].replace(/[_-]/g, " ") : stem;
+  return { version, description };
+}
+
+export async function applyKnex(ctx: KnexCtx): Promise<ApplyMigrationsResult> {
+  const beforeOut = await runKnex(ctx, ["migrate:status"]);
+  const before = parseKnexStatus(beforeOut.stdout);
+  await runKnex(ctx, ["migrate:latest"]);
+  const afterOut = await runKnex(ctx, ["migrate:status"]);
+  const after = parseKnexStatus(afterOut.stdout);
+
+  const newlyCompleted = after.completed.filter((f) => !before.completed.includes(f));
+  if (newlyCompleted.length === 0) {
+    return { applied: [], alreadyAtLatest: true, tool: "knex" };
+  }
+  const applied: AppliedMigration[] = newlyCompleted.map((filename) => {
+    const { version, description } = parseKnexFilename(filename);
+    return { version, description };
+  });
+  return { applied, alreadyAtLatest: false, tool: "knex" };
+}
+
+export async function rollbackKnex(
+  ctx: KnexCtx & { target: string }
+): Promise<RollbackMigrationResult> {
+  const beforeOut = await runKnex(ctx, ["migrate:status"]);
+  const before = parseKnexStatus(beforeOut.stdout);
+
+  const rollbackArgs = ["migrate:rollback"];
+  // Knex CLI rollback semantics:
+  //   migrate:rollback         -> last batch only
+  //   migrate:rollback --all   -> everything
+  // No revision-targeted rollback in core. Map "all" / "0" to --all;
+  // any other target value falls through to last-batch rollback. The
+  // adapter contract documents target as adapter-specific.
+  if (ctx.target === "all" || ctx.target === "0") {
+    rollbackArgs.push("--all");
+  }
+
+  await runKnex(ctx, rollbackArgs);
+  const afterOut = await runKnex(ctx, ["migrate:status"]);
+  const after = parseKnexStatus(afterOut.stdout);
+
+  const rolledBackFiles = before.completed.filter((f) => !after.completed.includes(f));
+  const rolledBack: AppliedMigration[] = rolledBackFiles.map((filename) => {
+    const { version, description } = parseKnexFilename(filename);
+    return { version, description };
+  });
+  return { rolledBack, tool: "knex" };
+}
+
+export async function statusKnex(ctx: KnexCtx): Promise<MigrationStatusResult> {
+  const { stdout } = await runKnex(ctx, ["migrate:status"]);
+  const { completed, pending } = parseKnexStatus(stdout);
+  const current =
+    completed.length > 0
+      ? parseKnexFilename(completed[completed.length - 1]).version
+      : undefined;
+  const pendingOut: PendingMigration[] = pending.map((filename) => {
+    const { version, description } = parseKnexFilename(filename);
+    return { version, filename, description };
+  });
+  return { current, pending: pendingOut, tool: "knex" };
 }

--- a/scripts/lakebase/migrate.cli.ts
+++ b/scripts/lakebase/migrate.cli.ts
@@ -103,7 +103,7 @@ Examples:
 Language support today:
   python (alembic)  Full: apply, rollback, status, list
   java, kotlin      Full: apply, status, list (rollback unsupported in Flyway Community Edition)
-  nodejs            list only (apply/rollback/status: FEIP-7099)
+  nodejs (knex)     Full: apply, rollback, status, list
 `;
 
 function printJson(result: unknown, pretty: boolean): void {

--- a/scripts/lakebase/migrate.ts
+++ b/scripts/lakebase/migrate.ts
@@ -6,11 +6,12 @@
 //   migrationStatus    – report current applied version + pending migrations
 //   listMigrations     – enumerate available migration files (no DB needed)
 //
-// Language dispatch: Python/Alembic ships as the reference implementation.
-// Java+Kotlin/Flyway (FEIP-7098) and Node/Knex (FEIP-7099) are stubbed; the
-// runners throw a clear "not yet implemented" error pointing at the
-// follow-up tickets. listMigrations() works for all three languages today
-// since it is a pure file-scan with no DB or runtime dependency.
+// Language dispatch: Python/Alembic, Java+Kotlin/Flyway, and Node/Knex
+// runners are all fully implemented (apply / status / list for all three;
+// rollback for Alembic + Knex). The original primitives lift (FEIP-7091)
+// shipped Flyway + Knex as stubs; they were completed alongside FEIP-7210
+// (adapter pattern) slices 2 + 3. listMigrations() is a pure file-scan
+// with no DB or runtime dependency.
 //
 // All primitives take explicit {instance, branch} args so headless agents
 // (Claude Desktop, OpenAI Codex, CI) can call them without a project .env.

--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -51,12 +51,15 @@
 #   --no-migrate-tools         Skip auto-provisioning alembic/flyway tools and
 #                              leave migrate-live + migrate-live-flyway gated
 #                              on whatever is already on PATH (default: enabled).
+#                              migrate-live-knex self-provisions via `npm install`
+#                              in beforeAll, no script-level prep needed.
 #   --help                     This help.
 #
 # What this script unlocks (every live-gated test in the kit):
 #   - All LAKEBASE_TEST_E2E-gated suites (cut-experiment, paired-branch,
 #     branch-create/delete, branch-utils, branch-endpoint, etc.).
 #   - migrate-live + migrate-live-flyway via auto-provisioned venv + tools.
+#   - migrate-live-knex (FEIP-7210 slice 3) via per-suite `npm install`.
 #   - tdd-experiment-lifecycle live describe (LAKEBASE_TEST_PROJECT_PATH).
 #   - detect-language-via-self-hosted-runner via --include-github-runner
 #     (LAKEBASE_TEST_E2E_GITHUB=1; pass --no-github-runner to opt out).

--- a/scripts/run-live-tests.sh
+++ b/scripts/run-live-tests.sh
@@ -2,19 +2,23 @@
 # Run the kit's live integration tests against a real Databricks workspace.
 #
 # Usage:
-#   scripts/run-live-tests.sh              # migrate-live (alembic + flyway), default
+#   scripts/run-live-tests.sh              # migrate-live (alembic + flyway + knex), default
 #   scripts/run-live-tests.sh --read-only  # tier 1 read-only suite against an existing branch
 #   scripts/run-live-tests.sh --all        # both of the above + any other live suites
+#
+# For the comprehensive "everything live, auto-provision everything"
+# entry point, use scripts/run-all-live-tests.sh instead. That driver
+# resolves DATABRICKS_HOST from a databricks CLI profile, provisions a
+# project + branch, sources .env.template.config + .env.local.config,
+# and unlocks every gated LAKEBASE_TEST_* describe. See CONTRIBUTING.md.
 #
 # Modes:
 #
 #   (default) migrate-live
 #     Provisions its own Lakebase projects on $DATABRICKS_HOST and runs
-#     the four migrate primitives (apply / rollback / status / list)
-#     once with the Alembic runner against a Python project layout and
-#     once with the Flyway runner against a Maven/Spring project layout.
-#     Each test creates and tears down its own project, suffixed with a
-#     timestamp.
+#     the migrate primitives (apply / rollback / status / list) once
+#     with the Alembic runner, once with the Flyway runner, once with
+#     the Knex runner. Each test creates + tears down its own project.
 #     Required env: DATABRICKS_HOST, LAKEBASE_TEST_E2E=1
 #     Required tools: databricks CLI (authenticated), python3, java
 #     The script auto-provisions on first run:
@@ -40,10 +44,10 @@ FLYWAY_VERSION="10.20.1"
 
 MODE="migrate"
 case "${1:-}" in
-  --read-only) MODE="read-only" ;;
-  --all)       MODE="all" ;;
-  "")          MODE="migrate" ;;
-  *)           echo "Unknown flag: $1. Use --read-only, --all, or no flag for migrate-live." >&2; exit 2 ;;
+  --read-only)  MODE="read-only" ;;
+  --all)        MODE="all" ;;
+  "")           MODE="migrate" ;;
+  *)            echo "Unknown flag: $1. Use --read-only / --all, or no flag for migrate-live." >&2; exit 2 ;;
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -173,9 +177,10 @@ if [[ "$MODE" == "migrate" || "$MODE" == "all" ]]; then
   yellow "==> About to create Lakebase projects on your workspace"
   yellow "    workspace:    $DATABRICKS_HOST"
   yellow "    project names:"
-  yellow "      migrate-7091-<timestamp>  (Alembic suite)"
-  yellow "      migrate-7098-<timestamp>  (Flyway suite)"
-  yellow "    cleanup:      automatic in each suite's afterAll() with 3-attempt retry"
+  yellow "      migrate-7091-<timestamp>  (Alembic suite, self-provisioned)"
+  yellow "      migrate-7099-<timestamp>  (Knex suite, self-provisioned)"
+  yellow "      live-fixture-<timestamp>  (globalSetup, shared by all live tests)"
+  yellow "    cleanup:      automatic in each suite's afterAll() + globalSetup teardown (3-attempt retry)"
   yellow "    manual fix:   databricks postgres delete-project <id>  (if cleanup leaks)"
   yellow ""
   yellow "    Press Ctrl-C in the next 5 seconds to abort. Setting LAKEBASE_TEST_NO_PROMPT=1"
@@ -192,7 +197,8 @@ case "$MODE" in
   migrate)
     npx vitest run \
       tests/bdd/migrate-live.test.ts \
-      tests/bdd/migrate-live-flyway.test.ts
+      tests/bdd/migrate-live-flyway.test.ts \
+      tests/bdd/migrate-live-knex.test.ts
     ;;
   read-only)
     npx vitest run \

--- a/skills/lakebase-release-workflows/SKILL.md
+++ b/skills/lakebase-release-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lakebase-release-workflows
 description: "Opinionated branching + release methodology for Lakebase-paired projects. Use when designing a project's branch layout, cutting a release candidate, promoting between long-running tiers, rolling back, or asking 'where should this work happen?' Encodes the prod / staging / {feature,test,uat,perf} default and the N-tier-capable cut-RC / regression-test / cut-backup / migrate release flow."
-compatibility: Requires the substrate's [lakebase-scm-workflows](../lakebase-scm-workflows/SKILL.md) skill for branch-pairing primitives, plus the substrate's migrate primitives (FEIP-7091, FEIP-7098).
+compatibility: Requires the substrate's [lakebase-scm-workflows](../lakebase-scm-workflows/SKILL.md) skill for branch-pairing primitives, plus the substrate's migrate primitives (FEIP-7091).
 metadata:
   version: "0.2.0"
 parent: databricks-lakebase

--- a/tests/bdd/alembic-adapter.test.ts
+++ b/tests/bdd/alembic-adapter.test.ts
@@ -1,0 +1,175 @@
+// FEIP-7210 slice 3: AlembicAdapter contract tests.
+//
+// Tests assert the adapter's static surface (id, languages, detect,
+// list, optional-capability protocol) without invoking the live Alembic
+// runner. apply + rollback + status are exercised against real Lakebase
+// + Alembic in env-gated live tests.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  _clearRegistryForTests,
+  getAdapter,
+  registerAdapter,
+} from "../../scripts/lakebase/migration-adapter";
+// Import the adapter SECOND so registration is observable. Production
+// imports auto-register; tests reset the registry beforeEach then
+// re-register to keep assertions explicit.
+import { AlembicAdapter } from "../../scripts/lakebase/adapters/alembic-adapter";
+
+const FIXTURE_ROOT = join(__dirname, "fixtures", "migrations-samples", "alembic");
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "alembic-adapter-"));
+  _clearRegistryForTests();
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  _clearRegistryForTests();
+});
+
+describe("AlembicAdapter: static surface", () => {
+  it("has id='alembic' + languages=['python']", () => {
+    expect(AlembicAdapter.id).toBe("alembic");
+    expect(AlembicAdapter.languages).toEqual(["python"]);
+  });
+
+  it("exposes rollback (Alembic supports downgrade)", () => {
+    expect(typeof AlembicAdapter.rollback).toBe("function");
+  });
+
+  it("omits baseline in slice 3 (Alembic stamp deferred)", () => {
+    expect(typeof AlembicAdapter.baseline).toBe("undefined");
+  });
+
+  it("apply + status + list are all functions", () => {
+    expect(typeof AlembicAdapter.apply).toBe("function");
+    expect(typeof AlembicAdapter.status).toBe("function");
+    expect(typeof AlembicAdapter.list).toBe("function");
+  });
+});
+
+describe("AlembicAdapter: detect", () => {
+  it("returns false for an empty project directory", () => {
+    expect(AlembicAdapter.detect(projectDir)).toBe(false);
+  });
+
+  it("returns true when alembic.ini exists at the project root", () => {
+    writeFileSync(join(projectDir, "alembic.ini"), "[alembic]\nscript_location = migrations\n");
+    expect(AlembicAdapter.detect(projectDir)).toBe(true);
+  });
+
+  it("returns true when migrations/env.py exists (no alembic.ini)", () => {
+    mkdirSync(join(projectDir, "migrations"), { recursive: true });
+    writeFileSync(join(projectDir, "migrations", "env.py"), "");
+    expect(AlembicAdapter.detect(projectDir)).toBe(true);
+  });
+
+  it("returns true when alembic/env.py exists (default `alembic init` layout)", () => {
+    mkdirSync(join(projectDir, "alembic"), { recursive: true });
+    writeFileSync(join(projectDir, "alembic", "env.py"), "");
+    expect(AlembicAdapter.detect(projectDir)).toBe(true);
+  });
+
+  it("returns FALSE for a Python project with no Alembic markers", () => {
+    // pyproject.toml + requirements.txt alone are NOT enough to claim the
+    // project. This is tighter than migrate.ts's language-level detection
+    // and is the right call for the adapter contract: Python project,
+    // but Alembic isn't configured.
+    writeFileSync(join(projectDir, "pyproject.toml"), "[project]\nname='x'\n");
+    writeFileSync(join(projectDir, "requirements.txt"), "django");
+    expect(AlembicAdapter.detect(projectDir)).toBe(false);
+  });
+});
+
+describe("AlembicAdapter: list (pure file-scan, no DB)", () => {
+  function makeVersionsDir(parent: "migrations" | "alembic"): string {
+    const dir = join(projectDir, parent, "versions");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  it("returns an empty array when neither versions directory exists", async () => {
+    const r = await AlembicAdapter.list({ projectDir });
+    expect(r.files).toEqual([]);
+  });
+
+  it("enumerates versions/*.py with parsed revid + description", async () => {
+    const dir = makeVersionsDir("migrations");
+    writeFileSync(join(dir, "0001_create_users.py"), "");
+    writeFileSync(join(dir, "0002_create_orders.py"), "");
+    const r = await AlembicAdapter.list({ projectDir });
+    expect(r.files).toHaveLength(2);
+    expect(r.files[0].version).toBe("0001");
+    expect(r.files[0].description).toBe("create users");
+    expect(r.files[0].type).toBe("Python");
+    expect(r.files[0].tool).toBe("alembic");
+    expect(r.files[1].version).toBe("0002");
+    expect(r.files[1].description).toBe("create orders");
+  });
+
+  it("supports the alembic/versions/ layout (default `alembic init`)", async () => {
+    const dir = makeVersionsDir("alembic");
+    writeFileSync(join(dir, "0001_init.py"), "");
+    const r = await AlembicAdapter.list({ projectDir });
+    expect(r.files).toHaveLength(1);
+    expect(r.files[0].version).toBe("0001");
+  });
+
+  it("prefers migrations/ over alembic/ when both exist", async () => {
+    const migrationsDir = makeVersionsDir("migrations");
+    const alembicDir = makeVersionsDir("alembic");
+    writeFileSync(join(migrationsDir, "0001_from_migrations.py"), "");
+    writeFileSync(join(alembicDir, "0001_from_alembic.py"), "");
+    const r = await AlembicAdapter.list({ projectDir });
+    expect(r.files).toHaveLength(1);
+    expect(r.files[0].description).toBe("from migrations");
+  });
+
+  it("ignores dunder + non-.py files in versions/", async () => {
+    const dir = makeVersionsDir("migrations");
+    writeFileSync(join(dir, "0001_valid.py"), "");
+    writeFileSync(join(dir, "__init__.py"), "");
+    writeFileSync(join(dir, "README.md"), "");
+    writeFileSync(join(dir, "0001_valid.pyc"), "");
+    const r = await AlembicAdapter.list({ projectDir });
+    expect(r.files.map((f) => f.filename)).toEqual(["0001_valid.py"]);
+  });
+
+  it("sorts lexicographically by filename (matches Alembic's typical revid scheme)", async () => {
+    const dir = makeVersionsDir("migrations");
+    writeFileSync(join(dir, "0003_third.py"), "");
+    writeFileSync(join(dir, "0001_first.py"), "");
+    writeFileSync(join(dir, "0002_second.py"), "");
+    const r = await AlembicAdapter.list({ projectDir });
+    expect(r.files.map((f) => f.version)).toEqual(["0001", "0002", "0003"]);
+  });
+});
+
+describe("AlembicAdapter: registry integration", () => {
+  it("registerAdapter + getAdapter('alembic') roundtrip returns the same instance", () => {
+    registerAdapter(AlembicAdapter);
+    expect(getAdapter("alembic")).toBe(AlembicAdapter);
+  });
+});
+
+describe("AlembicAdapter: against the alembic fixture project", () => {
+  it("detect() returns true on the canonical fixture (alembic.ini + env.py + versions/)", () => {
+    expect(AlembicAdapter.detect(FIXTURE_ROOT)).toBe(true);
+  });
+
+  it("list() finds both fixture migrations in apply order", async () => {
+    const r = await AlembicAdapter.list({ projectDir: FIXTURE_ROOT });
+    expect(r.files).toHaveLength(2);
+    expect(r.files[0].version).toBe("0001");
+    expect(r.files[0].description).toBe("create users");
+    expect(r.files[1].version).toBe("0002");
+    expect(r.files[1].description).toBe("create orders");
+  });
+});

--- a/tests/bdd/fixtures/migrations-samples/README.md
+++ b/tests/bdd/fixtures/migrations-samples/README.md
@@ -1,0 +1,16 @@
+# migration-tool fixtures
+
+Tiny project layouts for the three built-in migration adapters. Adapter
+contract tests (`flyway-adapter.test.ts`, `alembic-adapter.test.ts`,
+`knex-adapter.test.ts`) copy these into a tmpdir per test and exercise
+`detect()` + `list()` against them without booting any database.
+
+`apply` and `status` are NOT exercised here. Those need a real Lakebase
+branch and live in the env-gated `*-live` BDD suites.
+
+Each sample is the minimum filesystem shape an adapter needs to claim
+the project + enumerate two migrations in apply order:
+
+- `flyway/` Maven layout, V1 + V2 SQL files
+- `alembic/` alembic.ini + migrations/versions with revision chain (0001 -> 0002)
+- `knex/` knexfile.js + ./migrations with timestamp-prefixed files

--- a/tests/bdd/fixtures/migrations-samples/alembic/alembic.ini
+++ b/tests/bdd/fixtures/migrations-samples/alembic/alembic.ini
@@ -1,0 +1,10 @@
+[alembic]
+script_location = migrations
+# sqlalchemy.url is set programmatically in env.py from DATABASE_URL env var.
+
+[loggers]
+keys = root
+
+[logger_root]
+level = WARN
+handlers =

--- a/tests/bdd/fixtures/migrations-samples/alembic/migrations/env.py
+++ b/tests/bdd/fixtures/migrations-samples/alembic/migrations/env.py
@@ -1,0 +1,6 @@
+"""Alembic env.py placeholder.
+
+Real projects wire SQLAlchemy + run_migrations_online() here. The
+fixture only needs the file to exist so the adapter's detect() picks up
+this directory as an Alembic project, not just a generic Python one.
+"""

--- a/tests/bdd/fixtures/migrations-samples/alembic/migrations/versions/0001_create_users.py
+++ b/tests/bdd/fixtures/migrations-samples/alembic/migrations/versions/0001_create_users.py
@@ -1,0 +1,26 @@
+"""Create users.
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-01-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("email", sa.Text, nullable=False, unique=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("users")

--- a/tests/bdd/fixtures/migrations-samples/alembic/migrations/versions/0002_create_orders.py
+++ b/tests/bdd/fixtures/migrations-samples/alembic/migrations/versions/0002_create_orders.py
@@ -1,0 +1,27 @@
+"""Create orders.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-01-02 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "orders",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("total_cents", sa.Integer, nullable=False),
+        sa.Column("placed_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("orders")

--- a/tests/bdd/fixtures/migrations-samples/alembic/pyproject.toml
+++ b/tests/bdd/fixtures/migrations-samples/alembic/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "alembic-fixture"
+version = "0.0.1"
+dependencies = ["alembic", "sqlalchemy", "psycopg2-binary"]

--- a/tests/bdd/fixtures/migrations-samples/flyway/pom.xml
+++ b/tests/bdd/fixtures/migrations-samples/flyway/pom.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>flyway-fixture</artifactId>
+  <version>0.0.1</version>
+</project>

--- a/tests/bdd/fixtures/migrations-samples/flyway/src/main/resources/db/migration/V1__create_users.sql
+++ b/tests/bdd/fixtures/migrations-samples/flyway/src/main/resources/db/migration/V1__create_users.sql
@@ -1,0 +1,5 @@
+create table users (
+  id serial primary key,
+  email text not null unique,
+  created_at timestamptz not null default now()
+);

--- a/tests/bdd/fixtures/migrations-samples/flyway/src/main/resources/db/migration/V2__create_orders.sql
+++ b/tests/bdd/fixtures/migrations-samples/flyway/src/main/resources/db/migration/V2__create_orders.sql
@@ -1,0 +1,6 @@
+create table orders (
+  id serial primary key,
+  user_id integer not null references users(id),
+  total_cents integer not null check (total_cents >= 0),
+  placed_at timestamptz not null default now()
+);

--- a/tests/bdd/fixtures/migrations-samples/knex/knexfile.js
+++ b/tests/bdd/fixtures/migrations-samples/knex/knexfile.js
@@ -1,0 +1,9 @@
+// Knex configuration fixture. Connection is sourced from DATABASE_URL so
+// the fixture works for live tests against any branch DSN.
+module.exports = {
+  client: "pg",
+  connection: process.env.DATABASE_URL,
+  migrations: {
+    directory: "./migrations",
+  },
+};

--- a/tests/bdd/fixtures/migrations-samples/knex/migrations/20260101000000_create_users.js
+++ b/tests/bdd/fixtures/migrations-samples/knex/migrations/20260101000000_create_users.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.createTable("users", (table) => {
+    table.increments("id").primary();
+    table.string("email", 255).notNullable().unique();
+    table.timestamp("created_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists("users");
+};

--- a/tests/bdd/fixtures/migrations-samples/knex/migrations/20260102000000_create_orders.js
+++ b/tests/bdd/fixtures/migrations-samples/knex/migrations/20260102000000_create_orders.js
@@ -1,0 +1,12 @@
+exports.up = function (knex) {
+  return knex.schema.createTable("orders", (table) => {
+    table.increments("id").primary();
+    table.integer("user_id").notNullable().references("id").inTable("users");
+    table.integer("total_cents").notNullable();
+    table.timestamp("placed_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists("orders");
+};

--- a/tests/bdd/fixtures/migrations-samples/knex/package.json
+++ b/tests/bdd/fixtures/migrations-samples/knex/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "knex-fixture",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "knex": "^3.0.0",
+    "pg": "^8.11.0"
+  }
+}

--- a/tests/bdd/knex-adapter.test.ts
+++ b/tests/bdd/knex-adapter.test.ts
@@ -1,0 +1,166 @@
+// FEIP-7210 slice 3: KnexAdapter contract tests.
+//
+// Tests assert the adapter's static surface (id, languages, detect,
+// list, optional-capability protocol) without invoking the live Knex
+// runner. apply + rollback + status are exercised against real Lakebase
+// + Knex in env-gated live tests.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  _clearRegistryForTests,
+  getAdapter,
+  registerAdapter,
+} from "../../scripts/lakebase/migration-adapter";
+import { KnexAdapter } from "../../scripts/lakebase/adapters/knex-adapter";
+
+const FIXTURE_ROOT = join(__dirname, "fixtures", "migrations-samples", "knex");
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "knex-adapter-"));
+  _clearRegistryForTests();
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  _clearRegistryForTests();
+});
+
+describe("KnexAdapter: static surface", () => {
+  it("has id='knex' + languages=['nodejs']", () => {
+    expect(KnexAdapter.id).toBe("knex");
+    expect(KnexAdapter.languages).toEqual(["nodejs"]);
+  });
+
+  it("exposes rollback (Knex supports migrate:rollback)", () => {
+    expect(typeof KnexAdapter.rollback).toBe("function");
+  });
+
+  it("omits baseline (Knex has no native baseline concept)", () => {
+    expect(typeof KnexAdapter.baseline).toBe("undefined");
+  });
+
+  it("apply + status + list are all functions", () => {
+    expect(typeof KnexAdapter.apply).toBe("function");
+    expect(typeof KnexAdapter.status).toBe("function");
+    expect(typeof KnexAdapter.list).toBe("function");
+  });
+});
+
+describe("KnexAdapter: detect", () => {
+  it("returns false for an empty project directory", () => {
+    expect(KnexAdapter.detect(projectDir)).toBe(false);
+  });
+
+  it("returns true when knexfile.js exists at the project root", () => {
+    writeFileSync(join(projectDir, "knexfile.js"), "module.exports = {};");
+    expect(KnexAdapter.detect(projectDir)).toBe(true);
+  });
+
+  it("returns true when knexfile.ts exists at the project root", () => {
+    writeFileSync(join(projectDir, "knexfile.ts"), "export default {};");
+    expect(KnexAdapter.detect(projectDir)).toBe(true);
+  });
+
+  it("returns true when knexfile.mjs exists at the project root", () => {
+    writeFileSync(join(projectDir, "knexfile.mjs"), "export default {};");
+    expect(KnexAdapter.detect(projectDir)).toBe(true);
+  });
+
+  it("returns true when knexfile.cjs exists at the project root", () => {
+    writeFileSync(join(projectDir, "knexfile.cjs"), "module.exports = {};");
+    expect(KnexAdapter.detect(projectDir)).toBe(true);
+  });
+
+  it("returns FALSE for a Node.js project with no knexfile (package.json alone is not enough)", () => {
+    writeFileSync(join(projectDir, "package.json"), '{"name":"x","version":"0.0.1"}');
+    expect(KnexAdapter.detect(projectDir)).toBe(false);
+  });
+
+  it("does NOT detect a knexfile in a subdirectory (root-only marker)", () => {
+    mkdirSync(join(projectDir, "subdir"));
+    writeFileSync(join(projectDir, "subdir", "knexfile.js"), "module.exports = {};");
+    expect(KnexAdapter.detect(projectDir)).toBe(false);
+  });
+});
+
+describe("KnexAdapter: list (pure file-scan, no DB)", () => {
+  function makeMigrationsDir(): string {
+    const dir = join(projectDir, "migrations");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  it("returns an empty array when the migrations directory does not exist", async () => {
+    const r = await KnexAdapter.list({ projectDir });
+    expect(r.files).toEqual([]);
+  });
+
+  it("enumerates timestamp-prefixed .js files with parsed version + description", async () => {
+    const dir = makeMigrationsDir();
+    writeFileSync(join(dir, "20260101000000_create_users.js"), "");
+    writeFileSync(join(dir, "20260102000000_create_orders.js"), "");
+    const r = await KnexAdapter.list({ projectDir });
+    expect(r.files).toHaveLength(2);
+    expect(r.files[0].version).toBe("20260101000000");
+    expect(r.files[0].description).toBe("create users");
+    expect(r.files[0].type).toBe("JavaScript");
+    expect(r.files[0].tool).toBe("knex");
+    expect(r.files[1].version).toBe("20260102000000");
+    expect(r.files[1].description).toBe("create orders");
+  });
+
+  it("supports .ts migrations with type='TypeScript'", async () => {
+    const dir = makeMigrationsDir();
+    writeFileSync(join(dir, "20260101000000_create_users.ts"), "");
+    const r = await KnexAdapter.list({ projectDir });
+    expect(r.files).toHaveLength(1);
+    expect(r.files[0].type).toBe("TypeScript");
+  });
+
+  it("sorts by timestamp prefix (oldest first), matching Knex apply order", async () => {
+    const dir = makeMigrationsDir();
+    writeFileSync(join(dir, "20260103000000_third.js"), "");
+    writeFileSync(join(dir, "20260101000000_first.js"), "");
+    writeFileSync(join(dir, "20260102000000_second.js"), "");
+    const r = await KnexAdapter.list({ projectDir });
+    expect(r.files.map((f) => f.description)).toEqual(["first", "second", "third"]);
+  });
+
+  it("ignores dotfiles + non-js/ts files", async () => {
+    const dir = makeMigrationsDir();
+    writeFileSync(join(dir, "20260101000000_valid.js"), "");
+    writeFileSync(join(dir, ".DS_Store"), "");
+    writeFileSync(join(dir, "README.md"), "");
+    writeFileSync(join(dir, "20260101000000_valid.js.bak"), "");
+    const r = await KnexAdapter.list({ projectDir });
+    expect(r.files.map((f) => f.filename)).toEqual(["20260101000000_valid.js"]);
+  });
+});
+
+describe("KnexAdapter: registry integration", () => {
+  it("registerAdapter + getAdapter('knex') roundtrip returns the same instance", () => {
+    registerAdapter(KnexAdapter);
+    expect(getAdapter("knex")).toBe(KnexAdapter);
+  });
+});
+
+describe("KnexAdapter: against the knex fixture project", () => {
+  it("detect() returns true on the canonical fixture (knexfile.js + migrations/)", () => {
+    expect(KnexAdapter.detect(FIXTURE_ROOT)).toBe(true);
+  });
+
+  it("list() finds both fixture migrations in apply order", async () => {
+    const r = await KnexAdapter.list({ projectDir: FIXTURE_ROOT });
+    expect(r.files).toHaveLength(2);
+    expect(r.files[0].version).toBe("20260101000000");
+    expect(r.files[0].description).toBe("create users");
+    expect(r.files[1].version).toBe("20260102000000");
+    expect(r.files[1].description).toBe("create orders");
+  });
+});

--- a/tests/bdd/knex-runner-parser.test.ts
+++ b/tests/bdd/knex-runner-parser.test.ts
@@ -1,0 +1,116 @@
+// Unit tests for the Knex runner's `migrate:status` parser. The runner
+// was a stub in the original primitives lift (FEIP-7091); slice 3 of
+// FEIP-7210 promoted it to a real shell-out implementation.
+//
+// The runner derives apply/rollback results from before/after status
+// diffs. That makes parseKnexStatus the hinge: if it breaks on a Knex
+// CLI output format change, the whole runner silently mis-reports. We
+// lock the contract here with snapshot-style fixtures of Knex 3.x output
+// so a future Knex upgrade that drifts the format trips these tests
+// before it ships.
+
+import { describe, expect, it } from "vitest";
+import { parseKnexStatus } from "../../scripts/lakebase/migrate-runners/knex";
+
+describe("parseKnexStatus", () => {
+  it("returns empty arrays for empty output", () => {
+    expect(parseKnexStatus("")).toEqual({ completed: [], pending: [] });
+  });
+
+  it("parses 'No Pending' as zero pending", () => {
+    const out = [
+      "Using environment: development",
+      "Found 1 Completed Migration file/files.",
+      "20260101000000_create_users.js",
+      "No Pending Migration files Found.",
+      "",
+    ].join("\n");
+    const r = parseKnexStatus(out);
+    expect(r.completed).toEqual(["20260101000000_create_users.js"]);
+    expect(r.pending).toEqual([]);
+  });
+
+  it("parses completed + pending sections", () => {
+    const out = [
+      "Using environment: development",
+      "Found 1 Completed Migration file/files.",
+      "20260101000000_create_users.js",
+      "Found 2 Pending Migration file/files.",
+      "20260102000000_create_orders.js",
+      "20260103000000_create_payments.js",
+      "",
+    ].join("\n");
+    const r = parseKnexStatus(out);
+    expect(r.completed).toEqual(["20260101000000_create_users.js"]);
+    expect(r.pending).toEqual([
+      "20260102000000_create_orders.js",
+      "20260103000000_create_payments.js",
+    ]);
+  });
+
+  it("parses zero completed + multiple pending (fresh DB)", () => {
+    const out = [
+      "Found 0 Completed Migration file/files.",
+      "Found 2 Pending Migration file/files.",
+      "20260101000000_create_users.js",
+      "20260102000000_create_orders.js",
+    ].join("\n");
+    const r = parseKnexStatus(out);
+    expect(r.completed).toEqual([]);
+    expect(r.pending).toEqual([
+      "20260101000000_create_users.js",
+      "20260102000000_create_orders.js",
+    ]);
+  });
+
+  it("ignores informational lines (Using environment:, blanks)", () => {
+    const out = [
+      "Using environment: development",
+      "",
+      "Found 1 Completed Migration file/files.",
+      "",
+      "20260101000000_create_users.js",
+      "",
+      "No Pending Migration files Found.",
+    ].join("\n");
+    const r = parseKnexStatus(out);
+    expect(r.completed).toEqual(["20260101000000_create_users.js"]);
+    expect(r.pending).toEqual([]);
+  });
+
+  it("recognizes .ts + .cjs + .mjs filenames in the migration list", () => {
+    const out = [
+      "Found 2 Completed Migration file/files.",
+      "20260101000000_users.ts",
+      "20260101000001_orders.cjs",
+      "Found 1 Pending Migration file/files.",
+      "20260102000000_payments.mjs",
+    ].join("\n");
+    const r = parseKnexStatus(out);
+    expect(r.completed).toEqual(["20260101000000_users.ts", "20260101000001_orders.cjs"]);
+    expect(r.pending).toEqual(["20260102000000_payments.mjs"]);
+  });
+
+  it("is case-insensitive on the section headers", () => {
+    // Knex's casing isn't normative; some CI environments shift to all-caps
+    // when piped through certain log wrappers. Be tolerant.
+    const out = [
+      "FOUND 1 COMPLETED MIGRATION FILE/FILES.",
+      "20260101000000_users.js",
+      "NO PENDING MIGRATION FILES FOUND.",
+    ].join("\n");
+    const r = parseKnexStatus(out);
+    expect(r.completed).toEqual(["20260101000000_users.js"]);
+    expect(r.pending).toEqual([]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const out =
+      "Found 1 Completed Migration file/files.\r\n" +
+      "20260101000000_users.js\r\n" +
+      "No Pending Migration files Found.\r\n";
+    const r = parseKnexStatus(out);
+    expect(r.completed).toEqual(["20260101000000_users.js"]);
+    expect(r.pending).toEqual([]);
+  });
+});

--- a/tests/bdd/migrate-live-flyway.test.ts
+++ b/tests/bdd/migrate-live-flyway.test.ts
@@ -1,4 +1,5 @@
-// Live integration test for the Flyway migrate runner (FEIP-7098).
+// Live integration test for the Flyway migrate runner (part of the
+// FEIP-7091 primitives lift).
 //
 // Provisions its own Lakebase project on the configured Databricks
 // workspace, scaffolds a minimal Maven-style Flyway project layout,

--- a/tests/bdd/migrate-live-knex.test.ts
+++ b/tests/bdd/migrate-live-knex.test.ts
@@ -1,0 +1,305 @@
+// Live integration test for the Knex migrate runner.
+// The runner was a stub in the original primitives lift (FEIP-7091);
+// slice 3 of FEIP-7210 promoted it to a real shell-out implementation
+// and this suite exercises the full lifecycle against real Lakebase.
+//
+// Provisions its own Lakebase project on the configured Databricks
+// workspace, scaffolds a Knex-style Node.js project layout (knexfile.js
+// + two migrations), installs knex + pg locally so `npx --no-install`
+// can find them, then exercises the full apply / status / rollback /
+// re-apply lifecycle against the default branch.
+//
+// Unlike Flyway, Knex supports rollback natively, so this test covers
+// the round trip: apply -> verify tables exist -> rollback --all ->
+// verify tables gone -> re-apply.
+//
+// Gating:
+//   LAKEBASE_TEST_E2E=1          must be set; the suite skips otherwise
+//   DATABRICKS_HOST              workspace URL to provision against
+//   databricks CLI               authenticated to that workspace
+//   npm + npx                    on PATH (used to install knex locally)
+//   node                         on PATH (used by npx to run knex)
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  applyMigrations,
+  listMigrations,
+  migrationStatus,
+  rollbackMigration,
+} from "../../scripts/lakebase/migrate.js";
+import { getConnection } from "../../scripts/lakebase/get-connection.js";
+import {
+  createLakebaseProject,
+  deleteLakebaseProject,
+} from "../../scripts/lakebase/lakebase-project.js";
+import { getDefaultBranch } from "../../scripts/lakebase/branch-utils.js";
+
+const E2E = process.env.LAKEBASE_TEST_E2E === "1";
+const DATABRICKS_HOST = process.env.DATABRICKS_HOST ?? "";
+
+function hasCmd(cmd: string): boolean {
+  const res = spawnSync(cmd, ["--version"], { stdio: "ignore" });
+  return res.status === 0;
+}
+
+const DATABRICKS_AVAILABLE = E2E ? hasCmd("databricks") : false;
+const NPM_AVAILABLE = E2E ? hasCmd("npm") : false;
+const NPX_AVAILABLE = E2E ? hasCmd("npx") : false;
+const NODE_AVAILABLE = E2E ? hasCmd("node") : false;
+
+const RUN_SUITE =
+  E2E && DATABRICKS_HOST && DATABRICKS_AVAILABLE && NPM_AVAILABLE && NPX_AVAILABLE && NODE_AVAILABLE;
+
+describe.skipIf(!RUN_SUITE)(
+  "migrate live (knex against a freshly-provisioned Lakebase project)",
+  () => {
+    let projectDir: string;
+    let projectId: string;
+    let branchName: string;
+    const usersTable = `users_${Date.now()}`;
+    const ordersTable = `orders_${Date.now()}`;
+
+    beforeAll(async () => {
+      projectId = `migrate-7099-${Date.now()}`;
+      projectDir = fs.mkdtempSync(path.join(os.tmpdir(), `migrate-knex-live-${projectId}-`));
+      scaffoldKnexProject(projectDir, usersTable, ordersTable);
+
+      console.log(`  [setup] installing knex + pg in ${projectDir} (this can take ~30s)`);
+      const install = spawnSync("npm", ["install", "--silent", "--no-audit", "--no-fund", "knex@^3", "pg@^8"], {
+        cwd: projectDir,
+        stdio: "inherit",
+      });
+      if (install.status !== 0) {
+        throw new Error(`npm install failed with code ${install.status}`);
+      }
+
+      console.log(`  [setup] creating Lakebase project ${projectId} on ${DATABRICKS_HOST}`);
+      await createLakebaseProject({ projectId, host: DATABRICKS_HOST });
+
+      const dflt = await getDefaultBranch({ instance: projectId, host: DATABRICKS_HOST });
+      if (!dflt) {
+        throw new Error(
+          `Project ${projectId} has no default branch after creation. Check workspace + permissions.`
+        );
+      }
+      const fullName = dflt.name ?? "";
+      branchName = fullName.split("/branches/").pop() ?? dflt.uid;
+      console.log(`  [setup] default branch: ${branchName}`);
+    }, 240_000);
+
+    afterAll(async () => {
+      if (projectId) {
+        try {
+          const pool = await getConnection({
+            output: "pool",
+            instance: projectId,
+            branch: branchName,
+          });
+          await pool.query(`DROP TABLE IF EXISTS ${ordersTable}`);
+          await pool.query(`DROP TABLE IF EXISTS ${usersTable}`);
+          await pool.query(`DROP TABLE IF EXISTS knex_migrations`);
+          await pool.query(`DROP TABLE IF EXISTS knex_migrations_lock`);
+          await pool.end();
+        } catch {
+          // Best effort; project delete below removes everything anyway.
+        }
+        for (let attempt = 1; attempt <= 3; attempt++) {
+          try {
+            await deleteLakebaseProject({ projectId, host: DATABRICKS_HOST });
+            console.log(`  [teardown] deleted Lakebase project ${projectId}`);
+            break;
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (/not.?found/i.test(msg)) break;
+            if (attempt === 3) {
+              console.error(`  [teardown] FAILED to delete ${projectId}: ${msg}`);
+              console.error(
+                `  [teardown] clean up manually: databricks postgres delete-project ${projectId}`
+              );
+            } else {
+              await new Promise((r) => setTimeout(r, 5_000 * attempt));
+            }
+          }
+        }
+      }
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }, 240_000);
+
+    it("listMigrations enumerates both scaffolded migrations in apply order", () => {
+      const files = listMigrations({ projectDir });
+      expect(files).toHaveLength(2);
+      expect(files[0].tool).toBe("knex");
+      expect(files[0].description.toLowerCase()).toContain("users");
+      expect(files[1].description.toLowerCase()).toContain("orders");
+    });
+
+    it("migrationStatus reports current=undefined and two pending before apply", async () => {
+      const status = await migrationStatus({
+        instance: projectId,
+        branch: branchName,
+        projectDir,
+      });
+      expect(status.tool).toBe("knex");
+      expect(status.current).toBeUndefined();
+      expect(status.pending).toHaveLength(2);
+    }, 60_000);
+
+    it("applyMigrations applies both migrations; tables exist in DB", async () => {
+      const result = await applyMigrations({
+        instance: projectId,
+        branch: branchName,
+        projectDir,
+      });
+      expect(result.tool).toBe("knex");
+      expect(result.alreadyAtLatest).toBe(false);
+      expect(result.applied).toHaveLength(2);
+
+      const pool = await getConnection({
+        output: "pool",
+        instance: projectId,
+        branch: branchName,
+      });
+      try {
+        const u = await pool.query(`SELECT to_regclass($1) AS oid`, [usersTable]);
+        expect(u.rows[0].oid).not.toBeNull();
+        const o = await pool.query(`SELECT to_regclass($1) AS oid`, [ordersTable]);
+        expect(o.rows[0].oid).not.toBeNull();
+      } finally {
+        await pool.end();
+      }
+    }, 180_000);
+
+    it("migrationStatus reports a current version and no pending after apply", async () => {
+      const status = await migrationStatus({
+        instance: projectId,
+        branch: branchName,
+        projectDir,
+      });
+      expect(status.current).toBeDefined();
+      expect(status.pending).toHaveLength(0);
+    }, 60_000);
+
+    it("applyMigrations is idempotent: second call reports alreadyAtLatest", async () => {
+      const result = await applyMigrations({
+        instance: projectId,
+        branch: branchName,
+        projectDir,
+      });
+      expect(result.alreadyAtLatest).toBe(true);
+      expect(result.applied).toEqual([]);
+    }, 60_000);
+
+    it("rollbackMigration with target='all' rolls back both migrations; tables dropped", async () => {
+      const result = await rollbackMigration({
+        instance: projectId,
+        branch: branchName,
+        projectDir,
+        target: "all",
+      });
+      expect(result.tool).toBe("knex");
+      expect(result.rolledBack).toHaveLength(2);
+
+      const pool = await getConnection({
+        output: "pool",
+        instance: projectId,
+        branch: branchName,
+      });
+      try {
+        const u = await pool.query(`SELECT to_regclass($1) AS oid`, [usersTable]);
+        expect(u.rows[0].oid).toBeNull();
+        const o = await pool.query(`SELECT to_regclass($1) AS oid`, [ordersTable]);
+        expect(o.rows[0].oid).toBeNull();
+      } finally {
+        await pool.end();
+      }
+    }, 180_000);
+
+    it("re-apply after rollback restores both tables (round-trip lifecycle works)", async () => {
+      const result = await applyMigrations({
+        instance: projectId,
+        branch: branchName,
+        projectDir,
+      });
+      expect(result.alreadyAtLatest).toBe(false);
+      expect(result.applied).toHaveLength(2);
+
+      const pool = await getConnection({
+        output: "pool",
+        instance: projectId,
+        branch: branchName,
+      });
+      try {
+        const u = await pool.query(`SELECT to_regclass($1) AS oid`, [usersTable]);
+        expect(u.rows[0].oid).not.toBeNull();
+        const o = await pool.query(`SELECT to_regclass($1) AS oid`, [ordersTable]);
+        expect(o.rows[0].oid).not.toBeNull();
+      } finally {
+        await pool.end();
+      }
+    }, 180_000);
+  }
+);
+
+/**
+ * Scaffold a Knex-compatible project: package.json (so detectLanguage()
+ * returns "nodejs"), knexfile.js that reads DATABASE_URL, and two
+ * migrations under ./migrations that create the named users + orders
+ * tables. The Lakebase project name is timestamped so concurrent runs
+ * don't collide on table names.
+ */
+function scaffoldKnexProject(dir: string, usersTable: string, ordersTable: string): void {
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "knex-live-fixture", version: "0.0.1", private: true }, null, 2) + "\n"
+  );
+
+  fs.writeFileSync(
+    path.join(dir, "knexfile.js"),
+    `module.exports = {
+  client: "pg",
+  connection: process.env.DATABASE_URL,
+  migrations: { directory: "./migrations" },
+};
+`
+  );
+
+  const migrationsDir = path.join(dir, "migrations");
+  fs.mkdirSync(migrationsDir, { recursive: true });
+
+  // Knex apply order is timestamp-ascending. Stamp the two files apart
+  // so they sort deterministically even when generated in the same ms.
+  fs.writeFileSync(
+    path.join(migrationsDir, `20260101000000_create_${usersTable}.js`),
+    `exports.up = function (knex) {
+  return knex.schema.createTable("${usersTable}", (t) => {
+    t.increments("id").primary();
+    t.string("email", 255).notNullable().unique();
+    t.timestamp("created_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+  });
+};
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists("${usersTable}");
+};
+`
+  );
+
+  fs.writeFileSync(
+    path.join(migrationsDir, `20260102000000_create_${ordersTable}.js`),
+    `exports.up = function (knex) {
+  return knex.schema.createTable("${ordersTable}", (t) => {
+    t.increments("id").primary();
+    t.integer("user_id").notNullable().references("id").inTable("${usersTable}");
+    t.integer("total_cents").notNullable();
+    t.timestamp("placed_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+  });
+};
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists("${ordersTable}");
+};
+`
+  );
+}

--- a/tests/bdd/migrate.test.ts
+++ b/tests/bdd/migrate.test.ts
@@ -227,10 +227,14 @@ describe("listMigrations: language override", () => {
   });
 });
 
-describe("flyway rollback + knex apply/rollback/status: error paths", () => {
+describe("flyway rollback + knex apply: error paths", () => {
   // Flyway: apply + status are implemented (live test covers them).
   // Rollback intentionally throws because Flyway Community Edition has
-  // no `undo`. Knex primitives are stubs pending FEIP-7099.
+  // no `undo`.
+  // Knex: runner is fully implemented as of FEIP-7210 slice 3 (the
+  // original FEIP-7091 primitives lift shipped it as a stub). Live
+  // behavior is exercised by env-gated suites; here we only lock the
+  // pre-shell-out validation (no knexfile at root).
 
   it("flyway rollback throws with the Flyway Community caveat", async () => {
     const dir = mkTempDir();
@@ -244,12 +248,12 @@ describe("flyway rollback + knex apply/rollback/status: error paths", () => {
     }
   });
 
-  it("knex apply throws MigrationError with FEIP-7099 pointer", async () => {
+  it("knex apply throws MigrationError when no knexfile is present", async () => {
     const dir = mkTempDir();
     fs.writeFileSync(path.join(dir, "package.json"), "{}");
     try {
       const { applyKnex } = await import("../../scripts/lakebase/migrate-runners/knex.js");
-      await expect(applyKnex({ projectDir: dir, dsn: "x" })).rejects.toThrow(/FEIP-7099/);
+      await expect(applyKnex({ projectDir: dir, dsn: "x" })).rejects.toThrow(/No knexfile found/);
     } finally {
       rm(dir);
     }

--- a/tests/mcp-server/live-tools.test.ts
+++ b/tests/mcp-server/live-tools.test.ts
@@ -183,10 +183,10 @@ describe.skipIf(!RUN_SUITE)(
       }
     }, 180_000);
 
-    it("tools/list advertises all 25 expected tools", async () => {
+    it("tools/list advertises all 27 expected tools", async () => {
       const resp = await client.request("tools/list", {});
       const tools = (resp.result as { tools: { name: string }[] }).tools;
-      expect(tools.length).toBe(26);
+      expect(tools.length).toBe(27);
       const names = tools.map((t) => t.name).sort();
       expect(names).toContain("lakebase_branch_list");
       expect(names).toContain("lakebase_branch_show");

--- a/tools/openai-foundry/lakebase-app-dev-kit.tools.json
+++ b/tools/openai-foundry/lakebase-app-dev-kit.tools.json
@@ -176,7 +176,7 @@
       "type": "function",
       "function": {
         "name": "lakebase_apply_migrations",
-        "description": "Apply pending forward migrations against a Lakebase branch. Python/Alembic supported today; Java+Kotlin/Flyway (FEIP-7098) and Node/Knex (FEIP-7099) error with a clear pointer until those runners land.",
+        "description": "Apply pending forward migrations against a Lakebase branch. Supports Python/Alembic, Java+Kotlin/Flyway, and Node/Knex. Auto-detects the language from project markers (alembic.ini, pom.xml, knexfile.{js,ts}).",
         "parameters": {
           "type": "object",
           "properties": {
@@ -223,7 +223,7 @@
       "type": "function",
       "function": {
         "name": "lakebase_rollback_migration",
-        "description": "Roll back applied migrations on a Lakebase branch down to a target version. Python/Alembic only today (Flyway Community does not support rollback; Node/Knex via FEIP-7099). For Alembic, 'target' can be a revision id or a relative step like '-1'.",
+        "description": "Roll back applied migrations on a Lakebase branch down to a target version. Supported for Python/Alembic + Node/Knex; NOT supported for Java+Kotlin/Flyway (Flyway Community Edition has no `undo`). For Alembic, 'target' can be a revision id or a relative step like '-1'. For Knex, use 'all' or '0' for full rollback; other values roll back the last batch.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,12 @@ export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts", "tests/**/*.test.js"],
     exclude: ["templates/**", "node_modules/**", "dist/**"],
+    // 5s default is too tight for git-fixture tests on a loaded system
+    // (pre-push hook running tests right after typecheck); they spawn
+    // real git subprocesses against tempdir repos. Bump to 10s so a CPU-
+    // contended run doesn't flake the gate. Per-test overrides for the
+    // truly long ones (migrate-live, deploy-end-to-end, etc.) stay in
+    // place via their `it("...", fn, 180_000)` annotations.
+    testTimeout: 10_000,
   },
 });


### PR DESCRIPTION
## Summary

Slice 3 of the schema-migrate adapter pattern (ADR-0005). Lands the Alembic + Knex adapters and promotes the Knex runner from a stub to a full implementation. Closes the contract-level part of FEIP-7210; slices 4 (CLI rename + MCP tool) + 5+ (doctor checks, custom adapter loading) remain.

### Adapters
- **`AlembicAdapter`** wraps `applyAlembic` / `rollbackAlembic` / `statusAlembic`. `detect` = `alembic.ini` OR `migrations/env.py` OR `alembic/env.py`. `rollback` exposed; `baseline` omitted (deferred).
- **`KnexAdapter`** wraps the now-real Knex runner. `detect` = `knexfile.{js,ts,mjs,cjs}`. `rollback` exposed; `baseline` permanently omitted (Knex has no native baseline; absence advertises that via the optional-capability protocol).

### Knex runner promotion
- `scripts/lakebase/migrate-runners/knex.ts` was a stub. Now shells out to `npx --no-install knex --knexfile <path>` and derives results via before/after `migrate:status` state diff, mirroring `alembic.ts`. The parser (`parseKnexStatus`) is exported and locked by 8 unit tests against Knex 3.x output (typical / edge / casing / CRLF).
- Closes the stub deferral inside FEIP-7091 (no dedicated ticket; the original `FEIP-7099` reference in the stub was a typo for an unrelated ticket; sweep below corrects this).

### Tests
- AlembicAdapter: 18 contract tests + fixture exercise
- KnexAdapter: 19 contract tests + fixture exercise
- Knex runner parser: 8 unit tests
- `migrate-live-knex.test.ts`: 7 live scenarios (list -> status -> apply -> idempotent apply -> rollback --all -> re-apply). Validated 7/7 green on a real Lakebase project.
- Fixture projects at `tests/bdd/fixtures/migrations-samples/{flyway,alembic,knex}/` (committed) so adapter tests exercise detect + list against realistic minimal layouts in addition to inline tempdirs.

### Correctness sweep (FEIP-number drift)
The original Knex stub cited `FEIP-7099` (typo for an unrelated test-helper cleanup ticket); the original Flyway runner header cited `FEIP-7098` (typo for an unrelated tier-discovery ticket). Neither ever pointed at a real follow-up. Sweep across:
- `migrate.ts` header, `migrate.cli.ts` help text, `apps/mcp-server/tools.ts` + `tools/openai-foundry/...tools.json` apply + rollback descriptions, `migrate-runners/{flyway,knex}.ts` headers, test header comments, `skills/lakebase-release-workflows/SKILL.md` compat line
- All now reference `FEIP-7091` (the real parent migrate-primitives ticket) or `FEIP-7210` slice 3 (Knex completion specifically)
- Removed stale "Flyway / Knex error with a clear pointer until those runners land" language; both runners are real

### Other fixes
- `tests/mcp-server/live-tools.test.ts`: `tools/list` count assertion 26 -> 27 (drift fix for an unrelated tool added in a prior PR)
- `vitest.config.ts`: bumped default `testTimeout` 5s -> 10s. Git-fixture tests timed out flakily under pre-push load (spawning real git subprocesses against tempdir repos). Per-test overrides for the truly long ones (migrate-live, deploy-end-to-end) stay in place
- `scripts/run-live-tests.sh`: header now points at `run-all-live-tests.sh` as the comprehensive entry point; default migrate mode now runs `migrate-live-knex.test.ts` alongside `migrate-live` + `migrate-live-flyway`
- `scripts/run-all-live-tests.sh`: docs updated for the new migrate-live-knex suite (self-provisions via `npm install` in beforeAll; no script-level prep needed)
- `CONTRIBUTING.md`: prerequisites + migrate-live table updated for Knex

### ADR + JIRA
- `ADR-0005` updated with full "Implementation notes (2026-06-01)" section covering slices 1-3, detection tightening, open-question resolutions, and remaining work (separate repo, not in this PR)
- `FEIP-7210` updated with two comments: slice 3 progress + FEIP-number correction

## Test plan
- [x] Hermetic suite: 844 passed, 0 failed (vitest run with bumped 10s timeout)
- [x] `npm run typecheck`: clean
- [x] Live `migrate-live-knex.test.ts` against real Lakebase: 7/7 green in 52s
- [x] Live `migrate-live-flyway.test.ts`: 4/4 green (no regression)
- [x] Full live suite via prior unlocked run: 951/952 (the 1 skip is `peer-dep`, gated on `PEER_DEP_INTEGRATION` which `run-all-live-tests.sh` sets externally)

This pull request and its description were written by Isaac.