### PR TITLE
chore(release): v0.3.0-alpha.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.33",
+  "version": "0.3.0-alpha.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.33",
+      "version": "0.3.0-alpha.34",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.33",
+  "version": "0.3.0-alpha.34",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## Highlights since alpha.33

- **FEIP-7210 closed**: schema-migration adapter pattern (Flyway / Alembic / Knex), `lakebase-schema-migrate` bin rename, Knex runner promotion from stub to full impl. ADR-0005 moved from `proposed` to `accepted`. (#89, #90, #91, #95)
- **Schema-prefix audit**: every schema-migration identifier in the kit's public API now carries the `Schema` prefix (#96).
- **`waitForBranchAuthReady()`** kit primitive: handles the transient "External authorization failed" window on freshly-provisioned Lakebase projects for non-retrying Postgres drivers (#97).
- **Config refactor**: collapsed `run-all-live-tests.sh` to two surfaces; renamed test-config files; added `.env.kit.example` for kit users (#92, #93, #94).

## Validation

- Hermetic suite: 844 passed / 0 failed
- Full live suite via `run-all-live-tests.sh --profile fevm-serverless-stable-ecparr --teardown --no-prompt`: **952 passed / 0 failed / 0 skipped** (109/109 test files)

This pull request and its description were written by Isaac.