### PR TITLE
Scaffold /design + /build slash commands (FEIP-7212)

### DIFF
--- a/scripts/lakebase/create-project.cli.ts
+++ b/scripts/lakebase/create-project.cli.ts
@@ -19,6 +19,7 @@ interface ParsedArgs {
   language?: "java" | "kotlin" | "python" | "nodejs";
   runnerType?: "self-hosted" | "github-hosted";
   enableE2e?: boolean;
+  skipCommands?: boolean;
   help?: boolean;
 }
 
@@ -60,6 +61,9 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "--no-e2e":
         out.enableE2e = false;
         break;
+      case "--skip-commands":
+        out.skipCommands = true;
+        break;
       case "--help":
       case "-h":
         out.help = true;
@@ -89,6 +93,8 @@ Flags:
   --enable-e2e        Force-enable Playwright E2E wire-up (FEIP-7094)
   --no-e2e            Force-disable Playwright E2E wire-up
                       (default: on for --language nodejs, off otherwise)
+  --skip-commands     Skip scaffolding .claude/commands/{design,build}.md
+                      (default: commands are written)
   --json-input        Pass all args as a single JSON object (BDD harness)
 
 Output: JSON on stdout (CreateProjectResult). Progress to stderr.
@@ -124,6 +130,7 @@ async function main(): Promise<number> {
       language: args.language,
       runnerType: args.runnerType,
       enableE2e: args.enableE2e,
+      skipCommands: args.skipCommands,
     };
   }
 

