### PR TITLE
fix(branch-utils): isTier/tierBranchNames filter on !expireTime (FEIP-7098 follow-up)

### DIFF
--- a/scripts/lakebase/branch-utils.ts
+++ b/scripts/lakebase/branch-utils.ts
@@ -161,31 +161,48 @@ export async function getDefaultBranch(opts: BranchLookupOpts): Promise<Lakebase
 }
 
 /**
- * Tier check: returns true iff `name` matches a non-default Lakebase branch
- * by exact branchId. Mirrors the post-checkout hook's auto-discovery model
- * (see templates/project/common/scripts/post-checkout.sh:252-279): the
- * architect cuts long-running tiers (staging, uat, perf, ...) deliberately
- * via createLongRunningBranch, and a git checkout to a name matching any
- * such non-default Lakebase branch is a "tier checkout" that pairs the
- * existing branch rather than creating a feature branch.
+ * Tier predicate: a branch is a long-running tier iff it's non-default
+ * AND has no expireTime (the architect cut it deliberately via
+ * {@link createLongRunningBranch}, which sets `no_expiry: true` and
+ * therefore leaves expireTime absent on the API response).
  *
- * Pure utility – callers supply the branch list. This keeps the helper
- * sync, mockable, and cheap to call multiple times against the same
- * cached list during a single workflow.
+ * Mirrors the methodology's intent: feature branches carry a TTL
+ * (LakebaseBranchInfo.expireTime is set) and are transient; tiers
+ * (staging, uat, perf, ...) are no_expiry and persistent. The earlier
+ * "non-default" filter incorrectly swept in every feature branch.
+ *
+ * Pure utility – callers supply the branch list. This keeps the
+ * helper sync, mockable, and cheap to call multiple times against
+ * the same cached list during a single workflow.
  */
