### PR TITLE
N>=2 comparison-report renderer + JIRA adapter audit (FEIP-7208 / FEIP-7209)

### DIFF
--- a/scripts/tdd/adapters/jira.ts
+++ b/scripts/tdd/adapters/jira.ts
@@ -2,7 +2,7 @@ import type { SpecAdapter, AdapterContext, SpecEntity } from "./types";
 import type { Feature, Story, AC } from "../spec-sync";
 
 const NOT_IMPLEMENTED = (verb: string) =>
-  new Error(`JiraAdapter.${verb} not implemented; wire under FEIP-7167 follow-up`);
+  new Error(`JiraAdapter.${verb} not implemented; tracked under FEIP-7427`);
 
 export interface JiraAdapterConfig {
   projectKey: string;

--- a/scripts/tdd/comparison-report.ts
+++ b/scripts/tdd/comparison-report.ts
@@ -1,0 +1,216 @@
+// Markdown renderer for compareExperiments output. The structured
+// payload alone cannot drive the promote / synthesize / continue /
+// abandon-all HITL decision: a human needs to read one document and
+// answer. The Scrum-Master agent calls renderComparisonReport at
+// N>=2 convergence, writes it under .tdd/features/<F>/, and surfaces
+// the path back to the PO.
+//
+// The renderer is a pure function over ComparisonReport. The write
+// orchestrator handles file placement and the selection-log breadcrumb.
+
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { ComparisonReport, ExperimentRow, TagMatrixRow } from "./compare-experiments.js";
+
+export interface WriteComparisonReportArgs {
+  tddDir: string;
+  featureId: string;
+  report: ComparisonReport;
+  /**
+   * Override the `generated_at` ISO timestamp used in the on-disk
+   * filename. Defaults to `report.generated_at`. Pass an explicit
+   * value when the caller needs deterministic file paths.
+   */
+  filenameTimestamp?: string;
+  /**
+   * Skip the selection-log append. Default: false (append). Set when
+   * the caller wants to manage the log entry itself (e.g. dry-run,
+   * BDD harness, an agent that emits a richer log line).
+   */
+  skipSelectionLog?: boolean;
+}
+
+export interface WriteComparisonReportResult {
+  /** Absolute path of the rendered comparison file. */
+  reportPath: string;
+  /** True iff a selection-log breadcrumb was appended this call. */
+  logEntryAppended: boolean;
+  /** The rendered markdown body (also available without writing). */
+  content: string;
+}
+
+/**
+ * Write the rendered comparison report under
+ * `<tddDir>/features/<featureId>/comparison-<timestamp>.md` and
+ * append a one-line breadcrumb to `<tddDir>/selection-log.md` so the
+ * existing narrative-of-record points readers at the new file.
+ *
+ * The timestamp in the filename is the `generated_at` field from the
+ * report (or `filenameTimestamp` override). Colons are stripped so
+ * the filename survives ZIP / filesystem round-trips on case-folding
+ * platforms.
+ */
+export function writeComparisonReport(args: WriteComparisonReportArgs): WriteComparisonReportResult {
+  const featureDir = join(args.tddDir, "features", args.featureId);
+  mkdirSync(featureDir, { recursive: true });
+  const rawTs = args.filenameTimestamp ?? args.report.generated_at;
+  const safeTs = rawTs.replace(/[:]/g, "-");
+  const reportPath = join(featureDir, `comparison-${safeTs}.md`);
+  const content = renderComparisonReport(args.report);
+  writeFileSync(reportPath, content, "utf8");
+
+  let logEntryAppended = false;
+  if (!args.skipSelectionLog) {
+    const logPath = join(args.tddDir, "selection-log.md");
+    const breadcrumb =
+      `\n## ${args.report.generated_at} - Comparison report for ${args.featureId}\n` +
+      `- **Recommendation:** ${args.report.recommendation}\n` +
+      `- **Rationale:** ${args.report.rationale}\n` +
+      `- **Detail:** [comparison-${safeTs}.md](features/${args.featureId}/comparison-${safeTs}.md)\n`;
+    if (existsSync(logPath)) {
+      appendFileSync(logPath, breadcrumb);
+    } else {
+      writeFileSync(logPath, breadcrumb.replace(/^\n/, ""));
+    }
+    logEntryAppended = true;
+  }
+
+  return { reportPath, logEntryAppended, content };
+}
+
+/**
+ * Render a ComparisonReport as a markdown document. Pure function;
+ * no filesystem side effects.
+ *
+ * Layout (top-to-bottom):
+ *   1. H1 with feature id + generated timestamp.
+ *   2. Recommendation block (callout-style) with rationale.
+ *   3. Per-experiment header table (slug, branch, status, signal,
+ *      cycles, runtime, artifacts, test totals).
+ *   4. Tag x experiment matrix (one row per tag, one column per
+ *      experiment). Empty when no experiment reported per-tag data.
+ *   5. Schema-diff side-by-side (per-experiment summary).
+ *   6. HITL decision block with the four options + a structured
+ *      prompt the orchestrator copies verbatim into the next PO
+ *      message.
+ */
+export function renderComparisonReport(report: ComparisonReport): string {
+  const lines: string[] = [];
+  lines.push(`# Comparison report: ${report.feature_id}`);
+  lines.push(``);
+  lines.push(`Generated at \`${report.generated_at}\`. ${report.rows.length} experiment(s) evaluated.`);
+  lines.push(``);
+  lines.push(renderRecommendationBlock(report));
+  lines.push(``);
+  lines.push(`## Per-experiment summary`);
+  lines.push(``);
+  lines.push(renderExperimentTable(report.rows));
+  lines.push(``);
+  lines.push(`## Tag × experiment matrix`);
+  lines.push(``);
+  lines.push(renderMatrixTable(report.rows, report.matrix));
+  lines.push(``);
+  lines.push(`## Schema-diff side-by-side`);
+  lines.push(``);
+  lines.push(renderSchemaDiffTable(report.rows));
+  lines.push(``);
+  lines.push(renderDecisionBlock(report));
+  lines.push(``);
+  return lines.join("\n");
+}
+
+function renderRecommendationBlock(report: ComparisonReport): string {
+  return [
+    `> **Recommendation:** \`${report.recommendation}\``,
+    `>`,
+    `> ${report.rationale}`,
+  ].join("\n");
+}
+
+function renderExperimentTable(rows: ExperimentRow[]): string {
+  if (rows.length === 0) return `_No experiments cut yet._`;
+  const header = [
+    "| Experiment | Branch | Status | Signal | Cycles | Tests pass / fail | Code diff | Runtime | Artifacts |",
+    "|---|---|---|---|---|---|---|---|---|",
+  ];
+  const body = rows.map((r) => {
+    const tests =
+      r.tests_passed === undefined && r.tests_failed === undefined
+        ? "-"
+        : `${r.tests_passed ?? 0} / ${r.tests_failed ?? 0}`;
+    const codeDiff = r.code_diff_lines === undefined ? "-" : `${r.code_diff_lines} lines`;
+    const runtime = r.duration_ms === undefined ? "-" : formatDurationMs(r.duration_ms);
+    return `| \`${r.experiment_slug}\` | \`${r.branch_id}\` | ${r.status} | ${r.signal} | ${r.cycle_count} | ${tests} | ${codeDiff} | ${runtime} | ${r.artifact_count} |`;
+  });
+  return [...header, ...body].join("\n");
+}
+
+function renderMatrixTable(rows: ExperimentRow[], matrix: TagMatrixRow[]): string {
+  if (matrix.length === 0) {
+    return `_No per-tag outcomes recorded yet. The matrix populates once experiments record runner outcomes for [API] / [E2E] / [Infra] tags._`;
+  }
+  const slugs = rows.map((r) => r.experiment_slug);
+  const header = [
+    `| Tag | ${slugs.map((s) => `\`${s}\``).join(" | ")} |`,
+    `|---|${slugs.map(() => "---").join("|")}|`,
+  ];
+  const body = matrix.map((row) => {
+    const cells = slugs.map((slug) => {
+      const cell = row.cells[slug];
+      if (cell === null || cell === undefined) return "-";
+      return `${cell.passed} / ${cell.failed}`;
+    });
+    return `| \`${row.tag}\` | ${cells.join(" | ")} |`;
+  });
+  return [...header, ...body].join("\n");
+}
+
+function renderSchemaDiffTable(rows: ExperimentRow[]): string {
+  if (rows.length === 0) return `_No experiments to diff yet._`;
+  const anyDiff = rows.some((r) => r.schema_diff_summary && r.schema_diff_summary.length > 0);
+  if (!anyDiff) {
+    return `_No experiment has recorded a schema-diff summary yet (e.g. branches still provisioning)._`;
+  }
+  const header = ["| Experiment | Schema-diff vs parent |", "|---|---|"];
+  const body = rows.map((r) => {
+    const summary = r.schema_diff_summary
+      ? r.schema_diff_summary.replace(/\|/g, "\\|").replace(/\n/g, " ")
+      : "-";
+    return `| \`${r.experiment_slug}\` | ${summary} |`;
+  });
+  return [...header, ...body].join("\n");
+}
+
+function renderDecisionBlock(report: ComparisonReport): string {
+  const slugs = report.rows.map((r) => `\`${r.experiment_slug}\``);
+  const winners = report.rows.filter((r) => r.signal === "winning").map((r) => r.experiment_slug);
+  const winnerLine =
+    winners.length === 1
+      ? `Substrate signal indicates a single winner: \`${winners[0]}\`.`
+      : winners.length > 1
+        ? `Substrate signal indicates multiple winning experiments: ${winners.map((s) => `\`${s}\``).join(", ")}.`
+        : `No experiment is currently signalling "winning"; substrate recommendation is \`${report.recommendation}\`.`;
+  return [
+    `## HITL decision`,
+    ``,
+    winnerLine,
+    ``,
+    `Choose one path forward (the Scrum-Master orchestrator will route accordingly):`,
+    ``,
+    `1. **Promote** \`<slug>\` - take a single experiment to the feature PR as-is. Loser branches are archived.`,
+    `2. **Synthesize** - cherry-pick capabilities across ${slugs.join(", ") || "the experiments"} into a new synthesis branch and renegotiate the spec.`,
+    `3. **Continue** - let cycles keep running; no decision yet.`,
+    `4. **Abandon all** - none of the strategies converged; re-run the design-spec gate with new opinion gaps.`,
+    ``,
+    `Reply with one of: \`promote <slug>\`, \`synthesize\`, \`continue\`, \`abandon-all\`.`,
+  ].join("\n");
+}
+
+function formatDurationMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 100) / 10;
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.round(seconds - minutes * 60);
+  return `${minutes}m ${remainder}s`;
+}

