### PR TITLE
lakebase-adopt-tdd bin for brownfield TDD adoption (FEIP-7216)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "lakebase-schema-diff": "./dist/scripts/lakebase/schema-diff.cli.js",
     "lakebase-schema-migrate": "./dist/scripts/lakebase/schema-migrate.cli.js",
     "lakebase-github-token": "./dist/scripts/github/auth.cli.js",
+    "lakebase-adopt-tdd": "./dist/scripts/lakebase/adopt-tdd.cli.js",
     "lakebase-create-project": "./dist/scripts/lakebase/create-project.cli.js",
     "lakebase-cut-backup": "./dist/scripts/lakebase/cut-backup.cli.js",
     "lakebase-detect-language": "./dist/scripts/lakebase/detect-language.cli.js",

--- a/scripts/lakebase/adopt-tdd.cli.ts
+++ b/scripts/lakebase/adopt-tdd.cli.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// CLI wrapper around adoptTdd. Brownfield-only entry point: drop
+// `.tdd/` into an existing repo. Sibling to `lakebase-create-project`,
+// which is the greenfield path. See `adopt-tdd.ts` for the orchestrator.
+
+import { adoptTdd, type AdoptTddArgs } from "./adopt-tdd.js";
+
+interface ParsedArgs {
+  projectDir?: string;
+  update?: boolean;
+  force?: boolean;
+  dryRun?: boolean;
+  help?: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--project-dir":
+      case "-C":
+        out.projectDir = argv[++i];
+        break;
+      case "--update":
+        out.update = true;
+        break;
+      case "--force":
+        out.force = true;
+        break;
+      case "--dry-run":
+        out.dryRun = true;
+        break;
+      case "--help":
+      case "-h":
+        out.help = true;
+        break;
+      default:
+        if (!a.startsWith("-") && !out.projectDir) {
+          out.projectDir = a;
+        }
+        break;
+    }
+  }
+  return out;
+}
+
+const HELP = `lakebase-adopt-tdd – bootstrap the .tdd/ workflow tree on an existing repo
+
+Usage:
+  lakebase-adopt-tdd [path]                     fresh adoption; fails if .tdd/ exists
+  lakebase-adopt-tdd [path] --update            report drift, add missing files
+  lakebase-adopt-tdd [path] --update --force    additionally overwrite drifted files
+  lakebase-adopt-tdd [path] --dry-run --update  preview without writing
+
+Flags:
+  --project-dir <path>, -C <path>   Project root (defaults to current directory)
+  --update                          Allow running on a project that already has .tdd/
+  --force                           Overwrite drifted template files (implies --update)
+  --dry-run                         Report what would change; write nothing
+  --help, -h                        Show this help
+
+Output: JSON to stdout: { added, inSync, drifted, updated, noChanges }
+       Exit codes:
+         0 - success (whether or not changes were applied)
+         1 - operational failure (not a git repo, .tdd/ exists without --update, etc.)
+`;
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const input: AdoptTddArgs = {
+    projectDir: args.projectDir ?? process.cwd(),
+    update: args.update,
+    force: args.force,
+    dryRun: args.dryRun,
+  };
+  const result = adoptTdd(input);
+  process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+);

