### PR TITLE
feat(workflows): updateWorkflows() primitive for in-place refresh (FEIP-7139)

### DIFF
--- a/scripts/lakebase/workflow-drift.ts
+++ b/scripts/lakebase/workflow-drift.ts
@@ -1,12 +1,14 @@
-// Drift detector: scaffolded project's .github/workflows/*.yml vs the
-// kit's current templates (FEIP-7140).
+// Drift detector + in-place refresh for a scaffolded project's
+// .github/workflows/*.yml against the kit's current templates
+// (FEIP-7140 + FEIP-7139).
 //
 // Scaffolded projects ship copies of pr.yml, merge.yml, cleanup-orphans.yml
 // at scaffold time. The kit's templates evolve (new lint steps, schema-
 // diff gates, bug fixes) but existing projects never auto-pick those
-// changes up. This primitive surfaces the drift so a maintainer can
-// decide whether to refresh (via FEIP-7139 updateWorkflows when that
-// lands) or pin intentionally.
+// changes up. `detectWorkflowDrift` surfaces the gap; `updateWorkflows`
+// (FEIP-7139) closes it by writing the current kit templates into the
+// project's .github/workflows/, with the same {{LAKEBASE_KIT_VERSION}}
+// substitution the scaffolder does.
 //
 // The "kit version pinned by the project" surfaces via npm's installed
 // view: if the project depends on @databricks-solutions/lakebase-app-dev-kit,
@@ -175,4 +177,186 @@ export function detectWorkflowDrift(
     overall: hasDrift ? "drift" : "ok",
     files,
   };
