### PR TITLE
feat(paired-branch): auto-discover tiers from branch list (FEIP-7098)

### DIFF
--- a/scripts/lakebase/branch-utils.ts
+++ b/scripts/lakebase/branch-utils.ts
@@ -161,6 +161,34 @@ export async function getDefaultBranch(opts: BranchLookupOpts): Promise<Lakebase
 }
 
 /**
+ * Tier check: returns true iff `name` matches a non-default Lakebase branch
+ * by exact branchId. Mirrors the post-checkout hook's auto-discovery model
+ * (see templates/project/common/scripts/post-checkout.sh:252-279): the
+ * architect cuts long-running tiers (staging, uat, perf, ...) deliberately
+ * via createLongRunningBranch, and a git checkout to a name matching any
+ * such non-default Lakebase branch is a "tier checkout" that pairs the
+ * existing branch rather than creating a feature branch.
+ *
+ * Pure utility – callers supply the branch list. This keeps the helper
+ * sync, mockable, and cheap to call multiple times against the same
+ * cached list during a single workflow.
+ */
+export function isTier(name: string, branches: LakebaseBranchInfo[]): boolean {
+  if (!name) { return false; }
+  return branches.some((b) => !b.isDefault && b.nameLeaf === name);
+}
+
+/**
+ * Returns the names (branchId leaves) of every non-default Lakebase branch
+ * in the project. The "long-running tier" set the architect has cut. Useful
+ * for surfaces that need to enumerate tiers (e.g. extension UI grouping)
+ * rather than just test membership via {@link isTier}.
+ */
+export function tierBranchNames(branches: LakebaseBranchInfo[]): string[] {
+  return branches.filter((b) => !b.isDefault).map((b) => b.nameLeaf as string);
+}
+
+/**
  * Resolve a branch reference to its full resource name (projects/.../branches/...).
  * Returns undefined when the branch can't be found.
  */

--- a/scripts/lakebase/paired-branch.ts
+++ b/scripts/lakebase/paired-branch.ts
@@ -19,7 +19,7 @@ import * as path from "node:path";
 import { execFileSync } from "node:child_process";
 import { createBranch, waitForBranchReady } from "./branch-create.js";
 import { deleteBranch } from "./branch-delete.js";