--- a/scripts/lakebase/adopt-tdd.ts
+++ b/scripts/lakebase/adopt-tdd.ts
@@ -1,0 +1,184 @@
+// Brownfield TDD adoption: drop the `.tdd/` scaffold into an existing
+// repo so the lakebase-tdd-workflows skill has a place to write.
+//
+// Greenfield path: `lakebase-create-project` calls `layDownTddScaffold`
+// as one step in its 11-step pipeline. The brownfield equivalent needs
+// just that one step plus a clean idempotency model so a team can adopt
+// TDD on a repo that already exists without `create-project`'s GitHub /
+// Lakebase / language-scaffold side effects.
+//
+// This module owns the orchestrator + helpers; the CLI wrapper lives at
+// `adopt-tdd.cli.ts`. The pre/post-flight knobs (--update / --force /
+// --dry-run) all funnel through this function so the BDD harness can
+// drive every behavior without spawning a process.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface AdoptTddArgs {
+  /** Project root that will receive `.tdd/`. Must be a git repo. */
+  projectDir: string;
+  /**
+   * Re-run on a project that already has `.tdd/`. Without it the call
+   * refuses (the default-fail surfaces a clear hint instead of silently
+   * doing nothing). With it, missing template files are added and the
+   * report distinguishes in-sync vs drifted entries; existing files are
+   * preserved unless `force` is also true.
+   */
+  update?: boolean;
+  /**
+   * Overwrite drifted template files with the canonical kit version.
+   * Implies `update`. Project-authored files outside the template tree
+   * are never touched.
+   */
+  force?: boolean;
+  /**
+   * Report what would change without writing anything. Useful for CI
+   * checks and for the human-facing "what does this command do" probe.
+   */
+  dryRun?: boolean;
+  /**
+   * Override the kit's `templates/tdd-bootstrap/.tdd` source. The BDD
+   * harness uses this to drive against a fixture; production callers
+   * always let the substrate auto-locate.
+   */
+  bootstrapDir?: string;
+}
+
+export interface AdoptTddResult {
+  /** Files written this run (or, in dry-run, files that would be written). */
+  added: string[];
+  /** Files already present with content matching the canonical template. */
+  inSync: string[];
+  /** Files already present whose content differs from the canonical template. */
+  drifted: string[];
+  /** Files written this run because `force` overrode their drift. */
+  updated: string[];
+  /** True iff no files were modified (the call is a clean no-op). */
+  noChanges: boolean;
+}
+
+/**
+ * Drop the `templates/tdd-bootstrap/.tdd` tree into `projectDir/.tdd`.
+ *
+ * Default mode: refuses if `.tdd/` already exists. The caller is told
+ * to re-run with `update: true` if they want a brownfield refresh.
+ *
+ * `update` mode walks the template tree and writes any missing file;
+ * existing files are inspected and bucketed into `inSync` vs `drifted`.
+ *
+ * `force` mode (implies `update`) additionally rewrites drifted files
+ * with the canonical template content. The `.gitkeep` placeholders
+ * never count as drift since they are intentionally empty.
+ *
+ * `dryRun` mode returns the same report but writes nothing.
+ */
+export function adoptTdd(args: AdoptTddArgs): AdoptTddResult {
+  if (!fs.existsSync(args.projectDir)) {
+    throw new Error(`Project directory does not exist: ${args.projectDir}`);
+  }
+  if (!fs.existsSync(path.join(args.projectDir, ".git"))) {
+    throw new Error(
+      `Not a git repo root: ${args.projectDir}. Run \`git init\` first, or pass a path that already has \`.git/\`.`
+    );
+  }
+  const dest = path.join(args.projectDir, ".tdd");
+  const update = args.update === true || args.force === true;
+  if (fs.existsSync(dest) && !update) {
+    throw new Error(
+      `.tdd/ already exists at ${dest}. Re-run with --update to refresh missing files (drift is reported, not overwritten) or --update --force to overwrite drifted ones.`
+    );
+  }
+
+  const src = args.bootstrapDir ?? findBootstrapDir();
+  const entries = walkTemplateTree(src);
+  const added: string[] = [];
+  const inSync: string[] = [];
+  const drifted: string[] = [];
+  const updated: string[] = [];
+
+  for (const rel of entries) {
+    const fromPath = path.join(src, rel);
+    const toPath = path.join(dest, rel);
+    if (!fs.existsSync(toPath)) {
+      if (!args.dryRun) {
+        fs.mkdirSync(path.dirname(toPath), { recursive: true });
+        fs.copyFileSync(fromPath, toPath);
+      }
+      added.push(rel);
+      continue;
+    }
+    const before = fs.readFileSync(fromPath);
+    const after = fs.readFileSync(toPath);
+    if (before.equals(after)) {
+      inSync.push(rel);
+      continue;
+    }
+    if (args.force) {
+      if (!args.dryRun) {
+        fs.copyFileSync(fromPath, toPath);
+      }
+      updated.push(rel);
+    } else {
+      drifted.push(rel);
+    }
+  }
+
+  return {
+    added,
+    inSync,
+    drifted,
+    updated,
+    noChanges: added.length === 0 && updated.length === 0,
+  };
+}
+
+/**
+ * Walk the bootstrap tree and return paths relative to its root,
+ * sorted for deterministic output. `.gitkeep` files are kept because
+ * they preserve empty subdirectory structure in git.
+ */
+function walkTemplateTree(root: string): string[] {
+  if (!fs.existsSync(root)) {
+    throw new Error(`tdd-bootstrap template tree missing: ${root}`);
+  }
+  const out: string[] = [];
+  const stack: string[] = [""];
+  while (stack.length) {
+    const rel = stack.pop()!;
+    const abs = path.join(root, rel);
+    for (const entry of fs.readdirSync(abs)) {
+      const childRel = rel ? path.join(rel, entry) : entry;
+      const childAbs = path.join(abs, entry);
+      const stat = fs.statSync(childAbs);
+      if (stat.isDirectory()) {
+        stack.push(childRel);
+      } else {
+        out.push(childRel);
+      }
+    }
+  }
+  return out.sort();
+}
+
+let cachedBootstrapDir: string | undefined;
+function findBootstrapDir(): string {
+  if (cachedBootstrapDir) return cachedBootstrapDir;
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  let dir = here;
+  for (let i = 0; i < 6; i++) {
+    const candidate = path.join(dir, "templates", "tdd-bootstrap", ".tdd");
+    if (fs.existsSync(candidate)) {
+      cachedBootstrapDir = candidate;
+      return cachedBootstrapDir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(
+    `Could not locate templates/tdd-bootstrap/.tdd relative to ${here}. ` +
+      `Pass explicit { bootstrapDir } to override.`
+  );
+}

--- a/scripts/lakebase/index.ts
+++ b/scripts/lakebase/index.ts
@@ -5,6 +5,7 @@
 // re-export ambiguity, we only pull `createProject` from it and let the
 // canonical owner files (env-file.ts, project-verify.ts) export those names.
 
+export * from "./adopt-tdd.js";
 export * from "./branch-create.js";
 export * from "./branch-delete.js";
 export * from "./convention-branches.js";

--- a/tests/bdd/adopt-tdd.test.ts
+++ b/tests/bdd/adopt-tdd.test.ts
@@ -1,0 +1,208 @@
+// BDD coverage for the brownfield TDD adoption bin. Hermetic: every
+// test runs against a tmpdir + real git init + real kit templates.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { adoptTdd } from "../../scripts/lakebase/adopt-tdd";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(here, "..", "..");
+const REAL_BOOTSTRAP = path.join(REPO_ROOT, "templates", "tdd-bootstrap", ".tdd");
+
+function mkRepo(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `adopt-tdd-${prefix}-`));
+  execSync("git init --quiet", { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+
+function rm(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+describe("adoptTdd: fresh adoption", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = mkRepo("fresh");
+  });
+  afterEach(() => rm(repo));
+
+  it("copies the bootstrap tree into .tdd/ and reports every file in `added`", () => {
+    const result = adoptTdd({ projectDir: repo });
+    expect(result.added.length).toBeGreaterThan(0);
+    expect(result.inSync).toEqual([]);
+    expect(result.drifted).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.noChanges).toBe(false);
+
+    // Spot-check that representative files actually landed.
+    expect(fs.existsSync(path.join(repo, ".tdd", "spec.md"))).toBe(true);
+    expect(fs.existsSync(path.join(repo, ".tdd", "workflow-state.json"))).toBe(true);
+    expect(fs.existsSync(path.join(repo, ".tdd", "features", ".gitkeep"))).toBe(true);
+  });
+
+  it("refuses without --update when .tdd/ already exists", () => {
+    adoptTdd({ projectDir: repo });
+    expect(() => adoptTdd({ projectDir: repo })).toThrow(/already exists.*--update/i);
+  });
+});
+
+describe("adoptTdd: pre-flight checks", () => {
+  it("refuses when the project dir is missing", () => {
+    const missing = path.join(os.tmpdir(), `adopt-tdd-missing-${Date.now()}`);
+    expect(() => adoptTdd({ projectDir: missing })).toThrow(/does not exist/i);
+  });
+
+  it("refuses when the project dir is not a git repo", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "adopt-tdd-nogit-"));
+    try {
+      expect(() => adoptTdd({ projectDir: dir })).toThrow(/Not a git repo/i);
+    } finally {
+      rm(dir);
+    }
+  });
+});
+
+describe("adoptTdd: --update mode", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = mkRepo("update");
+  });
+  afterEach(() => rm(repo));
+
+  it("on a clean re-run, every file is in-sync and noChanges=true", () => {
+    adoptTdd({ projectDir: repo });
+    const second = adoptTdd({ projectDir: repo, update: true });
+    expect(second.added).toEqual([]);
+    expect(second.drifted).toEqual([]);
+    expect(second.updated).toEqual([]);
+    expect(second.inSync.length).toBeGreaterThan(0);
+    expect(second.noChanges).toBe(true);
+  });
+
+  it("reports drift on user-edited files without overwriting them", () => {
+    adoptTdd({ projectDir: repo });
+    const specPath = path.join(repo, ".tdd", "spec.md");
+    fs.writeFileSync(specPath, "user-edited content\n", "utf8");
+    const result = adoptTdd({ projectDir: repo, update: true });
+    expect(result.drifted).toContain("spec.md");
+    expect(result.updated).not.toContain("spec.md");
+    expect(fs.readFileSync(specPath, "utf8")).toBe("user-edited content\n");
+  });
+
+  it("adds files that the project is missing relative to the kit template", () => {
+    adoptTdd({ projectDir: repo });
+    fs.rmSync(path.join(repo, ".tdd", "smells.json"));
+    const result = adoptTdd({ projectDir: repo, update: true });
+    expect(result.added).toContain("smells.json");
+    expect(fs.existsSync(path.join(repo, ".tdd", "smells.json"))).toBe(true);
+  });
+});
+
+describe("adoptTdd: --force mode", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = mkRepo("force");
+  });
+  afterEach(() => rm(repo));
+
+  it("overwrites drifted files and reports them under `updated`", () => {
+    adoptTdd({ projectDir: repo });
+    const specPath = path.join(repo, ".tdd", "spec.md");
+    fs.writeFileSync(specPath, "user-edited content\n", "utf8");
+    const result = adoptTdd({ projectDir: repo, force: true });
+    expect(result.updated).toContain("spec.md");
+    expect(result.drifted).not.toContain("spec.md");
+    expect(fs.readFileSync(specPath, "utf8")).not.toBe("user-edited content\n");
+  });
+
+  it("force implies update: it also runs on a project that already has .tdd/", () => {
+    adoptTdd({ projectDir: repo });
+    // Without an explicit `update: true`, a force re-run still succeeds.
+    const result = adoptTdd({ projectDir: repo, force: true });
+    expect(result.noChanges).toBe(true);
+  });
+});
+
+describe("adoptTdd: --dry-run mode", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = mkRepo("dryrun");
+  });
+  afterEach(() => rm(repo));
+
+  it("reports a fresh adoption without writing any files", () => {
+    const result = adoptTdd({ projectDir: repo, dryRun: true });
+    expect(result.added.length).toBeGreaterThan(0);
+    expect(fs.existsSync(path.join(repo, ".tdd"))).toBe(false);
+  });
+
+  it("reports the same buckets in --update --dry-run mode", () => {
+    adoptTdd({ projectDir: repo });
+    fs.writeFileSync(path.join(repo, ".tdd", "spec.md"), "user-edit\n", "utf8");
+    const result = adoptTdd({ projectDir: repo, update: true, dryRun: true });
+    expect(result.drifted).toContain("spec.md");
+    // No files modified during dry-run.
+    expect(fs.readFileSync(path.join(repo, ".tdd", "spec.md"), "utf8")).toBe("user-edit\n");
+  });
+
+  it("dry-run with --force reports drifted files under `updated` without touching them", () => {
+    adoptTdd({ projectDir: repo });
+    const specPath = path.join(repo, ".tdd", "spec.md");
+    fs.writeFileSync(specPath, "user-edit\n", "utf8");
+    const result = adoptTdd({ projectDir: repo, force: true, dryRun: true });
+    expect(result.updated).toContain("spec.md");
+    expect(fs.readFileSync(specPath, "utf8")).toBe("user-edit\n");
+  });
+});
+
+describe("adoptTdd: bootstrap-dir override", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = mkRepo("override");
+  });
+  afterEach(() => rm(repo));
+
+  it("honors an explicit bootstrapDir and skips the auto-locate walk", () => {
+    // Synthesize a minimal fixture (a single file) and assert the
+    // override is the source of truth.
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "adopt-tdd-fixture-"));
+    try {
+      fs.writeFileSync(path.join(fixture, "README.md"), "# fixture-only\n");
+      const result = adoptTdd({ projectDir: repo, bootstrapDir: fixture });
+      expect(result.added).toEqual(["README.md"]);
+      expect(fs.readFileSync(path.join(repo, ".tdd", "README.md"), "utf8")).toBe(
+        "# fixture-only\n"
+      );
+    } finally {
+      rm(fixture);
+    }
+  });
+
+  it("rejects a missing bootstrapDir", () => {
+    const missing = path.join(os.tmpdir(), `missing-bootstrap-${Date.now()}`);
+    expect(() => adoptTdd({ projectDir: repo, bootstrapDir: missing })).toThrow(
+      /bootstrap template tree missing/i
+    );
+  });
+});
+
+describe("adoptTdd: canonical bootstrap inspection", () => {
+  it("the kit ships every file the docs reference", () => {
+    // Spot-check the bootstrap-dir auto-located via the real kit. If
+    // a future change reorganizes templates/tdd-bootstrap/.tdd the
+    // contract here breaks loudly instead of silently shrinking.
+    expect(fs.existsSync(path.join(REAL_BOOTSTRAP, "spec.md"))).toBe(true);
+    expect(fs.existsSync(path.join(REAL_BOOTSTRAP, "workflow-state.json"))).toBe(true);
+    expect(fs.existsSync(path.join(REAL_BOOTSTRAP, "selection-log.md"))).toBe(true);
+    expect(fs.existsSync(path.join(REAL_BOOTSTRAP, "smells.json"))).toBe(true);
+    expect(fs.existsSync(path.join(REAL_BOOTSTRAP, "features", ".gitkeep"))).toBe(true);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     "scripts/lakebase/schema-diff.cli": "scripts/lakebase/schema-diff.cli.ts",
     "scripts/lakebase/schema-migrate.cli": "scripts/lakebase/schema-migrate.cli.ts",
     "scripts/lakebase/create-project.cli": "scripts/lakebase/create-project.cli.ts",
+    "scripts/lakebase/adopt-tdd.cli": "scripts/lakebase/adopt-tdd.cli.ts",
     "scripts/lakebase/cut-backup.cli": "scripts/lakebase/cut-backup.cli.ts",
     "scripts/lakebase/detect-language.cli": "scripts/lakebase/detect-language.cli.ts",
     "scripts/lakebase/branch.cli": "scripts/lakebase/branch.cli.ts",


### PR DESCRIPTION
## Summary

Closes FEIP-7216. Greenfield bootstrap is `lakebase-create-project`; this is the brownfield sibling. `lakebase-adopt-tdd` drops just the `.tdd/` scaffold into an existing repo without touching the rest of the codebase.

- `adoptTdd({ projectDir, update?, force?, dryRun?, bootstrapDir? })`: pre-flights for a git repo, refuses to clobber an existing `.tdd/` without `--update`, buckets every template file into added / inSync / drifted / updated.
- `lakebase-adopt-tdd` CLI bin with `--update` / `--force` / `--dry-run` / `--project-dir` / `--help`.
- Exports + tsup entry + bin map.

## Test plan

- [x] 886/994 hermetic tests pass (+15 net)
- [x] tsc clean, build emits the new bin
- [ ] Smoke: `lakebase-adopt-tdd` on a fresh git repo, then again with `--update --dry-run` after editing `.tdd/spec.md`

This pull request and its description were written by Isaac.