+}
+
+// ─── updateWorkflows: FEIP-7139 in-place refresh ────────────────
+
+export type WorkflowUpdateOutcome = "added" | "updated" | "unchanged" | "removed";
+
+export interface WorkflowFileUpdate {
+  /** File name (e.g. "pr.yml"). */
+  name: string;
+  outcome: WorkflowUpdateOutcome;
+}
+
+export interface UpdateWorkflowsArgs {
+  /** Project directory containing .github/workflows/. */
+  projectDir: string;
+  /**
+   * Kit directory containing templates/project/common/.github/workflows/.
+   * Default: walk up from this module looking for the templates marker
+   * (same logic as {@link detectWorkflowDrift}).
+   */
+  kitDir?: string;
+  /**
+   * When true, removes project workflow .yml files that aren't in the
+   * kit templates. Default: false – projects legitimately add their own
+   * workflows alongside the kit's set.
+   */
+  pruneExtras?: boolean;
+  /**
+   * When true, report what WOULD change but don't write to disk.
+   * Default: false.
+   */
+  dryRun?: boolean;
+  /**
+   * When true, substitute `{{LAKEBASE_KIT_VERSION}}` with the kit's
+   * current version (read from its package.json) before writing.
+   * Default: true – matches the scaffolder's behavior.
+   */
+  substitute?: boolean;
+}
+
+export interface UpdateWorkflowsResult {
+  /** Per-file outcome (added / updated / unchanged / removed). */
+  files: WorkflowFileUpdate[];
+  /** True iff anything actually changed on disk (or would, in dryRun). */
+  changed: boolean;
+}
+
+/**
+ * Read the kit's `package.json` version. Walks up from the workflows
+ * templates dir to find `<kitRoot>/package.json`. Returns "unknown"
+ * (the same fallback the scaffolder uses) when the file can't be read,
+ * so refreshes don't fail on test fixture trees without a package.json.
+ */
+function readKitVersion(kitWorkflowsDir: string): string {
+  // kitWorkflowsDir = <kitRoot>/templates/project/common/.github/workflows
+  // Walk up 5 levels to reach <kitRoot>.
+  let dir = kitWorkflowsDir;
+  for (let i = 0; i < 5; i++) {
+    dir = path.dirname(dir);
+  }
+  try {
+    const raw = fs.readFileSync(path.join(dir, "package.json"), "utf-8");
+    const pkg = JSON.parse(raw) as { version?: unknown };
+    return typeof pkg.version === "string" ? pkg.version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function applyPlaceholders(content: string, version: string): string {
+  return content.replace(/\{\{LAKEBASE_KIT_VERSION\}\}/g, version);
+}
+
+/**
+ * Refresh a scaffolded project's `.github/workflows/*.yml` in place
+ * from the kit's current templates.
+ *
+ * Defaults to:
+ *   - WRITES the kit's template content into the project, overwriting
+ *     any drifted copies. `{{LAKEBASE_KIT_VERSION}}` is substituted with
+ *     the kit's current version (read from its package.json).
+ *   - LEAVES extra project workflow files in place (the project might
+ *     have added its own .yml alongside the kit's set). Pass
+ *     `pruneExtras: true` to remove them.
+ *   - CREATES .github/workflows/ if missing.
+ *
+ * Designed to be the safe counterpart to {@link detectWorkflowDrift}:
+ * after a drift report flags drifted/missing files, `updateWorkflows()`
+ * closes the gap in one call. The per-file `outcome` list mirrors the
+ * drift report's vocabulary so callers can diff before vs after if
+ * needed.
+ *
+ * Set `dryRun: true` to surface the same per-file outcomes without
+ * touching disk – useful for previews in lakebase-doctor.
+ */
+export function updateWorkflows(
+  args: UpdateWorkflowsArgs
+): UpdateWorkflowsResult {
+  const projectWorkflowsDir = path.join(
+    args.projectDir,
+    ".github",
+    "workflows"
+  );
+  const here = path.dirname(new URL(import.meta.url).pathname);
+  const kitWorkflowsDir = args.kitDir
+    ? path.join(
+        args.kitDir,
+        "templates",
+        "project",
+        "common",
+        ".github",
+        "workflows"
+      )
+    : findKitTemplatesDir(here);
+
+  const substitute = args.substitute !== false;
+  const dryRun = args.dryRun === true;
+  const pruneExtras = args.pruneExtras === true;
+
+  const templateFiles = fs.existsSync(kitWorkflowsDir)
+    ? fs.readdirSync(kitWorkflowsDir).filter((f) => f.endsWith(".yml"))
+    : [];
+  const projectFiles = fs.existsSync(projectWorkflowsDir)
+    ? fs.readdirSync(projectWorkflowsDir).filter((f) => f.endsWith(".yml"))
+    : [];
+
+  // Ensure the project directory exists before we write anything (unless
+  // dryRun OR the template set is empty).
+  if (!dryRun && templateFiles.length > 0 && !fs.existsSync(projectWorkflowsDir)) {
+    fs.mkdirSync(projectWorkflowsDir, { recursive: true });
+  }
+
+  const version = substitute ? readKitVersion(kitWorkflowsDir) : "";
+  const seen = new Set<string>();
+  const files: WorkflowFileUpdate[] = [];
+
+  for (const name of templateFiles) {
+    seen.add(name);
+    const projectPath = path.join(projectWorkflowsDir, name);
+    const templatePath = path.join(kitWorkflowsDir, name);
+    const templateRaw = fs.readFileSync(templatePath, "utf-8");
+    const desired = substitute ? applyPlaceholders(templateRaw, version) : templateRaw;
+    const existed = fs.existsSync(projectPath);
+    const current = existed ? fs.readFileSync(projectPath, "utf-8") : "";
+
+    let outcome: WorkflowUpdateOutcome;
+    if (!existed) {
+      outcome = "added";
+    } else if (current === desired) {
+      outcome = "unchanged";
+    } else {
+      outcome = "updated";
+    }
+
+    if (!dryRun && outcome !== "unchanged") {
+      fs.writeFileSync(projectPath, desired);
+    }
+    files.push({ name, outcome });
+  }
+
+  if (pruneExtras) {
+    for (const name of projectFiles) {
+      if (seen.has(name)) continue;
+      const projectPath = path.join(projectWorkflowsDir, name);
+      if (!dryRun) {
+        fs.unlinkSync(projectPath);
+      }
+      files.push({ name, outcome: "removed" });
+    }
+  }
+
+  // Sort to match detectWorkflowDrift's "interesting first" ordering.
+  const order: Record<WorkflowUpdateOutcome, number> = {
+    added: 0,
+    updated: 1,
+    removed: 2,
+    unchanged: 3,
+  };
+  files.sort((a, b) => order[a.outcome] - order[b.outcome] || a.name.localeCompare(b.name));
+
+  const changed = files.some((f) => f.outcome !== "unchanged");
+  return { files, changed };
 }

--- a/tests/bdd/update-workflows.test.ts
+++ b/tests/bdd/update-workflows.test.ts
@@ -1,0 +1,223 @@
+// Coverage for the workflow refresh primitive (FEIP-7139). Pure
+// filesystem; no live Lakebase, runs in the standard non-live suite.
+//
+// Uses a synthetic kit fixture for most cases (kitDir override) to keep
+// the tests independent of the real templates' content (which evolves).
+// A small "real kit" smoke test confirms updateWorkflows() finds the
+// kit's actual templates when kitDir is omitted.
+
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  updateWorkflows,
+  detectWorkflowDrift,
+} from "../../scripts/lakebase/workflow-drift.js";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
+  }
+});
+
+function mkTmp(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `lbscm-${prefix}-`));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function mkProject(): string {
+  const dir = mkTmp("upd-proj");
+  fs.mkdirSync(path.join(dir, ".github", "workflows"), { recursive: true });
+  return dir;
+}
+
+/**
+ * Build a tiny synthetic "kit" fixture with two workflow templates.
+ * Returns the kitDir path that updateWorkflows() accepts.
+ */
+function mkSyntheticKit(version: string, files: Record<string, string>): string {
+  const kit = mkTmp("upd-kit");
+  fs.writeFileSync(
+    path.join(kit, "package.json"),
+    JSON.stringify({ name: "fixture", version }, null, 2)
+  );
+  const wfDir = path.join(kit, "templates", "project", "common", ".github", "workflows");
+  fs.mkdirSync(wfDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(wfDir, name), content);
+  }
+  return kit;
+}
+
+describe("updateWorkflows – synthetic kit fixture", () => {
+  it("writes every template into an empty project (outcome=added)", () => {
+    const project = mkProject();
+    const kit = mkSyntheticKit("9.9.9", {
+      "pr.yml": "name: pr\n",
+      "merge.yml": "name: merge\n",
+    });
+    const result = updateWorkflows({ projectDir: project, kitDir: kit });
+    expect(result.changed).toBe(true);
+    const byName = (n: string) => result.files.find((f) => f.name === n)!;
+    expect(byName("pr.yml").outcome).toBe("added");
+    expect(byName("merge.yml").outcome).toBe("added");
+    expect(fs.readFileSync(path.join(project, ".github", "workflows", "pr.yml"), "utf-8")).toBe("name: pr\n");
+  });
+
+  it("substitutes {{LAKEBASE_KIT_VERSION}} with the kit's package.json version", () => {
+    const project = mkProject();
+    const kit = mkSyntheticKit("1.2.3", {
+      "pr.yml": "version: {{LAKEBASE_KIT_VERSION}}\n",
+    });
+    updateWorkflows({ projectDir: project, kitDir: kit });
+    const written = fs.readFileSync(
+      path.join(project, ".github", "workflows", "pr.yml"),
+      "utf-8"
+    );
+    expect(written).toBe("version: 1.2.3\n");
+  });
+
+  it("skips substitution when substitute=false", () => {
+    const project = mkProject();
+    const kit = mkSyntheticKit("1.2.3", {
+      "pr.yml": "version: {{LAKEBASE_KIT_VERSION}}\n",
+    });
+    updateWorkflows({ projectDir: project, kitDir: kit, substitute: false });
+    const written = fs.readFileSync(
+      path.join(project, ".github", "workflows", "pr.yml"),
+      "utf-8"
+    );
+    expect(written).toBe("version: {{LAKEBASE_KIT_VERSION}}\n");
+  });
+
+  it("returns outcome=unchanged for files that already match the kit", () => {
+    const project = mkProject();
+    const kit = mkSyntheticKit("1.0.0", { "pr.yml": "name: pr\n" });
+    // First call seeds the project.
+    updateWorkflows({ projectDir: project, kitDir: kit });
+    // Second call is a no-op.
+    const result = updateWorkflows({ projectDir: project, kitDir: kit });
+    expect(result.changed).toBe(false);
+    expect(result.files[0].outcome).toBe("unchanged");
+  });
+
+  it("returns outcome=updated when project copy differs from the kit", () => {
+    const project = mkProject();
+    const kit = mkSyntheticKit("1.0.0", { "pr.yml": "name: pr\n" });
+    fs.writeFileSync(
+      path.join(project, ".github", "workflows", "pr.yml"),
+      "name: drifted\n"
+    );
+    const result = updateWorkflows({ projectDir: project, kitDir: kit });
+    expect(result.changed).toBe(true);
+    expect(result.files[0].outcome).toBe("updated");
+    expect(fs.readFileSync(path.join(project, ".github", "workflows", "pr.yml"), "utf-8")).toBe("name: pr\n");
+  });
+
+  it("leaves extra project files in place by default", () => {
+    const project = mkProject();
+    const kit = mkSyntheticKit("1.0.0", { "pr.yml": "name: pr\n" });
+    fs.writeFileSync(
+      path.join(project, ".github", "workflows", "custom.yml"),
+      "name: custom\n"
+    );
+    const result = updateWorkflows({ projectDir: project, kitDir: kit });
+    expect(result.files.find((f) => f.name === "custom.yml")).toBeUndefined();
+    expect(fs.existsSync(path.join(project, ".github", "workflows", "custom.yml"))).toBe(true);
+  });
+
+  it("removes extra project files when pruneExtras=true", () => {
+    const project = mkProject();
+    const kit = mkSyntheticKit("1.0.0", { "pr.yml": "name: pr\n" });
+    fs.writeFileSync(
+      path.join(project, ".github", "workflows", "custom.yml"),
+      "name: custom\n"
+    );
+    const result = updateWorkflows({
+      projectDir: project,
+      kitDir: kit,
+      pruneExtras: true,
+    });
+    const extra = result.files.find((f) => f.name === "custom.yml");
+    expect(extra?.outcome).toBe("removed");
+    expect(fs.existsSync(path.join(project, ".github", "workflows", "custom.yml"))).toBe(false);
+  });
+
+  it("dryRun=true reports outcomes without touching disk", () => {
+    const project = mkProject();
+    const kit = mkSyntheticKit("1.0.0", { "pr.yml": "name: pr-new\n" });
+    fs.writeFileSync(
+      path.join(project, ".github", "workflows", "pr.yml"),
+      "name: pr-old\n"
+    );
+    const result = updateWorkflows({
+      projectDir: project,
+      kitDir: kit,
+      dryRun: true,
+    });
+    expect(result.changed).toBe(true);
+    expect(result.files[0].outcome).toBe("updated");
+    // Project file UNCHANGED on disk despite changed=true
+    expect(
+      fs.readFileSync(path.join(project, ".github", "workflows", "pr.yml"), "utf-8")
+    ).toBe("name: pr-old\n");
+  });
+
+  it("creates .github/workflows/ when missing", () => {
+    const project = mkTmp("upd-proj-no-wf");
+    expect(fs.existsSync(path.join(project, ".github"))).toBe(false);
+    const kit = mkSyntheticKit("1.0.0", { "pr.yml": "name: pr\n" });
+    const result = updateWorkflows({ projectDir: project, kitDir: kit });
+    expect(result.files[0].outcome).toBe("added");
+    expect(fs.existsSync(path.join(project, ".github", "workflows", "pr.yml"))).toBe(true);
+  });
+
+  it("falls back to 'unknown' when kit package.json is missing", () => {
+    const project = mkProject();
+    // Build a kit fixture but DELETE its package.json
+    const kit = mkSyntheticKit("ignored", {
+      "pr.yml": "version: {{LAKEBASE_KIT_VERSION}}\n",
+    });
+    fs.unlinkSync(path.join(kit, "package.json"));
+    updateWorkflows({ projectDir: project, kitDir: kit });
+    const written = fs.readFileSync(
+      path.join(project, ".github", "workflows", "pr.yml"),
+      "utf-8"
+    );
+    expect(written).toBe("version: unknown\n");
+  });
+});
+
+describe("updateWorkflows + detectWorkflowDrift integration", () => {
+  it("after a raw refresh (substitute=false) the project reads back as overall=ok against the same kit", () => {
+    // detectWorkflowDrift (FEIP-7140) does a byte-equality comparison
+    // against the raw template content. When updateWorkflows substitutes
+    // {{LAKEBASE_KIT_VERSION}}, the post-refresh project differs from
+    // the template by exactly those substituted lines (a known
+    // limitation of the drift detector; tracked as a separate FEIP).
+    // To exercise the real-template round-trip we disable substitution
+    // here; substitution semantics are covered in the synthetic-kit
+    // suite above.
+    const project = mkProject();
+    const result = updateWorkflows({
+      projectDir: project,
+      kitDir: REPO_ROOT,
+      substitute: false,
+    });
+    expect(result.changed).toBe(true);
+    const drift = detectWorkflowDrift({ projectDir: project, kitDir: REPO_ROOT });
+    expect(drift.overall).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary

New substrate primitive that refreshes a scaffolded project's \`.github/workflows/*.yml\` from the kit's current templates. The counterpart to \`detectWorkflowDrift\` (FEIP-7140): drift detects, this closes the gap.

API: \`updateWorkflows({ projectDir, kitDir?, pruneExtras?, dryRun?, substitute? })\`

- Outcomes per file: \`added\` / \`updated\` / \`unchanged\` / \`removed\`.
- Substitutes \`{{LAKEBASE_KIT_VERSION}}\` with the kit's \`package.json\` version by default, matching the scaffolder's \`deployWorkflows()\`.
- \`pruneExtras\` defaults to \`false\` (projects legitimately add their own \`.yml\` files alongside the kit's set, same posture \`detectWorkflowDrift\` takes with its \"extra\" status).
- \`dryRun\` returns the same per-file outcomes without touching disk. Intended for \`lakebase-doctor\` preview output.
- Creates \`.github/workflows/\` if missing.
- Kit version falls back to \`\"unknown\"\` when \`package.json\` is missing, matching \`deployWorkflows\`.

## Test plan

- [x] 855/0/108 hermetic (new \`update-workflows.test.ts\`: 11/11 green)
- [x] Typecheck clean
- [x] Round-trip integration: \`updateWorkflows(substitute=false)\` then \`detectWorkflowDrift\` reads back as \`overall=ok\`

## Known follow-up (not in this PR)

\`detectWorkflowDrift\` does byte-equality against raw template content and doesn't account for the \`{{LAKEBASE_KIT_VERSION}}\` substitution \`updateWorkflows\` (and the scaffolder) apply. After a substituted refresh, drift will fire on those substituted lines. Tracked as a separate fix to the drift detector; not blocking this primitive.

This pull request and its description were written by Isaac.