-export function isTier(name: string, branches: LakebaseBranchInfo[]): boolean {
-  if (!name) { return false; }
-  return branches.some((b) => !b.isDefault && b.nameLeaf === name);
+export function isLongRunningTierBranch(b: LakebaseBranchInfo): boolean {
+  return !b.isDefault && !b.expireTime;
 }
 
 /**
- * Returns the names (branchId leaves) of every non-default Lakebase branch
- * in the project. The "long-running tier" set the architect has cut. Useful
- * for surfaces that need to enumerate tiers (e.g. extension UI grouping)
- * rather than just test membership via {@link isTier}.
+ * Tier check: returns true iff `name` matches a long-running tier
+ * Lakebase branch by exact branchId leaf. See
+ * {@link isLongRunningTierBranch} for the underlying classification.
+ *
+ * Mirrors the post-checkout hook's auto-discovery model
+ * (templates/project/common/scripts/post-checkout.sh:252-279).
+ */
+export function isTier(name: string, branches: LakebaseBranchInfo[]): boolean {
+  if (!name) { return false; }
+  return branches.some((b) => isLongRunningTierBranch(b) && b.nameLeaf === name);
+}
+
+/**
+ * Returns the names (branchId leaves) of every long-running tier
+ * Lakebase branch in the project (staging, uat, perf, ...). Useful
+ * for surfaces that need to enumerate tiers (e.g. extension UI
+ * grouping) rather than just test membership via {@link isTier}.
+ *
+ * Filters on {@link isLongRunningTierBranch} so feature branches
+ * (which are non-default but carry an expireTime) are excluded.
  */
 export function tierBranchNames(branches: LakebaseBranchInfo[]): string[] {
-  return branches.filter((b) => !b.isDefault).map((b) => b.nameLeaf as string);
+  return branches.filter(isLongRunningTierBranch).map((b) => b.nameLeaf as string);
 }
 
 /**

--- a/tests/bdd/tier-discovery.test.ts
+++ b/tests/bdd/tier-discovery.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { isTier, tierBranchNames } from "../../scripts/lakebase/branch-utils.js";
+import {
+  isTier,
+  tierBranchNames,
+  isLongRunningTierBranch,
+} from "../../scripts/lakebase/branch-utils.js";
 import type { LakebaseBranchInfo } from "../../scripts/lakebase/branch-utils.js";
 import { asBranchUid, asBranchName } from "../../scripts/lakebase/branch-id.js";
 
 // Sample branch list mirroring what listBranches() returns for a project
-// with one default branch + multiple long-running tiers + one feature.
+// with one default branch + two long-running tiers (no expireTime) +
+// two feature branches (one with TTL, one bare). Tiers are no_expiry by
+// convention; features carry a TTL or were created with default
+// expiration. The default branch is also excluded.
 function fixture(): LakebaseBranchInfo[] {
   return [
     {
@@ -20,6 +27,7 @@ function fixture(): LakebaseBranchInfo[] {
       name: "projects/p1/branches/staging",
       state: "READY",
       isDefault: false,
+      // No expireTime: created via createLongRunningBranch (no_expiry: true)
     },
     {
       uid: asBranchUid("br-uat-uid"),
@@ -27,26 +35,64 @@ function fixture(): LakebaseBranchInfo[] {
       name: "projects/p1/branches/uat",
       state: "READY",
       isDefault: false,
+      // No expireTime: long-running tier
     },
     {
-      uid: asBranchUid("br-feature-uid"),
+      uid: asBranchUid("br-feature-x-uid"),
       nameLeaf: asBranchName("feature-x"),
       name: "projects/p1/branches/feature-x",
       state: "READY",
       isDefault: false,
+      expireTime: "2026-06-30T00:00:00Z",
+    },
+    {
+      uid: asBranchUid("br-demo-feature-uid"),
+      nameLeaf: asBranchName("demo-feature"),
+      name: "projects/p1/branches/demo-feature",
+      state: "READY",
+      isDefault: false,
+      expireTime: "2026-07-15T12:00:00Z",
     },
   ];
 }
 
+describe("isLongRunningTierBranch", () => {
+  it("returns true for non-default branches with no expireTime", () => {
+    const branches = fixture();
+    const staging = branches.find((b) => b.nameLeaf === "staging")!;
+    const uat = branches.find((b) => b.nameLeaf === "uat")!;
+    expect(isLongRunningTierBranch(staging)).toBe(true);
+    expect(isLongRunningTierBranch(uat)).toBe(true);
+  });
+
+  it("returns false for the default branch even when expireTime is absent", () => {
+    const prod = fixture().find((b) => b.isDefault)!;
+    expect(isLongRunningTierBranch(prod)).toBe(false);
+  });
+
+  it("returns false for non-default branches that carry an expireTime (feature branches)", () => {
+    const branches = fixture();
+    const feature = branches.find((b) => b.nameLeaf === "feature-x")!;
+    const demoFeature = branches.find((b) => b.nameLeaf === "demo-feature")!;
+    expect(isLongRunningTierBranch(feature)).toBe(false);
+    expect(isLongRunningTierBranch(demoFeature)).toBe(false);
+  });
+});
+
 describe("isTier", () => {
-  it("returns true for any non-default Lakebase branch name", () => {
+  it("returns true for long-running tier names", () => {
     const branches = fixture();
     expect(isTier("staging", branches)).toBe(true);
     expect(isTier("uat", branches)).toBe(true);
-    // Feature branches are also non-default in the list. The hook treats
-    // tier-vs-feature on raw git branch name; sanitize is the caller's
-    // responsibility (intentionally – matches post-checkout.sh).
-    expect(isTier("feature-x", branches)).toBe(true);
+  });
+
+  it("returns false for feature branches even though they're non-default", () => {
+    // Reproduces the FEIP-7098 follow-up bug: feature-x and demo-feature
+    // are non-default Lakebase branches, but they carry an expireTime
+    // (created with TTL) so they're NOT tiers.
+    const branches = fixture();
+    expect(isTier("feature-x", branches)).toBe(false);
+    expect(isTier("demo-feature", branches)).toBe(false);
   });
 
   it("returns false for the default branch", () => {
@@ -69,20 +115,25 @@ describe("isTier", () => {
 
   it("matches by exact branchId leaf, not substring", () => {
     const branches = fixture();
-    // 'stag' is a prefix of 'staging' but not an exact match
     expect(isTier("stag", branches)).toBe(false);
     expect(isTier("staging-2", branches)).toBe(false);
   });
 });
 
 describe("tierBranchNames", () => {
-  it("returns every non-default branchId leaf", () => {
+  it("returns only long-running tier branchIds (excludes features with expireTime)", () => {
     const names = tierBranchNames(fixture()).sort();
-    expect(names).toEqual(["feature-x", "staging", "uat"]);
+    expect(names).toEqual(["staging", "uat"]);
   });
 
   it("excludes the default branch", () => {
     expect(tierBranchNames(fixture())).not.toContain("production");
+  });
+
+  it("excludes feature branches that carry an expireTime", () => {
+    const names = tierBranchNames(fixture());
+    expect(names).not.toContain("feature-x");
+    expect(names).not.toContain("demo-feature");
   });
 
   it("returns [] when every branch is default (degenerate case)", () => {
@@ -100,5 +151,26 @@ describe("tierBranchNames", () => {
 
   it("returns [] when the list is empty", () => {
     expect(tierBranchNames([])).toEqual([]);
+  });
+
+  it("returns [] when every non-default branch carries an expireTime (all features)", () => {
+    const allFeatures: LakebaseBranchInfo[] = [
+      {
+        uid: asBranchUid("br-default-uid"),
+        nameLeaf: asBranchName("production"),
+        name: "projects/p/branches/production",
+        state: "READY",
+        isDefault: true,
+      },
+      {
+        uid: asBranchUid("br-feature-a-uid"),
+        nameLeaf: asBranchName("feature-a"),
+        name: "projects/p/branches/feature-a",
+        state: "READY",
+        isDefault: false,
+        expireTime: "2026-06-15T00:00:00Z",
+      },
+    ];
+    expect(tierBranchNames(allFeatures)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Reported symptom in the extension UI: feature branches (\`demo-feature\`, \`smoke-test\`) showed as long-running tiers (purple icon, tier section, refused-to-delete). Root cause: \`isTier\` and \`tierBranchNames\` filtered only on \`!isDefault\`, which sweeps in every non-default branch including features.

The convention in the kit:

| Branch | How created | \`expireTime\` | \`isDefault\` |
|---|---|---|---|
| Default | \`createProject\` | absent | \`true\` |
| Long-running tier | \`createLongRunningBranch\` (sets \`noExpiry: true\`) | absent | \`false\` |
| Feature | \`createBranch\` / \`createFeatureBranch\` | present (TTL) | \`false\` |

Predicate becomes \`!b.isDefault && !b.expireTime\`. Encoded in a new \`isLongRunningTierBranch()\` helper, reused by \`isTier\` and \`tierBranchNames\`.

## Test plan

- [x] 871/0/108 hermetic
- [x] Typecheck clean
- [x] Fixture in \`tier-discovery.test.ts\` now models both tier (no \`expireTime\`) and feature (with \`expireTime\`) branches
- [x] New cases assert \`feature-x\` and \`demo-feature\` are NOT classified as tiers

## Acknowledged edge case

A \"legacy\" branch created via raw CLI with \`no_expiry\` outside the kit's helpers will still be classified as a tier. Documented in the existing \`expireTime\` docstring; in-convention branches are reliably classified.

This pull request and its description were written by Isaac.