-import { getBranchByName, getDefaultBranch } from "./branch-utils.js";
+import { getBranchByName, isTier, listBranches } from "./branch-utils.js";
 import type { LakebaseBranchInfo } from "./branch-utils.js";
 import {
   endpointPath,
@@ -406,7 +406,7 @@ export async function syncEnvToCurrentBranch(args: SyncEnvArgs): Promise<SyncEnv
 
 // ─── checkoutPaired ────────────────────────────────────────────
 
-export type CheckoutMode = "trunk" | "staging" | "feature" | "feature-created";
+export type CheckoutMode = "trunk" | "tier" | "feature" | "feature-created";
 
 export interface CheckoutPairedArgs {
   /** Project directory (must contain .env). */
@@ -421,12 +421,6 @@ export interface CheckoutPairedArgs {
    * the post-checkout hook. Default: no alias – uses main/master.
    */
   trunkAlias?: string;
-  /**
-   * Override: when the current git branch equals this name, pair with the
-   * Lakebase `staging` branch (which must already exist; this function does
-   * NOT auto-create it). Mirrors LAKEBASE_STAGING_BRANCH.
-   */
-  stagingAlias?: string;
   /**
    * Pinned base branch for feature mode. Mirrors LAKEBASE_BASE_BRANCH. When
    * set, new feature branches always fork from this branch instead of using
@@ -474,12 +468,17 @@ export interface CheckoutPairedResult {
  * developers running `git checkout` in a terminal, the hook handles this
  * automatically – calling checkoutPaired then is redundant.
  *
- * Mirrors the hook's three-mode logic and parent fallback chain:
+ * Mirrors the hook's three-mode logic and parent fallback chain. Tier
+ * discovery is auto from the Lakebase branch list – no per-tier alias
+ * is needed (this is the post-alpha.9 model, see FEIP-7098):
  *
  *   1. **trunk** – current branch == `trunkAlias` (or main/master if no
  *      alias). Pairs .env with the project's default Lakebase branch.
- *   2. **staging** – current branch == `stagingAlias`. Pairs .env with the
- *      Lakebase `staging` branch IF it already exists; does NOT auto-create.
+ *   2. **tier** – current branch name matches a non-default Lakebase branch
+ *      by exact branchId (any long-running tier the architect has cut:
+ *      staging / uat / perf / dev / ...). Pairs .env with that branch;
+ *      does NOT auto-create. Tiers must be bootstrapped deliberately via
+ *      {@link createLongRunningBranch}.
  *   3. **feature** – anything else. Auto-creates a Lakebase branch with the
  *      same sanitized name, using parent precedence:
  *        a. `baseBranch` arg (pinned 3-tier base)
@@ -519,45 +518,40 @@ export async function checkoutPaired(args: CheckoutPairedArgs): Promise<Checkout
   const previousBranch =
     args.previousBranch ?? readEnvVar(envPath, "LAKEBASE_BRANCH_ID") ?? "";
 
-  // 4. Determine mode
+  // 4. Determine mode. One listBranches() call powers both the default-branch
+  // resolution AND the tier check, mirroring the hook's "pull the branch
+  // list once" pattern (post-checkout.sh:198-221). Auto-discovers any
+  // long-running tier the architect has cut – no per-tier alias is needed.
   const trunkAlias = args.trunkAlias?.trim();
-  const stagingAlias = args.stagingAlias?.trim();
   let mode: CheckoutMode = "feature";
   let lakebaseBranch = branchId;
 
   const isTrunkAlias = trunkAlias && rawBranch === trunkAlias;
   const isMainOrMaster = !trunkAlias && (rawBranch === "main" || rawBranch === "master");
-  const isStagingAlias = stagingAlias && rawBranch === stagingAlias;
+
+  const lakebaseBranches = await listBranches({ instance });
+  // Match the hook's tier-discovery rule: a git branch maps to a tier when
+  // its raw name (NOT the sanitized form) exactly matches a non-default
+  // Lakebase branch. The hook compares against $BRANCH directly; we do the
+  // same so a `feature/x` git branch never accidentally pairs with a tier
+  // just because its sanitized form happens to collide.
+  const tierMatch = isTier(rawBranch, lakebaseBranches);
 
   if (isTrunkAlias || isMainOrMaster) {
     mode = "trunk";
-    const def = await getDefaultBranch({ instance });
+    const def = lakebaseBranches.find((b) => b.isDefault);
     if (!def) {
       throw new Error(
         `Could not resolve default Lakebase branch for instance "${instance}"`
       );
     }
     lakebaseBranch = def.name.split("/branches/").pop() ?? def.uid;
-  } else if (isStagingAlias) {
-    mode = "staging";
-    const staging = await getBranchByName("staging", { instance });
-    if (!staging) {
-      warnings.push(
-        `On git branch "${rawBranch}" (staging alias) but Lakebase "staging" branch does not exist. ` +
-          `It must be bootstrapped deliberately – this function does not auto-create it.`
-      );
-      // Don't update .env when staging is missing – return a hollow result
-      return {
-        branchId,
-        mode,
-        matchedLakebaseBranch: "staging",
-        endpointHost: "",
-        databaseUrl: "",
-        envUpdated: false,
-        warnings,
-      };
-    }
-    lakebaseBranch = "staging";
+  } else if (tierMatch) {
+    mode = "tier";
+    // rawBranch is guaranteed by isTier() to match an existing non-default
+    // Lakebase branch by exact branchId. No auto-create branch; tiers must
+    // be cut deliberately via createLongRunningBranch.
+    lakebaseBranch = rawBranch;
   } else {
     // Feature mode – find or create the Lakebase branch with parent fallback
     let existing = await getBranchByName(branchId, { instance });

--- a/tests/bdd/checkout-paired.test.ts
+++ b/tests/bdd/checkout-paired.test.ts
@@ -41,7 +41,7 @@ describe("checkoutPaired – shape", () => {
   });
 
   it("CheckoutMode is the documented union", () => {
-    const modes: CheckoutMode[] = ["trunk", "staging", "feature", "feature-created"];
+    const modes: CheckoutMode[] = ["trunk", "tier", "feature", "feature-created"];
     expect(modes.length).toBe(4);
   });
 
@@ -90,8 +90,9 @@ describe("checkoutPaired – input validation", () => {
 
 describe.skipIf(!live)("checkoutPaired – destructive live E2E", () => {
   // Live E2E here only covers the FEATURE mode against an existing test branch.
-  // Trunk and staging modes need workspace-specific aliases configured; skip
-  // those at the live tier and rely on integration tests in the extension.
+  // Trunk and tier modes depend on the workspace's Lakebase branch list state
+  // (which tiers the architect has cut); skip those at the live tier and rely
+  // on integration tests in the extension.
   it("pairs an existing feature branch and writes a valid .env", async () => {
     const dir = makeFakeGitRepo();
     try {

--- a/tests/bdd/tier-discovery.test.ts
+++ b/tests/bdd/tier-discovery.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { isTier, tierBranchNames } from "../../scripts/lakebase/branch-utils.js";
+import type { LakebaseBranchInfo } from "../../scripts/lakebase/branch-utils.js";
+import { asBranchUid, asBranchName } from "../../scripts/lakebase/branch-id.js";
+
+// Sample branch list mirroring what listBranches() returns for a project
+// with one default branch + multiple long-running tiers + one feature.
+function fixture(): LakebaseBranchInfo[] {
+  return [
+    {
+      uid: asBranchUid("br-prod-uid"),
+      nameLeaf: asBranchName("production"),
+      name: "projects/p1/branches/production",
+      state: "READY",
+      isDefault: true,
+    },
+    {
+      uid: asBranchUid("br-staging-uid"),
+      nameLeaf: asBranchName("staging"),
+      name: "projects/p1/branches/staging",
+      state: "READY",
+      isDefault: false,
+    },
+    {
+      uid: asBranchUid("br-uat-uid"),
+      nameLeaf: asBranchName("uat"),
+      name: "projects/p1/branches/uat",
+      state: "READY",
+      isDefault: false,
+    },
+    {
+      uid: asBranchUid("br-feature-uid"),
+      nameLeaf: asBranchName("feature-x"),
+      name: "projects/p1/branches/feature-x",
+      state: "READY",
+      isDefault: false,
+    },
+  ];
+}
+
+describe("isTier", () => {
+  it("returns true for any non-default Lakebase branch name", () => {
+    const branches = fixture();
+    expect(isTier("staging", branches)).toBe(true);
+    expect(isTier("uat", branches)).toBe(true);
+    // Feature branches are also non-default in the list. The hook treats
+    // tier-vs-feature on raw git branch name; sanitize is the caller's
+    // responsibility (intentionally – matches post-checkout.sh).
+    expect(isTier("feature-x", branches)).toBe(true);
+  });
+
+  it("returns false for the default branch", () => {
+    const branches = fixture();
+    expect(isTier("production", branches)).toBe(false);
+  });
+
+  it("returns false for unknown names", () => {
+    const branches = fixture();
+    expect(isTier("does-not-exist", branches)).toBe(false);
+  });
+
+  it("returns false for empty input", () => {
+    expect(isTier("", fixture())).toBe(false);
+  });
+
+  it("returns false for empty branch list", () => {
+    expect(isTier("staging", [])).toBe(false);
+  });
+
+  it("matches by exact branchId leaf, not substring", () => {
+    const branches = fixture();
+    // 'stag' is a prefix of 'staging' but not an exact match
+    expect(isTier("stag", branches)).toBe(false);
+    expect(isTier("staging-2", branches)).toBe(false);
+  });
+});
+
+describe("tierBranchNames", () => {
+  it("returns every non-default branchId leaf", () => {
+    const names = tierBranchNames(fixture()).sort();
+    expect(names).toEqual(["feature-x", "staging", "uat"]);
+  });
+
+  it("excludes the default branch", () => {
+    expect(tierBranchNames(fixture())).not.toContain("production");
+  });
+
+  it("returns [] when every branch is default (degenerate case)", () => {
+    const onlyDefault: LakebaseBranchInfo[] = [
+      {
+        uid: asBranchUid("br-only-default-uid"),
+        nameLeaf: asBranchName("main"),
+        name: "projects/p/branches/main",
+        state: "READY",
+        isDefault: true,
+      },
+    ];
+    expect(tierBranchNames(onlyDefault)).toEqual([]);
+  });
+
+  it("returns [] when the list is empty", () => {
+    expect(tierBranchNames([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Aligns substrate \`checkoutPaired()\` with the post-checkout hook's auto-discovery model (the model the hook adopted in alpha.9). Closes FEIP-7098 on the kit side.

- New \`isTier(name, branches)\` + \`tierBranchNames(branches)\` helpers in \`branch-utils.ts\`. Pure + sync; callers supply the cached branch list.
- \`checkoutPaired()\` drops \`stagingAlias\` arg. The tier check now runs against the listBranches() result, so any non-default Lakebase branch acts as a tier when the git branch name matches. \`CheckoutMode\` union renames \`\"staging\" -> \"tier\"\` to reflect the more general semantics.
- One \`listBranches()\` call powers both the default-branch lookup and the tier check (matches the hook's \"pull the list once\" pattern).
- Tier matching is on the raw git branch name (not sanitized), mirroring the hook. Prevents \`feature/x\` accidentally pairing with a tier via sanitized-name collision.

## Test plan

- [x] 854/0/108 hermetic (new \`tier-discovery.test.ts\`: 10/10 green)
- [x] Typecheck clean
- [x] Live BDD path unchanged (existing live tests target FEATURE mode only; tier path covered by extension integration)

Follow-up: extension PR consumes \`isTier()\` via \`LakebaseService\` so the extension UI gates trunk / tier / feature off the same seam. Separate PR + 0.5.9 extension release.

This pull request and its description were written by Isaac.