--- a/skills/lakebase-tdd-workflows/agents/scrum-master.md
+++ b/skills/lakebase-tdd-workflows/agents/scrum-master.md
@@ -62,7 +62,7 @@ N=1:
 20. There is **no** promote/synthesize ceremony in N=1 – the branch IS the feature. Surface to PO for PR creation.
 
 N≥2:
-21. When experiments converge, run `compareExperiments()`. Show the report to PO.
+21. When experiments converge, run `compareExperiments()` and then `writeComparisonReport({ tddDir, featureId, report })` to render a single markdown file (`.tdd/features/<F>/comparison-<timestamp>.md`) that the PO can read top-to-bottom. The renderer covers the per-experiment table, tag×experiment matrix, schema-diff side-by-side, and an HITL decision block; it also appends a one-line breadcrumb to `selection-log.md`. Surface the file path to the PO.
 22. PO chooses:
     - **promote** → call `promoteExperiment({hitlApproved: true, approverEmail})`, then `approveGate({ featureId, gate: "promote", approver, hitlApproved: true, artifactInputs: { promote_ref: "<winner-slug>:<branch_id>" } })`.
     - **synthesize** → call `synthesizeExperiments({hitlApproved: true, picks, ...})`; spec is renegotiated; transition phase back to "test-list-construction" with the new tree. Call `withdrawGate({ featureId, gate: "spec", approver, reason: "synthesis renegotiation" })` to cascade-withdraw plan + test_list so the next iteration re-runs the gate flow on the new tree.

