### PR TITLE
feat(lakebase): waitForBranchAuthReady() + wire into schema-migrate-live-knex

### DIFF
--- a/scripts/lakebase/get-connection.ts
+++ b/scripts/lakebase/get-connection.ts
@@ -15,7 +15,7 @@
 
 import { execFileSync } from "node:child_process";
 import { createLakebasePool } from "@databricks/lakebase";
-import type { Pool } from "pg";
+import { Client, type Pool } from "pg";
 import { resolveBranchId } from "./branch-utils.js";
 import { DEFAULT_DATABASE, DEFAULT_ENDPOINT, POSTGRES_PORT } from "./constants.js";
 import { KIT_TIMEOUTS } from "./kit-config.js";
@@ -195,4 +195,102 @@ function dbcli(args: string[]): string {
       `databricks ${args.join(" ")} failed: ${e.message}${stderr ? `\nstderr: ${stderr.trim()}` : ""}`
     );
   }
+}
+
+/**
+ * Wait until a freshly-provisioned Lakebase branch will accept a
+ * Postgres connection with credentials minted via `getConnection`.
+ *
+ * Use this after `createLakebaseProject` / `createBranch` and before
+ * handing a DSN to a non-retrying Postgres client (notably the `pg`
+ * Node driver, which surfaces transient "External authorization
+ * failed" errors as terminal during the IAM-role-propagation window).
+ * JDBC-based drivers (Flyway, Liquibase) generally retry internally so
+ * they don't hit this problem; the `pg`-based path (Knex, custom
+ * Node.js consumers, `getConnection({output: "pool"})`) does.
+ *
+ * Strategy: mint a fresh credential, open a probe `pg.Client`,
+ * `SELECT 1`, close. If the connect or query fails with an
+ * auth-failure error, wait + mint again + retry. The credential is
+ * short-lived so a new mint per attempt is required (the OLD token
+ * may have outlived the retry window).
+ *
+ * Times out after `timeoutMs` (default 60s) with the last error.
+ */
+export interface WaitForBranchAuthReadyArgs extends GetConnectionArgs {
+  /** Total budget. Defaults to 60_000 ms. */
+  timeoutMs?: number;
+  /** Initial backoff between probes. Defaults to 2_000 ms. */
+  initialBackoffMs?: number;
+}
+
+export async function waitForBranchAuthReady(
+  args: WaitForBranchAuthReadyArgs
+): Promise<void> {
+  const timeoutMs = args.timeoutMs ?? 60_000;
+  const initialBackoffMs = args.initialBackoffMs ?? 2_000;
+  const deadline = Date.now() + timeoutMs;
+  let backoffMs = initialBackoffMs;
+  let lastErr: unknown;
+  let attempt = 0;
+
+  while (Date.now() < deadline) {
+    attempt++;
+    let client: Client | undefined;
+    try {
+      const dsn = await getConnection({
+        instance: args.instance,
+        branch: args.branch,
+        endpointName: args.endpointName,
+        database: args.database,
+        output: "dsn",
+      });
+      client = new Client({ connectionString: dsn.url });
+      await client.connect();
+      await client.query("SELECT 1");
+      await client.end();
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (client) {
+        try {
+          await client.end();
+        } catch {
+          // best-effort
+        }
+      }
+      if (!isTransientAuthFailure(err)) {
+        // Not an auth race: surface immediately so the caller doesn't
+        // burn the entire budget waiting on a real config error.
+        throw err;
+      }
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      const wait = Math.min(backoffMs, remaining);
+      await new Promise((r) => setTimeout(r, wait));
+      // Exponential up to 8s ceiling; keeps the worst case to a small
+      // number of probes inside the 60s budget.
+      backoffMs = Math.min(backoffMs * 2, 8_000);
+    }
+  }
+  throw new Error(
+    `waitForBranchAuthReady: timed out after ${timeoutMs}ms (${attempt} attempts) ` +
+      `against projects/${args.instance}/branches/${args.branch}. ` +
+      `Last error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`
+  );
+}
+
+/**
+ * Recognize the auth-failure error shapes that justify a retry. We
+ * match conservatively on substring rather than exact code because
+ * Postgres surfaces this as a SQLSTATE 28000 / 28P01 family with
+ * different message text across server versions.
+ */
+function isTransientAuthFailure(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    /external authorization failed/i.test(msg) ||
+    /password authentication failed/i.test(msg) ||
+    /authentication failed/i.test(msg)
+  );
 }

--- a/tests/bdd/schema-migrate-live-knex.test.ts
+++ b/tests/bdd/schema-migrate-live-knex.test.ts
@@ -31,7 +31,7 @@ import {
   schemaMigrationStatus,
   rollbackSchemaMigration,
 } from "../../scripts/lakebase/schema-migrate.js";
-import { getConnection } from "../../scripts/lakebase/get-connection.js";
+import { getConnection, waitForBranchAuthReady } from "../../scripts/lakebase/get-connection.js";
 import {
   createLakebaseProject,
   deleteLakebaseProject,
@@ -89,6 +89,15 @@ describe.skipIf(!RUN_SUITE)(
       const fullName = dflt.name ?? "";
       branchName = fullName.split("/branches/").pop() ?? dflt.uid;
       console.log(`  [setup] default branch: ${branchName}`);
+
+      // Wait for the freshly-provisioned branch's IAM role to propagate
+      // before letting the `pg`-based Knex CLI try to authenticate. The
+      // `pg` driver surfaces transient "External authorization failed"
+      // errors as terminal; JDBC retries internally, hence Flyway never
+      // sees this. See scripts/lakebase/get-connection.ts.
+      console.log(`  [setup] waiting for branch auth readiness on ${branchName}`);
+      await waitForBranchAuthReady({ instance: projectId, branch: branchName });
+      console.log(`  [setup] branch auth ready`);
     }, 240_000);
 
     afterAll(async () => {


### PR DESCRIPTION
## Summary

The full live suite intermittently flakes on the Knex test's first DB-touching call with `External authorization failed`. Isolated runs pass 7/7; the failure only manifests inside the full suite, against a freshly-provisioned project.

**Root cause:** Lakebase's external-auth subsystem needs a moment after `create-project` before the workspace's IAM role mapping propagates to the new Postgres endpoint. JDBC-based drivers (Flyway, Liquibase) retry transparently inside their connect; the `pg` Node driver (Knex, custom Node consumers) surfaces the transient auth error as terminal.

## Two pieces

1. **Kit-level `waitForBranchAuthReady`** in `scripts/lakebase/get-connection.ts`. Mints a fresh credential, opens a `pg.Client` probe, runs `SELECT 1`, closes. On `External authorization failed` / `password authentication failed` / `authentication failed`, waits with exponential backoff (2s -> 8s ceiling) and re-mints. Configurable `timeoutMs` (default 60s) + `initialBackoffMs` (default 2s). Surfaces non-auth errors immediately so config bugs aren't masked. Exported for any caller.
2. **Call from `tests/bdd/schema-migrate-live-knex.test.ts`** in `beforeAll` after `getDefaultBranch`. Guarantees the branch is ready before the Knex suite touches it.

## Test plan

- [x] `npm run typecheck`: clean
- [x] `npm test`: 844 passed, 0 failed (no live tests touched)
- [ ] Full live suite via `run-all-live-tests.sh` post-merge: expect 952/0/0

This pull request and its description were written by Isaac.