--- a/scripts/lakebase/create-project.ts
+++ b/scripts/lakebase/create-project.ts
@@ -54,6 +54,13 @@ export interface CreateProjectArgs {
    * FEIP-7094 Phase 2.
    */
   enableE2e?: boolean;
+  /**
+   * Skip the `.claude/commands/{design,build}.md` scaffold. Default:
+   * false (commands are written). Set to true for projects that already
+   * have their own slash commands they want to keep, or for non-Claude-Code
+   * consumers that only use the substrate library.
+   */
+  skipCommands?: boolean;
 }
 
 export interface CreateProjectResult {
@@ -100,6 +107,7 @@ export async function createProject(
   // overrides regardless of language.
   const enableE2e =
     input.enableE2e !== undefined ? input.enableE2e : language === "nodejs";
+  const skipCommands = input.skipCommands === true;
   const warnings: string[] = [];
 
   if (useGithub && !input.githubOwner) {
@@ -182,6 +190,7 @@ export async function createProject(
     lakebaseProjectId,
     language,
     runnerType,
+    skipCommands,
     report: (m, d) => report(m, d),
   });
 

--- a/scripts/lakebase/scaffold.ts
+++ b/scripts/lakebase/scaffold.ts
@@ -97,6 +97,55 @@ export async function deployScripts(targetDir: string, opts?: ScaffoldOptions): 
   return copyDir(path.join(commonDir(opts), "scripts"), path.join(targetDir, "scripts"), true);
 }
 
+export interface DeployClaudeCommandsResult {
+  /** Paths (relative to targetDir) that were written. */
+  written: string[];
+  /** Paths that already existed and were left untouched (force=false). */
+  skipped: string[];
+}
+
+export interface DeployClaudeCommandsOptions extends ScaffoldOptions {
+  /** Overwrite existing .claude/commands/*.md. Default: false. */
+  force?: boolean;
+}
+
+/**
+ * Deploy `.claude/commands/{design,build}.md` from
+ * `common/.claude/commands/`. Substitutes `${KIT_VERSION_AT_SCAFFOLD}`
+ * with the kit version that ran the scaffold so the project file pins
+ * to a specific substrate revision (the future drift detector reads
+ * this back). Skips files that already exist in the project unless
+ * `force: true` so a re-run does not clobber a user's edits.
+ */
+export async function deployClaudeCommands(
+  targetDir: string,
+  opts?: DeployClaudeCommandsOptions
+): Promise<DeployClaudeCommandsResult> {
+  const src = path.join(commonDir(opts), ".claude", "commands");
+  if (!fs.existsSync(src)) {
+    return { written: [], skipped: [] };
+  }
+  const destDir = path.join(targetDir, ".claude", "commands");
+  fs.mkdirSync(destDir, { recursive: true });
+  const version = kitVersion(opts);
+  const written: string[] = [];
+  const skipped: string[] = [];
+  for (const entry of fs.readdirSync(src)) {
+    if (!entry.endsWith(".md")) continue;
+    const relDest = path.join(".claude", "commands", entry);
+    const destPath = path.join(targetDir, relDest);
+    if (fs.existsSync(destPath) && !opts?.force) {
+      skipped.push(relDest);
+      continue;
+    }
+    const before = fs.readFileSync(path.join(src, entry), "utf-8");
+    const after = before.replace(/\$\{KIT_VERSION_AT_SCAFFOLD\}/g, version);
+    fs.writeFileSync(destPath, after);
+    written.push(relDest);
+  }
+  return { written, skipped };
+}
+
 /** Deploy GitHub Actions workflows from common/.github/workflows/. */
 export async function deployWorkflows(targetDir: string, opts?: ScaffoldOptions): Promise<string[]> {
   const written = copyDir(
@@ -339,6 +388,13 @@ export interface ScaffoldStaticAllArgs extends ScaffoldOptions {
   language?: ProjectLanguage;
   runnerType?: RunnerType;
   report?: ScaffoldReportFn;
+  /**
+   * Skip `.claude/commands/{design,build}.md`. Default: false (commands
+   * are scaffolded). Set to true when the project already has its own
+   * commands or when scaffolding programmatically (CI bootstrap) for
+   * a consumer that does not use Claude Code.
+   */
+  skipCommands?: boolean;
 }
 
 export interface ScaffoldAllArgs extends ScaffoldStaticAllArgs {
@@ -350,6 +406,8 @@ export interface ScaffoldStaticAllResult {
   scripts: string[];
   workflows: string[];
   hooksInstalled: string;
+  /** `.claude/commands/*.md` files written this run. Empty when skipped. */
+  claudeCommands: string[];
 }
 
 /**
@@ -401,7 +459,14 @@ export async function scaffoldStaticAll(args: ScaffoldStaticAllArgs): Promise<Sc
   report("Installing git hooks");
   const hooksInstalled = await installHooks(args.targetDir);
 
-  return { scripts, workflows, hooksInstalled };
+  let claudeCommands: string[] = [];
+  if (!args.skipCommands) {
+    report("Deploying .claude/commands/");
+    const cmd = await deployClaudeCommands(args.targetDir, opts);
+    claudeCommands = cmd.written;
+  }
+
+  return { scripts, workflows, hooksInstalled, claudeCommands };
 }
 
 /**

--- a/skills/lakebase-scm-workflows/README.md
+++ b/skills/lakebase-scm-workflows/README.md
@@ -83,6 +83,7 @@ When create-project finishes you get a scaffolded layout shaped like:
     merge.yml                              ← migrate parent on merge
   playwright.config.ts                     ← Playwright config (only with --enable-e2e; default-on for nodejs)
   tests/e2e/smoke.spec.ts                  ← Playwright smoke fixture, same gate as the config
+  .claude/commands/                        ← /design + /build slash commands (opt-out via --skip-commands)
   .tdd/                                    ← lakebase-tdd-workflows scaffold (opt-out via --enable-tdd false)
   README.md, .gitignore, package.json/pom.xml/pyproject.toml, ...
 ```

--- a/skills/lakebase-scm-workflows/SKILL.md
+++ b/skills/lakebase-scm-workflows/SKILL.md
@@ -126,6 +126,10 @@ lakebase-create-project --project-name proj-checkout --parent-dir ~/code \
 # Default-on for --language nodejs; opt in elsewhere with --enable-e2e or
 # turn off with --no-e2e:
 lakebase-create-project ... --language nodejs --enable-e2e
+
+# Skip the .claude/commands/{design,build}.md scaffold (for projects
+# that already have their own slash commands or non-Claude-Code consumers):
+lakebase-create-project ... --skip-commands
 ```
 
 ```ts
@@ -140,6 +144,7 @@ const result = await createProject({
   enableTdd: true,                // default: true – lays down .tdd/ scaffold
   enableE2e: undefined,           // default: true for nodejs, false otherwise.
                                   // Explicit boolean overrides the language default.
+  skipCommands: false,            // default: false – writes .claude/commands/{design,build}.md
 });
 ```
 

--- a/skills/lakebase-tdd-workflows/README.md
+++ b/skills/lakebase-tdd-workflows/README.md
@@ -116,7 +116,7 @@ Before cutting any new experiment, the orchestrator checks the budget – at the
 
 Three flows – shown as what you'd prompt your agent to do, using a cart-checkout example throughout. The agent reads [`SKILL.md`](SKILL.md) (plus the Scrum-Master / Navigator / Driver agent prompts) and runs the underlying substrate primitives on your behalf.
 
-The project-level slash commands `/design` and `/build` are the canonical entry points. They're thin wrappers that project skills install on top of this substrate – they handle project-specific concerns (JIRA hierarchy, IDE branch suggestions, manual review gates) and delegate the workflow facilitation here. If a slash command isn't installed in your project, just describe what you want to your agent directly; the prompts below work either way.
+The project-level slash commands `/design` and `/build` are the canonical entry points. They're thin wrappers around this substrate, scaffolded into new projects by `lakebase-create-project` under `.claude/commands/` (opt-out via `--skip-commands`). Projects extend them with their own concerns (JIRA hierarchy, IDE branch suggestions, manual review gates) by dropping sibling `design.{pre,post}-hook.md` or `build.{pre,post}-hook.md` files next to the scaffolded command. If a slash command isn't installed in your project, just describe what you want to your agent directly; the prompts below work either way.
 
 ### 1. Author a feature spec
 
@@ -170,11 +170,11 @@ For when you want to run something directly without the agent. Most TDD work goe
 
 ## Project-level entry points
 
-- **`/design`** – wraps Spec Author + Architect Reviewer + Test Strategist phases. Project-specific JIRA hierarchy creation lives here.
-- **`/build`** – wraps Orchestrator. Project-specific PR/merge ceremony lives here.
+- **`/design`** – wraps Spec Author + Architect Reviewer + Test Strategist phases. Scaffolded into new projects by `lakebase-create-project`. Project-specific JIRA hierarchy creation lives in `design.pre-hook.md`.
+- **`/build`** – wraps Orchestrator. Scaffolded into new projects by `lakebase-create-project`. Project-specific PR/merge ceremony lives in `build.post-hook.md`.
 - **`/ship`** – lives in `lakebase-release-workflows`. Not part of this skill.
 
-Substrate ships no slash commands. It ships skills + agents + scripts + CLI bins. The MCP server (`apps/mcp-server/`) exposes the tool surface for MCP-capable consumers.
+The substrate itself ships no installed slash commands; the scaffolder writes the command files into the project at `lakebase-create-project` time (templated, with a kit-version pin). The substrate's runtime surface stays skills + agents + scripts + CLI bins. The MCP server (`apps/mcp-server/`) exposes the tool surface for MCP-capable consumers.
 
 ## Integration with sibling skills
 

--- a/templates/project/common/.claude/commands/build.md
+++ b/templates/project/common/.claude/commands/build.md
@@ -1,0 +1,33 @@
+# /build : feature build pipeline
+
+Drives a designed feature through TDD cycles to ready-for-review. This wraps the lakebase-tdd-workflows Scrum-Master orchestrator as a one-shot you can invoke from Claude Code in a Lakebase-paired project.
+
+## Usage
+
+```
+/build <feature-id> [--parallel-experiments N]
+```
+
+Requires `.tdd/features/<feature-id>/test-list.json` to exist (the artifact `/design` produces). If the test list is missing, this command stops with a pointer back to `/design <feature-id>`.
+
+## Phases
+
+1. **Scrum-Master orchestrator** picks the next AC, runs Driver / Navigator cycles, watches smells, surfaces gate 3 (test-list immutability) and gate 4 (promote vs synthesize) to the human.
+2. At gate 3 the orchestrator stops and refers back to `/design --resume <feature-id>` when the test list needs renegotiation.
+3. At gate 4 the orchestrator invokes `archiveExperiment` for losing branches once the human picks promote or synthesize.
+
+The orchestrator is implemented by the substrate agent at `@lakebase-tdd-workflows/agents/scrum-master`. Per-cycle work fans out to `@lakebase-tdd-workflows/agents/driver` and `@lakebase-tdd-workflows/agents/navigator`.
+
+## Project pre/post hooks
+
+If `.claude/commands/build.pre-hook.md` exists in this project, it runs before phase 1. Common uses: confirm CI is green, refresh Lakebase credentials, ping the on-call channel that a build is starting.
+
+If `.claude/commands/build.post-hook.md` exists in this project, it runs after promote. Common uses: open the PR via the project's PR bin, post a summary to Slack, move the JIRA epic to "review."
+
+Hooks are owned by the project; this command file only consults them when present. One pre-hook plus one post-hook per command (no chains in v1).
+
+## Substrate version
+
+Pinned to: `${KIT_VERSION_AT_SCAFFOLD}`
+
+The future `lakebase-update-commands` bin will re-pull this command's canonical template while preserving your pre/post hooks.

--- a/templates/project/common/.claude/commands/design.md
+++ b/templates/project/common/.claude/commands/design.md
@@ -1,0 +1,38 @@
+# /design : feature design pipeline
+
+Drives a feature from idea to spec to architect review to test list. This wraps the canonical lakebase-tdd-workflows design phases as a single one-shot you can invoke from Claude Code in a Lakebase-paired project.
+
+## Usage
+
+```
+/design <feature-id> [--reviewer @user] [--test-strategist @user]
+```
+
+If `.tdd/` does not exist in the project root, this command hard-fails with a setup hint instead of lazy-initializing: the TDD workflow has invariants (`.tdd/` shape, `selection-log.md`) a lazy bootstrap cannot reconstruct. Run the project's TDD adoption bin first, or `lakebase-create-project` when starting fresh.
+
+## Phases (HITL-gated)
+
+1. **Spec Author** drafts `spec.md` + `feature.json` from the prompt.
+2. **Architect Reviewer** challenges scope and boundaries. Gate 1 stops the pipeline until the human signs off.
+3. **Test Strategist** writes `test-list.json`. Gate 2 stops the pipeline until the human signs off.
+
+Each phase is implemented by the substrate agent of the same name:
+- `@lakebase-tdd-workflows/agents/spec-author`
+- `@lakebase-tdd-workflows/agents/architect-reviewer`
+- `@lakebase-tdd-workflows/agents/test-strategist`
+
+References resolve through Claude Code's `@skill-name/agent-name` lookup, so agent renames inside the substrate skill stay safe.
+
+## Project pre/post hooks
+
+If `.claude/commands/design.pre-hook.md` exists in this project, it runs before phase 1. Common uses: create a JIRA epic for the feature, claim a working branch in Lakebase.
+
+If `.claude/commands/design.post-hook.md` exists in this project, it runs after phase 3. Common uses: notify a Slack channel, assign reviewers, link the spec into a tracking doc.
+
+The hooks are owned by the project, not the substrate: this command file only consults them when present. Author the markdown files freely; one pre-hook plus one post-hook per command (no chains in v1).
+
+## Substrate version
+
+Pinned to: `${KIT_VERSION_AT_SCAFFOLD}`
+
+Bumping the kit may shift agent prompts. The future `lakebase-update-commands` bin will re-pull canonical templates while preserving the pre/post hook files above.

--- a/tests/bdd/deploy-claude-commands.test.ts
+++ b/tests/bdd/deploy-claude-commands.test.ts
@@ -1,0 +1,160 @@
+// FEIP-7212 BDD coverage for the .claude/commands scaffold. Hermetic:
+// runs against a real kit templates tree + tmpdir; no shell-outs.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  deployClaudeCommands,
+  scaffoldStaticAll,
+} from "../../scripts/lakebase/scaffold";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(here, "..", "..");
+const REPO_TEMPLATES = path.join(REPO_ROOT, "templates", "project");
+
+function mkTempProject(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `feip7212-${prefix}-`));
+}
+
+function rmTempProject(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+describe("deployClaudeCommands", () => {
+  let targetDir: string;
+  beforeEach(() => {
+    targetDir = mkTempProject("deploy");
+  });
+  afterEach(() => rmTempProject(targetDir));
+
+  it("writes design.md and build.md under .claude/commands/", async () => {
+    const result = await deployClaudeCommands(targetDir, { templatesDir: REPO_TEMPLATES });
+    expect(result.written.sort()).toEqual(
+      [path.join(".claude", "commands", "build.md"), path.join(".claude", "commands", "design.md")].sort()
+    );
+    expect(result.skipped).toEqual([]);
+    expect(fs.existsSync(path.join(targetDir, ".claude", "commands", "design.md"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, ".claude", "commands", "build.md"))).toBe(true);
+  });
+
+  it("substitutes ${KIT_VERSION_AT_SCAFFOLD} with the real kit version", async () => {
+    const kitPkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8")) as {
+      version: string;
+    };
+    await deployClaudeCommands(targetDir, { templatesDir: REPO_TEMPLATES });
+    const design = fs.readFileSync(path.join(targetDir, ".claude", "commands", "design.md"), "utf8");
+    const build = fs.readFileSync(path.join(targetDir, ".claude", "commands", "build.md"), "utf8");
+    expect(design).not.toMatch(/\$\{KIT_VERSION_AT_SCAFFOLD\}/);
+    expect(build).not.toMatch(/\$\{KIT_VERSION_AT_SCAFFOLD\}/);
+    expect(design).toContain(`Pinned to: \`${kitPkg.version}\``);
+    expect(build).toContain(`Pinned to: \`${kitPkg.version}\``);
+  });
+
+  it("skips existing files by default and reports them in `skipped`", async () => {
+    fs.mkdirSync(path.join(targetDir, ".claude", "commands"), { recursive: true });
+    const userContent = "# my custom /design\n";
+    fs.writeFileSync(path.join(targetDir, ".claude", "commands", "design.md"), userContent);
+    const result = await deployClaudeCommands(targetDir, { templatesDir: REPO_TEMPLATES });
+    expect(result.skipped).toContain(path.join(".claude", "commands", "design.md"));
+    expect(result.written).not.toContain(path.join(".claude", "commands", "design.md"));
+    expect(result.written).toContain(path.join(".claude", "commands", "build.md"));
+    expect(fs.readFileSync(path.join(targetDir, ".claude", "commands", "design.md"), "utf8")).toBe(
+      userContent
+    );
+  });
+
+  it("overwrites with force=true even when files already exist", async () => {
+    fs.mkdirSync(path.join(targetDir, ".claude", "commands"), { recursive: true });
+    fs.writeFileSync(path.join(targetDir, ".claude", "commands", "design.md"), "stale\n");
+    const result = await deployClaudeCommands(targetDir, {
+      templatesDir: REPO_TEMPLATES,
+      force: true,
+    });
+    expect(result.written).toContain(path.join(".claude", "commands", "design.md"));
+    expect(result.skipped).not.toContain(path.join(".claude", "commands", "design.md"));
+    expect(fs.readFileSync(path.join(targetDir, ".claude", "commands", "design.md"), "utf8")).not.toBe(
+      "stale\n"
+    );
+  });
+
+  it("returns empty arrays when the kit ships no command templates", async () => {
+    // Synthesize a templates tree that mimics the kit layout but omits
+    // the .claude/commands subdir. The marker file
+    // (common/.gitignore.base) MUST exist so the auto-locate logic in
+    // scaffold.ts doesn't fall back to the real kit templates.
+    const fakeTemplates = mkTempProject("no-commands-templates");
+    const fakeCommon = path.join(fakeTemplates, "common");
+    fs.mkdirSync(fakeCommon, { recursive: true });
+    fs.writeFileSync(path.join(fakeCommon, ".gitignore.base"), "");
+    try {
+      const result = await deployClaudeCommands(targetDir, { templatesDir: fakeTemplates });
+      expect(result.written).toEqual([]);
+      expect(result.skipped).toEqual([]);
+      expect(fs.existsSync(path.join(targetDir, ".claude", "commands"))).toBe(false);
+    } finally {
+      rmTempProject(fakeTemplates);
+    }
+  });
+
+  it("design.md references @lakebase-tdd-workflows agents and the pre/post-hook convention", async () => {
+    await deployClaudeCommands(targetDir, { templatesDir: REPO_TEMPLATES });
+    const design = fs.readFileSync(path.join(targetDir, ".claude", "commands", "design.md"), "utf8");
+    expect(design).toMatch(/@lakebase-tdd-workflows\/agents\/spec-author/);
+    expect(design).toMatch(/@lakebase-tdd-workflows\/agents\/architect-reviewer/);
+    expect(design).toMatch(/@lakebase-tdd-workflows\/agents\/test-strategist/);
+    expect(design).toMatch(/design\.pre-hook\.md/);
+    expect(design).toMatch(/design\.post-hook\.md/);
+  });
+
+  it("build.md references the Scrum-Master orchestrator + Driver + Navigator", async () => {
+    await deployClaudeCommands(targetDir, { templatesDir: REPO_TEMPLATES });
+    const build = fs.readFileSync(path.join(targetDir, ".claude", "commands", "build.md"), "utf8");
+    expect(build).toMatch(/@lakebase-tdd-workflows\/agents\/scrum-master/);
+    expect(build).toMatch(/@lakebase-tdd-workflows\/agents\/driver/);
+    expect(build).toMatch(/@lakebase-tdd-workflows\/agents\/navigator/);
+    expect(build).toMatch(/build\.pre-hook\.md/);
+    expect(build).toMatch(/build\.post-hook\.md/);
+  });
+});
+
+describe("scaffoldStaticAll integration", () => {
+  let targetDir: string;
+  beforeEach(() => {
+    targetDir = mkTempProject("static");
+    // scaffoldStaticAll's installHooks step calls `git config --local`,
+    // which requires a real git repo (a bare .git/hooks dir is not enough).
+    execSync("git init --quiet", { cwd: targetDir, stdio: "pipe" });
+  });
+  afterEach(() => rmTempProject(targetDir));
+
+  it("scaffolds .claude/commands by default and reports the paths in claudeCommands", async () => {
+    const result = await scaffoldStaticAll({
+      targetDir,
+      templatesDir: REPO_TEMPLATES,
+      language: "nodejs",
+    });
+    expect(result.claudeCommands.sort()).toEqual(
+      [path.join(".claude", "commands", "build.md"), path.join(".claude", "commands", "design.md")].sort()
+    );
+    expect(fs.existsSync(path.join(targetDir, ".claude", "commands", "design.md"))).toBe(true);
+  });
+
+  it("skipCommands=true skips the scaffold and reports an empty claudeCommands list", async () => {
+    const result = await scaffoldStaticAll({
+      targetDir,
+      templatesDir: REPO_TEMPLATES,
+      language: "nodejs",
+      skipCommands: true,
+    });
+    expect(result.claudeCommands).toEqual([]);
+    expect(fs.existsSync(path.join(targetDir, ".claude", "commands"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes FEIP-7212. The lakebase-tdd-workflows README treats `/design` and `/build` as canonical entry points but every consumer had to hand-roll them. `lakebase-create-project` now scaffolds them under `.claude/commands/` by default (opt-out: `--skip-commands`).

- `templates/project/common/.claude/commands/{design,build}.md`: thin wrappers around the substrate agents, pinned to the kit version via `\${KIT_VERSION_AT_SCAFFOLD}`. Documented `design.{pre,post}-hook.md` and `build.{pre,post}-hook.md` convention for project extensions.
- `deployClaudeCommands` helper in `scripts/lakebase/scaffold.ts` with substitution + idempotent skip-existing semantics. Wired into `scaffoldStaticAll`.
- `--skip-commands` flag added to `lakebase-create-project`.
- Docs: SKILL.md flag doc, README scaffold-layout diagram, lakebase-tdd-workflows/README.md framing now reflects scaffolded-by-default.

Per ADR-0007: implementation steps 1-5. Steps 6 and 7 (drift detector + update bin) filed as follow-ups FEIP-7424 + FEIP-7425.

## Test plan

- [x] 880/988 hermetic tests pass (+9 net)
- [x] tsc clean, build emits the templated commands
- [ ] Scaffold a fresh project and confirm `.claude/commands/{design,build}.md` land with version pin

This pull request and its description were written by Isaac.