--- a/tests/bdd/comparison-report.test.ts
+++ b/tests/bdd/comparison-report.test.ts
@@ -1,0 +1,228 @@
+// BDD coverage for the comparison-report renderer + writer.
+// Hermetic: pure-function renderer + tmpdir writer; no shell-outs.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  renderComparisonReport,
+  writeComparisonReport,
+} from "../../scripts/tdd/comparison-report";
+import type { ComparisonReport, ExperimentRow, TagMatrixRow } from "../../scripts/tdd/compare-experiments";
+
+const FIXED_TIMESTAMP = "2026-06-02T08:15:00.000Z";
+
+function row(overrides: Partial<ExperimentRow>): ExperimentRow {
+  return {
+    experiment_slug: overrides.experiment_slug ?? "exp-x",
+    branch_id: overrides.branch_id ?? "feature-x",
+    status: overrides.status ?? "succeeded",
+    signal: overrides.signal ?? "winning",
+    cycle_count: overrides.cycle_count ?? 3,
+    artifact_count: overrides.artifact_count ?? 2,
+    ...overrides,
+  };
+}
+
+function matrixRow(overrides: Partial<TagMatrixRow>): TagMatrixRow {
+  return {
+    tag: overrides.tag ?? "api",
+    cells: overrides.cells ?? {},
+  };
+}
+
+function mkReport(overrides: Partial<ComparisonReport>): ComparisonReport {
+  return {
+    feature_id: overrides.feature_id ?? "F1-checkout",
+    generated_at: overrides.generated_at ?? FIXED_TIMESTAMP,
+    rows: overrides.rows ?? [],
+    matrix: overrides.matrix ?? [],
+    recommendation: overrides.recommendation ?? "continue",
+    rationale: overrides.rationale ?? "no decision yet",
+  };
+}
+
+function mkTempTdd(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `feip7208-${prefix}-`));
+}
+
+function rm(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+describe("renderComparisonReport: layout", () => {
+  it("renders the canonical four sections plus header + recommendation", () => {
+    const report = mkReport({
+      rows: [row({ experiment_slug: "exp-a" }), row({ experiment_slug: "exp-b" })],
+    });
+    const md = renderComparisonReport(report);
+    expect(md).toMatch(/^# Comparison report: F1-checkout/);
+    expect(md).toMatch(/## Per-experiment summary/);
+    expect(md).toMatch(/## Tag × experiment matrix/);
+    expect(md).toMatch(/## Schema-diff side-by-side/);
+    expect(md).toMatch(/## HITL decision/);
+    // Recommendation callout near the top.
+    expect(md).toMatch(/> \*\*Recommendation:\*\* `continue`/);
+  });
+
+  it("lists every experiment in the per-experiment table", () => {
+    const report = mkReport({
+      rows: [
+        row({ experiment_slug: "exp-postgres-arrays", branch_id: "checkout-pg" }),
+        row({ experiment_slug: "exp-json-blob", branch_id: "checkout-json" }),
+      ],
+    });
+    const md = renderComparisonReport(report);
+    expect(md).toMatch(/`exp-postgres-arrays`/);
+    expect(md).toMatch(/`checkout-pg`/);
+    expect(md).toMatch(/`exp-json-blob`/);
+    expect(md).toMatch(/`checkout-json`/);
+  });
+
+  it("surfaces a friendly placeholder when no per-tag data has been recorded yet", () => {
+    const report = mkReport({ rows: [row({})], matrix: [] });
+    const md = renderComparisonReport(report);
+    expect(md).toMatch(/No per-tag outcomes recorded yet/);
+  });
+
+  it("renders the tag × experiment matrix with one row per tag", () => {
+    const report = mkReport({
+      rows: [row({ experiment_slug: "exp-a" }), row({ experiment_slug: "exp-b" })],
+      matrix: [
+        matrixRow({
+          tag: "api",
+          cells: { "exp-a": { passed: 5, failed: 0 }, "exp-b": { passed: 5, failed: 1 } },
+        }),
+        matrixRow({
+          tag: "e2e",
+          cells: { "exp-a": { passed: 1, failed: 0 }, "exp-b": null },
+        }),
+      ],
+    });
+    const md = renderComparisonReport(report);
+    expect(md).toMatch(/\| `api` \| 5 \/ 0 \| 5 \/ 1 \|/);
+    expect(md).toMatch(/\| `e2e` \| 1 \/ 0 \| - \|/);
+  });
+
+  it("places experiments that have no schema-diff data behind a placeholder, otherwise renders a side-by-side table", () => {
+    const noDiff = mkReport({ rows: [row({ schema_diff_summary: undefined })] });
+    const noDiffMd = renderComparisonReport(noDiff);
+    expect(noDiffMd).toMatch(/No experiment has recorded a schema-diff summary yet/);
+
+    const withDiff = mkReport({
+      rows: [
+        row({ experiment_slug: "exp-a", schema_diff_summary: "+orders, +cart_items" }),
+        row({ experiment_slug: "exp-b", schema_diff_summary: "+orders, +cart_json" }),
+      ],
+    });
+    const withDiffMd = renderComparisonReport(withDiff);
+    expect(withDiffMd).toMatch(/\| `exp-a` \| \+orders, \+cart_items \|/);
+    expect(withDiffMd).toMatch(/\| `exp-b` \| \+orders, \+cart_json \|/);
+  });
+
+  it("escapes pipe characters in schema-diff summaries so the table stays intact", () => {
+    const report = mkReport({
+      rows: [row({ experiment_slug: "exp-a", schema_diff_summary: "col_a int | col_b text" })],
+    });
+    const md = renderComparisonReport(report);
+    expect(md).toMatch(/col_a int \\\| col_b text/);
+  });
+});
+
+describe("renderComparisonReport: HITL decision block", () => {
+  it("includes all four options + the structured reply prompt", () => {
+    const md = renderComparisonReport(mkReport({ rows: [row({})] }));
+    expect(md).toMatch(/\*\*Promote\*\*/);
+    expect(md).toMatch(/\*\*Synthesize\*\*/);
+    expect(md).toMatch(/\*\*Continue\*\*/);
+    expect(md).toMatch(/\*\*Abandon all\*\*/);
+    expect(md).toMatch(/Reply with one of: `promote <slug>`, `synthesize`, `continue`, `abandon-all`/);
+  });
+
+  it("calls out a single winner by slug when one exists", () => {
+    const report = mkReport({
+      rows: [
+        row({ experiment_slug: "exp-pg", signal: "winning" }),
+        row({ experiment_slug: "exp-json", signal: "stalled" }),
+      ],
+    });
+    const md = renderComparisonReport(report);
+    expect(md).toMatch(/Substrate signal indicates a single winner: `exp-pg`/);
+  });
+
+  it("lists multiple winners when more than one experiment signals winning", () => {
+    const report = mkReport({
+      rows: [
+        row({ experiment_slug: "exp-pg", signal: "winning" }),
+        row({ experiment_slug: "exp-json", signal: "winning" }),
+      ],
+    });
+    const md = renderComparisonReport(report);
+    expect(md).toMatch(/multiple winning experiments: `exp-pg`, `exp-json`/);
+  });
+
+  it("falls back to the substrate recommendation when no experiment is winning", () => {
+    const report = mkReport({
+      rows: [row({ signal: "stalled" })],
+      recommendation: "abandon-all",
+    });
+    const md = renderComparisonReport(report);
+    expect(md).toMatch(/No experiment is currently signalling "winning"; substrate recommendation is `abandon-all`/);
+  });
+});
+
+describe("writeComparisonReport", () => {
+  let tddDir: string;
+  beforeEach(() => {
+    tddDir = mkTempTdd("write");
+  });
+  afterEach(() => rm(tddDir));
+
+  it("writes the rendered markdown to features/<F>/comparison-<timestamp>.md and appends a selection-log entry", () => {
+    const report = mkReport({});
+    const result = writeComparisonReport({ tddDir, featureId: "F1", report });
+    expect(fs.existsSync(result.reportPath)).toBe(true);
+    expect(result.reportPath).toMatch(/features\/F1\/comparison-2026-06-02T08-15-00\.000Z\.md$/);
+    expect(result.content).toMatch(/# Comparison report: F1-checkout/);
+    expect(result.logEntryAppended).toBe(true);
+    const log = fs.readFileSync(path.join(tddDir, "selection-log.md"), "utf8");
+    expect(log).toMatch(/Comparison report for F1/);
+    expect(log).toMatch(/comparison-2026-06-02T08-15-00\.000Z\.md/);
+  });
+
+  it("honors filenameTimestamp override for deterministic paths", () => {
+    const report = mkReport({});
+    const result = writeComparisonReport({
+      tddDir,
+      featureId: "F1",
+      report,
+      filenameTimestamp: "fixed-ts",
+    });
+    expect(result.reportPath).toMatch(/comparison-fixed-ts\.md$/);
+  });
+
+  it("skipSelectionLog=true skips the breadcrumb append", () => {
+    const result = writeComparisonReport({
+      tddDir,
+      featureId: "F1",
+      report: mkReport({}),
+      skipSelectionLog: true,
+    });
+    expect(result.logEntryAppended).toBe(false);
+    expect(fs.existsSync(path.join(tddDir, "selection-log.md"))).toBe(false);
+  });
+
+  it("appends to an existing selection-log without clobbering prior content", () => {
+    const logPath = path.join(tddDir, "selection-log.md");
+    fs.writeFileSync(logPath, "# Selection log\n\nPrior entry.\n");
+    writeComparisonReport({ tddDir, featureId: "F1", report: mkReport({}) });
+    const log = fs.readFileSync(logPath, "utf8");
+    expect(log).toMatch(/Prior entry\./);
+    expect(log).toMatch(/Comparison report for F1/);
+  });
+});


### PR DESCRIPTION
## Summary

Two TDD tickets in one PR:

### FEIP-7208: comparison-report renderer

`compareExperiments` emits structured data but the JSON alone cannot drive promote / synthesize / continue / abandon-all HITL choices. This adds the markdown renderer the Scrum-Master orchestrator emits at N≥2 convergence so the PO reads one file end-to-end.

- `scripts/tdd/comparison-report.ts`: `renderComparisonReport` (pure) + `writeComparisonReport` (writes `features/<F>/comparison-<ts>.md` and appends a `selection-log.md` breadcrumb). Sections: recommendation callout, per-experiment table, tag×experiment matrix, schema-diff side-by-side, HITL decision block.
- `agents/scrum-master.md` step 21 now points at `writeComparisonReport`.
- `tests/bdd/comparison-report.test.ts`: 14 hermetic cases.

### FEIP-7209: JIRA adapter audit

Audited `scripts/tdd/adapters/jira.ts` and confirmed: concept-only (every method throws), no factory export, zero call sites. The stub's error message pointed at a non-existent "FEIP-7167 follow-up"; retargeted at the new FEIP-7427 which tracks the actual JIRA REST API implementation. Audit comment posted on FEIP-7209.

## Test plan

- [x] 984/1094 hermetic tests pass (+14 net for FEIP-7208)
- [x] tsc clean
- [x] FEIP-7427 filed under FEIP-7059 for the real JIRA adapter implementation

This pull request and its description were written by Isaac.