### PR TITLE
fix(scripts): drop leftover FEATURE_TTL_DAYS validation from run-all-live-tests.sh

### DIFF
--- a/scripts/run-all-live-tests.sh
+++ b/scripts/run-all-live-tests.sh
@@ -139,11 +139,6 @@ if ! [[ "$GRACE_SECONDS" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
-if [[ -n "$FEATURE_TTL_DAYS" ]] && ! [[ "$FEATURE_TTL_DAYS" =~ ^[0-9]+$ ]]; then
-  red "--feature-ttl-days must be a positive integer (got: $FEATURE_TTL_DAYS)"
-  exit 2
-fi
-
 if [[ -z "$PROFILE" ]]; then
   red "--profile is required."
   red "See $0 --help"


### PR DESCRIPTION
## Summary

Follow-up to PR #92. That PR removed the `--feature-ttl-days` flag and its variable declaration, but missed a validation block 30 lines later that still referenced `$FEATURE_TTL_DAYS`. Under `set -u`, this errors immediately:

```
scripts/run-all-live-tests.sh: line 142: FEATURE_TTL_DAYS: unbound variable
```

The validation has no caller post-#92. Removing it.

## Test plan
- [x] `bash -n scripts/run-all-live-tests.sh` (shell syntax clean)
- [x] `bash scripts/run-all-live-tests.sh --profile <name> --teardown --no-prompt` no longer hits the unbound-variable error

This pull request and its description were written by Isaac.