### PR TITLE
Document workflow skill features across all three READMEs

### DIFF
--- a/skills/lakebase-release-workflows/README.md
+++ b/skills/lakebase-release-workflows/README.md
@@ -1,0 +1,145 @@
+# lakebase-release-workflows
+
+The opinionated branching layout and release flow every Lakebase-paired project should follow. Composes on top of [`lakebase-scm-workflows`](../lakebase-scm-workflows/README.md) (which gives you `createBranch`, `getSchemaDiff`, `applySchemaMigrations`, and the matching CLI bins) and adds the canonical answer to "how do those primitives compose into a release."
+
+This README is the human-facing overview. The agent's operating contract (the branch table, the four-phase release sequence, the per-tier policy gates, the planned orchestrator primitives) lives in [`SKILL.md`](SKILL.md). The full reasoning and decision record lives in [`references/branching-and-release-methodology.md`](references/branching-and-release-methodology.md).
+
+## When to use
+
+- A new project is being bootstrapped and you need to decide branch layout and chain length.
+- A release candidate needs cutting, regression-testing, backing up, and migrating into a long-running tier.
+- An N-tier promotion (`dev` → `staging` → `prod`) needs to happen one tier at a time.
+- A rollback is being discussed and you need to know which backup branch to point at.
+- A team is asking whether a non-standard chain (extra preprod tier, split test / uat / perf) is supported and how to wire it.
+
+## Branch convention
+
+A project's branches form a directed chain of long-running tiers ending in `prod`. Working branches (`feature`, `test`, `uat`, `perf`) each target one tier in that chain, chosen by the architect at project bootstrap. Two-tier is the default; any chain length is supported and is stored in project metadata so agents and the VS Code extension read the same source of truth.
+
+Two-tier (default):
+
+```
+prod                                     (only updated by a release)
+ │
+ ▼
+staging                                  (next release accumulates here)
+ │
+ ▼
+{feature, test, uat, perf}               (working branches off staging)
+```
+
+Three-tier example (architect splits early work onto `dev`, validation onto `staging`):
+
+```
+prod              (only updated by a release from staging)
+ │
+ ▼
+staging           (only updated by a release from dev; validation work happens here)
+ │       ▲
+ │       └─── {test, uat, perf}
+ ▼
+dev               (next release accumulates here; feature work happens here)
+ │
+ ▼
+{feature}
+```
+
+| Branch | Purpose | Who merges in |
+|---|---|---|
+| `prod` | Production state. Lakebase + git both authoritative. | Release promotion only (no PRs from working branches). |
+| Each intermediate tier (`staging`, `dev`, `preprod`, ...) | Pre-promotion integration. Where the next release at this tier bakes. | Releases from the tier below + PRs from working-branch types whose configured target is this tier. |
+| `feature/<n>` | New work | Dev |
+| `test/<n>` | QA / regression rehearsal | QA |
+| `uat/<n>` | User acceptance | UAT runner / product |
+| `perf/<n>` | Load and performance testing | Perf engineer |
+
+Each working-branch type pairs to its own Lakebase branch via [`lakebase-scm-workflows`](../lakebase-scm-workflows/README.md)'s `createBranch` / `createFeatureBranch`. Schema changes flow up the chain one release at a time.
+
+## Every merge into a long-running branch IS a release
+
+The substrate maintains this convention uniformly. There is no separate "casual PR merge" vs "formal release" distinction:
+
+- `feature/X → staging` is a release to `staging`
+- `feature/X → dev` (three-tier shop) is a release to `dev`
+- `dev → staging` (three-tier shop) is a release to `staging`
+- `staging → prod` is a release to `prod`
+
+The same four-phase shape runs in all cases. What differs is whether the release candidate is implicit (the working branch IS the RC) or explicit (cut from `to` and merged with `from` for a tier-to-tier promotion).
+
+## The four-phase release flow
+
+A release promotes one branch (the `from` source) into a long-running target (the `to` tier). `from` can be a working branch or another long-running tier; `to` is always a long-running tier. The shape is identical at every release, only the from / to labels change. `to == prod` adds the app-deploy step; intermediate-tier releases skip it.
+
+A PR is required for every release. There are no direct pushes to long-running branches.
+
+1. **PR open → cut `ci-pr-branch` from `to`.** The substrate auto-creates an ephemeral Lakebase branch (per PR) forked from the current `to`. This is the release candidate. Cutting from `to` (not `from`) is what locks the release surface: the test runs against the current target's data shape, not whatever has accumulated on `from`. Wired by the kit-scaffolded `.github/workflows/pr.yml`.
+2. **Regression test the `ci-pr-branch`.** `pr.yml` runs `applySchemaMigrations` against the RC, then the project's full test suite. Merge is gated on this passing: GitHub branch protection blocks the merge button until the check is green.
+3. **PR merge → cut backup of `to`.** `merge.yml` on the `to` push fires `lakebase-cut-backup`, snapshotting current `to` (Lakebase branch + git tag). One-step revert target. Runs at every tier: `staging-backup-<id>` matters less than `prod-backup-<id>`, but the same primitive runs for both.
+4. **Migrate `to`.** `merge.yml` continues with `applySchemaMigrations` against `to`'s Lakebase branch, fast-forwards `to` in git, and (only when `to == prod`) deploys the app.
+
+The shape is identical for `feature/X → staging` and `staging → prod`. For `staging → prod` specifically, the `ci-pr-branch` is cut from a fresh prod (NOT from staging) so the migration test runs against real production data shape: "ensure it will work on my prod" before merging.
+
+## How to use
+
+Pointer notes for the most common asks. The agent reads [`SKILL.md`](SKILL.md) for the operating contract; humans read these.
+
+### Pick a branch layout for a fresh project
+
+Default to two-tier unless the team has a concrete reason to add an intermediate. Three-tier (`dev → staging → prod`) is appropriate when QA / UAT / perf testing needs a stable target that doesn't change every time a feature lands. Four+ tiers are unusual; reach for the full reference before recommending one.
+
+### Cut a release between tiers
+
+Open a PR from `from` into `to` (the GitHub-Actions side is fully scaffolded by `lakebase-create-project`). `pr.yml` cuts the RC, runs migrations, and runs tests. Merge once green. `merge.yml` cuts the backup, migrates, fast-forwards, and (for `prod`) deploys.
+
+### Roll back a botched release
+
+The `<tier>-backup-<id>` Lakebase branch created in phase 3 is your one-step target. Repoint the tier's working branches at it via the SCM substrate (`createPairedBranch` with the backup as parent) and revert the git pointer to the matching tag. The reference doc has the full procedure.
+
+### Use the substrate's `cut-backup` directly
+
+The backup primitive ships today as `lakebase-cut-backup` (CLI) and `cutBackup` (JS / MCP), reusable outside the release flow when you want a no-expiry snapshot off any source branch:
+
+```bash
+lakebase-cut-backup --instance proj-checkout --source-branch staging --backup-name pre-migration-experiment
+```
+
+```ts
+import { cutBackup } from "@databricks-solutions/lakebase-app-dev-kit";
+const result = await cutBackup({
+  instance: "proj-checkout",
+  sourceBranch: "staging",
+  backupName: "pre-migration-experiment",
+});
+// result.backup.uid, result.backup.state, result.sourceBranchName
+```
+
+This is the same primitive `merge.yml` calls in phase 3.
+
+## Status: orchestrator under construction
+
+The branch convention, the four-phase shape, and the YAML scaffolding (`pr.yml` + `merge.yml`) ship today via [`lakebase-scm-workflows`](../lakebase-scm-workflows/README.md)'s `lakebase-create-project`. The named release orchestrator primitives (parameterized over from / to so the same primitive serves every adjacent pair in any chain length) are planned but not yet wired:
+
+- `bootstrap-branch-convention({chain, workingTypeTargets})`: creates the configured long-running chain (default `[staging, prod]`) plus the working-branch types, all from prod, and writes parent-pair metadata + the type → target-tier mapping.
+- `cutRC({from, to, releaseId})`: branches the release candidate off current `to` and merges `from` in.
+- `regressionTest({rc, suite})`: runs the project's full end-to-end suite against the RC branch.
+- `cutBackup({to, releaseId})`: snapshots current `to` for rollback. Available today.
+- `migrate({rc, to, releaseId})`: applies `applySchemaMigrations` against `to`'s Lakebase branch and fast-forwards the git pointer.
+- `release`: orchestrator that calls the four phases in order with explicit gates between each.
+
+Until the named orchestrator primitives land, follow the manual procedure documented in the reference. The YAML workflows scaffolded by `lakebase-create-project` already implement phases 1, 2, and 4 end-to-end; phase 3 wires `lakebase-cut-backup` as shown above.
+
+## Integration with sibling skills
+
+- [`lakebase-scm-workflows`](../lakebase-scm-workflows/README.md): provides `createBranch`, `createPairedBranch`, `getSchemaDiff`, `applySchemaMigrations`, and `cutBackup`. Release-workflows uses these primitives; it does not duplicate them.
+- [`lakebase-tdd-workflows`](../lakebase-tdd-workflows/README.md): the TDD workflow ends at "PR opened against `staging`." Release-workflows takes over from there. No overlap; the handoff is the PR.
+- `databricks-lakebase` (dev-hub): the parent skill. Lakebase Postgres CLI basics (project / branch / endpoint shapes, "never delete the production branch" rule). This skill composes on top of it.
+
+## When to load the full reference
+
+Load [`references/branching-and-release-methodology.md`](references/branching-and-release-methodology.md) when:
+
+- A project is being bootstrapped and you have to recommend a branch layout, including deciding chain length.
+- A release decision is in question ("can we cut the RC from `from` this time?" answer: no, see the doc).
+- A consumer asks why `to`-backup exists separately from the RC.
+- An N-tier shop's per-tier policy gates need to be designed.
+- Drift from this convention is being proposed and you need the original reasoning to push back or extend.

--- a/skills/lakebase-scm-workflows/README.md
+++ b/skills/lakebase-scm-workflows/README.md
@@ -32,7 +32,7 @@ For agent use (running the bins directly), clone the repo and run `npm install` 
 
 ## Operations
 
-Each operation has a CLI bin AND a matching MCP tool. JS/TS callers can also import the same functions from the package. The 25-tool MCP server covers full parity with the 11 CLI bins.
+Each operation has a CLI bin AND a matching MCP tool. JS/TS callers can also import the same functions from the package. The MCP server covers full parity with the CLI bins; the precise tool inventory is generated from `apps/mcp-server/tools.ts`.
 
 **Branch lifecycle** (`lakebase-branch` / `lakebase_branch_*`)
 - `list` / `show` – enumerate or inspect branches on a project
@@ -59,6 +59,18 @@ Each operation has a CLI bin AND a matching MCP tool. JS/TS callers can also imp
 
 **Backup** (`lakebase-cut-backup`)
 - Cut a no-expiry backup branch off a source branch
+
+**TDD adoption** (`lakebase-adopt-tdd`)
+- Brownfield-only sibling to `lakebase-create-project`. Drops the `.tdd/` workflow tree into an existing repo, reports drift on re-runs (`--update`), and can overwrite drifted templates (`--force`) or preview without writing (`--dry-run`).
+
+**Infra test runner** (`lakebase-infra-runner`)
+- Runs the `[Infra]`-tag suite for a Lakebase branch (schema-diff, migration status, endpoint readiness). Reads `--instance` / `--branch` flags first, then falls back to `LAKEBASE_PROJECT_ID` / `LAKEBASE_BRANCH_ID` so the same invocation works in a fresh dev shell (env set by the post-checkout hook) and in CI (env set by the resolve-credentials step). Exit codes: 0 = pass, 1 = check failed, 2 = input-validation. `--junit-output <path>` emits a JUnit XML report.
+
+**Feature status** (`lakebase-feature-status`)
+- One-screen snapshot of a feature's TDD workflow state. Reads `.tdd/<feature-id>/...` and renders either human-readable or `--json` output. The TDD-paired companion command for `lakebase-tdd-workflows` consumers; see that skill for the experiment / cycle / synthesis surface this drives.
+
+**Workflow drift** (`lakebase_workflow_drift` MCP tool, `verifyProject` JS export)
+- Checks that a project's `.githooks/` and `.github/workflows/*.yml` match the templates `lakebase-create-project` would lay down today. Exposed as an MCP tool and via `verifyProject(projectDir)` / `verifyHooks(projectDir)` / `verifyWorkflows(projectDir)` from the package; `lakebase-doctor` rolls this into its overall health check.
 
 Run any bin with `--help` for the full subcommand + flag reference.
 
@@ -164,9 +176,85 @@ The agent reads the current git branch, calls `lakebase-get-connection --output 
 | `lakebase-schema-diff` | Parent-aware schema diff between any branch and its parent (or a comparison override). |
 | `lakebase-schema-migrate` | Apply / rollback / status / list schema migrations against a branch (Flyway / Alembic / Knex). |
 | `lakebase-cut-backup` | Cut a no-expiry backup branch off a source branch. |
-| `lakebase-detect-language` | Detect project language for CI step outputs. |
+| `lakebase-detect-language` | Detect project language for CI step outputs (`java` / `kotlin` / `python` / `nodejs`). |
 | `lakebase-github-token` | Resolve / diagnose the GitHub token via the same auth chain CI uses. |
-| `lakebase-mcp-server` | Stdio MCP server exposing 25 tools (full parity with the CLI bins). For Claude Desktop / OpenAI Codex / Cursor-via-MCP / Genie Code consumers. |
+| `lakebase-adopt-tdd` | Drop the `.tdd/` workflow tree into an existing repo. Supports `--update`, `--force`, `--dry-run`. |
+| `lakebase-infra-runner` | Run the `[Infra]`-tag suite (schema-diff + migration status + endpoint readiness) for a branch. Used by scaffolded `test:infra` scripts. |
+| `lakebase-feature-status` | One-screen snapshot of a TDD feature's workflow state. Pairs with `lakebase-tdd-workflows`. |
+| `lakebase-mcp-server` | Stdio MCP server exposing the full tool surface (parity with the CLI bins). For Claude Desktop / OpenAI Codex / Cursor-via-MCP / Genie Code consumers. |
+
+## JS/TS exports
+
+Every CLI bin is a thin wrapper around a substrate function published from `@databricks-solutions/lakebase-app-dev-kit`. Hosts that embed the substrate (the `lakebase-scm-extension` VS Code/Cursor extension, custom Node services, agent tools) import these directly instead of shelling out. The full list comes from `dist/scripts/index.d.ts`; the most-used entry points by area:
+
+**Branch lifecycle** (`./lakebase` subpath or root):
+- `createBranch`, `deleteBranch`, `waitForBranchReady` (Lakebase-only CRUD)
+- `createPairedBranch`, `deletePairedBranch`, `checkoutPaired`, `syncEnvToCurrentBranch` (git + Lakebase + `.env` lockstep)
+- `createFeatureBranch`, `createTestBranch`, `createUatBranch`, `createPerfBranch` plus `CONVENTION_TIER_DEFAULTS` (tier conventions with PSA TTLs)
+- `asBranchName`, `asBranchUid`, `looksLikeBranchUid`, `branchNameFromResourcePath` (id parsing; the substrate accepts uid, sanitized name, or resource path interchangeably)
+
+**Connection + endpoint**:
+- `getConnection({ output: "dsn" | "pool", ... })` (single-seam credential mint, overloaded return type)
+- `getEndpoint`, `ensureEndpoint`, `resolveEndpointHost`, `endpointPath` (raw endpoint metadata without minting credentials)
+- `mintCredential`, `getCredential`, `waitForBranchAuthReady`, `resolveCurrentUser` (OAuth + auth-readiness primitives)
+- `POSTGRES_PORT`, `DEFAULT_DATABASE`, `DEFAULT_ENDPOINT` (constants)
+
+**Schema**:
+- `getSchemaDiff` (parent-aware structured diff; returns `SchemaDiffResult` with `tablesAdded` / `tablesRemoved` / `tablesModified` / `inSync`)
+- `queryBranchSchema`, `queryBranchTables` (live `information_schema` introspection over a branch's DSN)
+
+**Migrations**:
+- `applySchemaMigrations`, `rollbackSchemaMigration`, `schemaMigrationStatus`, `listSchemaMigrations` (Flyway / Alembic / Knex via a shared adapter)
+- `detectLanguage(projectDir)`, `toolForLanguage(language)` (language to migration tool mapping)
+- `FlywayAdapter`, `AlembicAdapter`, `KnexAdapter` (per-tool adapter values, for custom orchestration)
+
+**Project bootstrap**:
+- `createProject(args, onProgress?)` (the orchestrator behind `lakebase-create-project`; returns `CreateProjectResult` with the warnings list non-fatal steps collect into)
+- `layDownTddScaffold(targetDir)` and `adoptTdd(args)` (greenfield + brownfield TDD scaffolds)
+- `deployLanguageProject`, `deploySpringStarter`, `SpringInitializrClient`, `resolveLatestBootVersion`, `resolveLatestLtsJavaVersion`, `isPrereleaseBootVersion`, `isLtsJavaVersion` (language scaffolds; Spring Initializr for Java / Kotlin, static templates for Python / Node)
+
+**Project verification**:
+- `verifyProject`, `verifyHooks`, `verifyWorkflows` (drift checks against the templates `create-project` would lay down today; `lakebase-doctor` consumes these)
+- `runDoctor(args)` (the orchestrator behind `lakebase-doctor`; returns `DoctorReport` with per-check `ok` / `warn` / `fail` / `skip` status)
+
+**GitHub** (from `./github` subpath or root):
+- `resolveGitHubToken`, `diagnoseGitHubAuth`, `tryVsCodeSession`, `tryGhAuthToken`, `GITHUB_SCOPES` (token resolution chain: env → VS Code session → `gh auth token`)
+- `createPullRequest`, `getPullRequest`, `mergePullRequest`, `mergePairedPullRequest`, `getPullRequestReviews`, `getPullRequestFiles`, `getPullRequestComments`, `listIssueComments`, `listWorkflowRuns`, `fastForwardBranch` (PR flow primitives behind `lakebase-pr`)
+- `createRepo`, `deleteRepo`, `repoExists`, `getRepoFullName`, `getCurrentUser` (GitHub repo CRUD used by `create-project`)
+- `createRegistrationToken`, `listRepoRunners`, `getRunnerIdByName`, `getRunnerStatus`, `deleteRunner` (self-hosted runner management)
+- `setRepoSecret`, `setRepoSecrets`, `listSecretNames` (CI secrets sync)
+
+**Env file** (`./lakebase`):
+- `writeEnvFile`, `updateEnvConnection` (the `.env` writes behind `--write-env` and the post-checkout hook)
+
+**Infra runner**:
+- `runInfraSuite(args)` returning `InfraSuiteResult`, plus `formatJUnit(result)` for CI report emission. This is what `lakebase-infra-runner` and the scaffolded `test:infra` script call.
+
+**Backup**:
+- `cutBackup(args)` returning `CutBackupResult` (the substrate behind `lakebase-cut-backup`)
+
+Typical call sites:
+
+```ts
+import {
+  getConnection,
+  getSchemaDiff,
+  createPairedBranch,
+} from "@databricks-solutions/lakebase-app-dev-kit";
+
+const { dsn } = await getConnection({
+  output: "dsn",
+  instance: "proj-checkout",
+  branch: "feature-add-orders",
+});
+
+const diff = await getSchemaDiff({
+  instance: "proj-checkout",
+  branch: "feature-add-orders",
+});
+```
+
+Subpath imports (`@databricks-solutions/lakebase-app-dev-kit/lakebase`, `/github`, `/git`, `/util`) are available for hosts that want narrower bundles.
 
 ## Composition
 

--- a/skills/lakebase-tdd-workflows/README.md
+++ b/skills/lakebase-tdd-workflows/README.md
@@ -112,6 +112,28 @@ The branch is deleted by default after notes are captured. **Spike code is never
 
 Before cutting any new experiment, the orchestrator checks the budget – at the concurrent-branch or wall-clock limit, it asks the PO to extend or stop, rather than cutting anyway.
 
+### 4. Cycle (RED / GREEN / REFACTOR)
+
+Inside an experiment branch the orchestrator advances one test-list item at a time through a Beck-style cycle. Each cycle is persisted as a JSON artifact under `.tdd/experiments/<feature>/<slug>/cycles/<cycleId>.json`, with stage transitions (`PLAN` → `RED` → `GREEN` → `REFACTOR`), the verdict (`passed | failed | skipped`), runner output, and any smells flagged during the cycle. The cycle primitives (`beginCycle`, `recordRunnerOutcome`, `markGreen`, `markRefactored`, `flagSmells`) are the only sanctioned way to write that history – the agent never edits cycle JSON by hand.
+
+### 5. Smells
+
+After every cycle, and at each gate transition, the orchestrator runs the detector catalog (`detectAll`) over the feature state and writes any hits to `.tdd/features/<feature>/smells.json`. A hit surfaces a proposed remediation to the HITL – the orchestrator does not auto-fix. The catalog covers: cycle stall, fragility ratio, test cost spiral, test deletion attempts, boundary violations, test-list drift, API coherence drift, cross-experiment divergence, dead-requirement signal, and E2E-row perma-red.
+
+### 6. Comparison, promote, synthesize (N≥2)
+
+At convergence of a parallel race, the orchestrator builds a `ComparisonReport` (`compareExperiments`) – one row per experiment with tag-matrix outcomes, plus a Markdown render written next to the feature. The PO then chooses:
+
+- **Promote** (`promoteExperiment`) – one experiment becomes the feature PR; losers are moved to `_archive/`.
+- **Synthesize** (`synthesizeExperiments`) – PO picks capabilities across experiments; the spec is renegotiated and a fresh branch runs the next cycle.
+- **Archive** (`archiveExperiment`) – move an experiment record into `_archive/` without promoting.
+
+Both promote and synthesize require `hitlApproved: true` at the function boundary; the gate cannot be skipped programmatically.
+
+### 7. Gates and integrity
+
+Every HITL decision is recorded in `.tdd/features/<feature>/gates.json` via `approveGate` / `withdrawGate`. `verifyGateIntegrity` hashes the artifacts referenced by an approved gate (`hashArtifact`, `normalizeForHash`) and reports drift if the underlying files have changed since approval. `withGatesLock` serializes concurrent writes to the gates file so two agents (e.g. Navigator + Driver running in parallel) cannot corrupt state. `migrateGatesFromSelectionLog` upgrades legacy projects that pre-date the gates schema.
+
 ## How to use
 
 Three flows – shown as what you'd prompt your agent to do, using a cart-checkout example throughout. The agent reads [`SKILL.md`](SKILL.md) (plus the Scrum-Master / Navigator / Driver agent prompts) and runs the underlying substrate primitives on your behalf.
@@ -164,6 +186,7 @@ For when you want to run something directly without the agent. Most TDD work goe
 | Command | Purpose |
 |---|---|
 | `lakebase-feature-status <featureId> [--tdd <dir>] [--json]` | One-screen snapshot of a feature's TDD workflow state (phase, plan, test-list completion, experiments, recent decisions, open smells). |
+| `lakebase-infra-runner [--instance <id>] [--branch <id>] [--project-dir <path>] [--comparison-branch <id>] [--junit-output <file>]` | Run the `[Infra]`-tag suite against a paired Lakebase branch. Backs the scaffolded `test:infra` script; reads `LAKEBASE_PROJECT_ID` / `LAKEBASE_BRANCH_ID` when flags are absent. Emits JUnit XML when `--junit-output` is set. |
 | `node dist/scripts/tdd/spec-sync.cli.js <tddDir>` | Walk the `.tdd/` tree and print drift reports. Exit 0 even when reports exist (warn-only by design). |
 | `node dist/scripts/tdd/test-list.cli.js <tddDir> <featureId>` | Regenerate per-AC views from the feature-level master test list. |
 | `bash tests/run_all.sh` (per scaffolded project) | Run every `validate_*.sh` in the project's `tests/` directory (the project's full validation suite). |
@@ -175,6 +198,139 @@ For when you want to run something directly without the agent. Most TDD work goe
 - **`/ship`** – lives in `lakebase-release-workflows`. Not part of this skill.
 
 The substrate itself ships no installed slash commands; the scaffolder writes the command files into the project at `lakebase-create-project` time (templated, with a kit-version pin). The substrate's runtime surface stays skills + agents + scripts + CLI bins. The MCP server (`apps/mcp-server/`) exposes the tool surface for MCP-capable consumers.
+
+## Agents
+
+The role agents under [`agents/`](agents/) are invokable directly with `@lakebase-tdd-workflows/<agent-name>` in Claude Code, or referenced by the Scrum-Master when it delegates a phase. Each agent file is a self-contained prompt; the Scrum-Master coordinates them.
+
+| Agent | File | Invoked when |
+|---|---|---|
+| Scrum-Master | [`agents/scrum-master.md`](agents/scrum-master.md) | `/build` or "build the feature." Top-level orchestrator: runs the design-spec gate, spawns experiments to budget, drives cycles, watches smells, surfaces gate decisions. |
+| Architect Reviewer | [`agents/architect-reviewer.md`](agents/architect-reviewer.md) | Phase 1. Applies the layering lens to each AC and populates `layer` + `architectural_notes`. Imports `software-design-principles`. |
+| Test Strategist | [`agents/test-strategist.md`](agents/test-strategist.md) | Phase 2. Converts annotated ACs into the ordered master test list and emits per-AC views. |
+| Navigator | [`agents/navigator.md`](agents/navigator.md) | Each cycle, RED step. Writes the failing test for the current test-list item and reviews the Driver's GREEN code. Never weakens an assertion. |
+| Driver | [`agents/driver.md`](agents/driver.md) | Each cycle, GREEN + REFACTOR steps. Writes the minimal honest code to make the failing test pass, then cleans up. Never deletes or weakens a test. |
+
+## Under the covers (JS/TS primitives)
+
+The substrate's behavior is exposed as a TypeScript surface under `scripts/tdd/`. The agents call these; you can also call them directly from a Node script or from your own tooling. Import paths shown are the in-repo source paths; published consumers import from the kit package.
+
+```ts
+import { cutExperiment, listExperiments, deleteExperiment } from "@databricks-solutions/lakebase-app-dev-kit/scripts/tdd/experiment.js";
+```
+
+### Experiments and spikes
+
+| Primitive | Purpose |
+|---|---|
+| `cutExperiment(args)` | Cut a paired Lakebase branch for an experiment and write its record under `.tdd/experiments/<feature>/<slug>/`. |
+| `listExperiments(tddDir, featureId)` | Enumerate experiment records for a feature. |
+| `readOutcomes(tddDir, featureId, slug)` / `writeOutcomes(...)` | Read/write the per-experiment `outcomes.json` (tag matrix, tests passed/failed, schema diff summary). |
+| `recordTagRun(outcomes, tag, verdict)` / `tagRunCount(outcomes, tag)` / `acLayerToTag(layer)` | Helpers for maintaining the tag-matrix bookkeeping on `outcomes.json`. |
+| `deleteExperiment(args)` | Tear down a Lakebase branch and (optionally) the on-disk experiment record. HITL-gated. |
+| `cutSpike(args)` / `listSpikes(tddDir)` / `deleteSpike(args)` | Same lifecycle for the spike side-mode under `.tdd/spikes/`. |
+| `archiveExperiment(args)` | Move an experiment record into `_archive/` without tearing down its branch. |
+
+### Cycle and runner
+
+| Primitive | Purpose |
+|---|---|
+| `beginCycle({ tddDir, featureId, slug, acId, stage })` | Start a new RED/GREEN/REFACTOR cycle and return the cycle artifact. |
+| `nextCycleId(scope)` / `listCycles(scope)` | Cycle-id allocation and history walk. |
+| `writeCycleArtifact(scope, artifact)` / `readCycleArtifact(scope, cycleId)` | Low-level cycle artifact IO; prefer `beginCycle` + the stage helpers. |
+| `recordRunnerOutcome(args)` | Attach a test-runner outcome (pass/fail/skip + raw output) to a cycle. |
+| `markGreen(scope, cycleId)` / `markRefactored(scope, cycleId, notes?)` / `flagSmells(scope, cycleId, smells)` | Stage transitions on an in-flight cycle. |
+| `readAcLayer(tddDir, featureId, acId)` | Resolve the architect-assigned layer for an AC. |
+| `openBranchDsn(args)` | Open a per-branch Postgres DSN for the cycle's runner (delegates to `lakebase-scm-workflows`). |
+
+### Test list
+
+| Primitive | Purpose |
+|---|---|
+| `readMasterTestList(tddDir, featureId)` / `writeMasterTestList(tddDir, list)` | Read/write the feature-level ordered test list. |
+| `viewByAc(list, acId)` / `viewsForAllAcs(list)` | Build per-AC slices of the master list. |
+| `writePerAcViews(tddDir, featureId, list)` | Regenerate the per-AC view files on disk (also what `test-list.cli.js` calls). |
+| `mutateTestList(args)` | Authorized mutation path: enforces ordering invariants and rejects unsafe deletes. Throws `TestListImmutabilityError` when the list is gate-protected. |
+| `isTestListProtected(featureId, opts?)` | True once Gate 3 has approved the list; further mutation requires explicit reopen. |
+
+### Plan and design-spec gate
+
+| Primitive | Purpose |
+|---|---|
+| `analyzeForGate(input, options?)` | The design-spec analyzer. Scans the approved test list for opinion-gap signals and returns an `ExperimentPlan` proposal (N, strategies, budget, rationale). |
+| `recordPlan(tddDir, plan, deciderEmail?)` | Persist an approved plan to `plan.json` and append the decision to `selection-log.md`. |
+| `readPlan(tddDir, featureId)` / `writePlan(tddDir, plan)` | Direct plan IO. |
+| `checkE2eGate({ tddDir, featureId })` | Pre-merge guard: refuses to advance if any `[E2E]`-tagged AC is still red. |
+
+### Gates and integrity
+
+| Primitive | Purpose |
+|---|---|
+| `approveGate({ featureId, gate, decider, artifacts })` | Record HITL approval for one of `spec | plan | test_list | promote`. Throws `GateAlreadyClosedError` on double-approve. |
+| `withdrawGate(args)` | Revoke a previously approved gate (e.g. after a smell flags drift). |
+| `verifyGateIntegrity({ tddDir, featureId, gate })` | Re-hash referenced artifacts and report drift since approval. |
+| `readGates(featureId, opts?)` / `writeGates(state, opts?)` / `defaultGatesState(featureId)` | Direct gate-state IO. |
+| `withGatesLock(featureId, fn, opts?)` | Serialize concurrent writes; throws `GatesLockBusyError` if another process holds the lock. |
+| `migrateGatesFromSelectionLog(args)` | One-shot migration for legacy projects that pre-date `gates.json`. |
+| `hashArtifact(content)` / `normalizeForHash(content)` | Content-addressable hashing used by gate integrity checks. |
+
+### Comparison, promote, synthesize
+
+| Primitive | Purpose |
+|---|---|
+| `compareExperiments(tddDir, featureId)` | Build a `ComparisonReport` (rows + tag matrix) over a feature's experiments. |
+| `writeComparisonReport(args)` / `renderComparisonReport(report)` | Persist and render the Markdown comparison artifact. |
+| `promoteExperiment({ tddDir, featureId, slug, hitlApproved })` | Promote one experiment into the feature PR; archive the rest. `hitlApproved` is mandatory. |
+| `synthesizeExperiments({ tddDir, featureId, picks, hitlApproved })` | Cut a fresh synthesis branch built from capabilities picked across experiments. `hitlApproved` is mandatory. |
+
+### Smells
+
+| Primitive | Purpose |
+|---|---|
+| `detectAll(input)` | Run every detector in `SMELL_CATALOG` against the current feature state. |
+| `detectCycleStall` / `detectFragilityRatio` / `detectTestCostSpiral` / `detectTestDeletionAttempt` / `detectBoundaryViolation` / `detectTestListDrift` / `detectApiCoherenceDrift` / `detectCrossExperimentDivergence` / `detectDeadRequirementSignal` / `detectE2eRowPermaRed` | Individual detectors; call directly when you want to bound the scope. |
+| `runDetectorsForScope(scope, input)` | Run the subset of detectors appropriate to a given scope (cycle, gate, comparison). |
+| `readSmellsLog(tddDir)` / `writeSmellsLog(tddDir, hits)` | Read/write the persisted smells log. |
+| `SMELL_CATALOG` | The canonical catalog of detectors with id, description, and severity. |
+
+### Budget
+
+| Primitive | Purpose |
+|---|---|
+| `snapshotBudget(tddDir, featureId)` | Current usage (open experiment count, wall-clock minutes spent) against the approved plan budget. |
+| `checkBudget(snapshot)` | Compute violations from a snapshot. |
+| `canCutAnotherExperiment(tddDir, featureId)` | Pre-flight check used by the Scrum-Master before `cutExperiment`. |
+
+### Spec IO and validation
+
+| Primitive | Purpose |
+|---|---|
+| `readFeature(tddDir, featureId)` / `writeFeature(tddDir, feature)` | Read/write the feature record (`.tdd/features/<id>/feature.json`). |
+| `readWorkflowState(tddDir)` / `writeWorkflowState(tddDir, state)` | Cross-feature workflow pointer (which feature is "current", last gate, etc.). |
+| `validateSpec(tddDir)` | Walk the `.tdd/` tree and return `DriftReport[]`. Backs `spec-sync.cli.js`. |
+| `writeArtifact(args)` / `listArtifacts(tddDir, featureId, kind?)` / `readArtifact(args)` | Generic artifact IO under `.tdd/features/<id>/artifacts/`. |
+
+### Status
+
+| Primitive | Purpose |
+|---|---|
+| `getFeatureStatus(tddDir, featureId)` | Build a `FeatureStatusSnapshot` (phase, plan, test-list summary, experiments, recent decisions, open smells). |
+| `renderFeatureStatus(snapshot)` | Pretty-print the snapshot for terminals. Backs `lakebase-feature-status`. |
+
+### Parallel runner
+
+| Primitive | Purpose |
+|---|---|
+| `runExperimentsInParallel<T>(args)` | Fan out a worker function across N experiments with concurrency + per-task timeout, collecting `ExperimentRunResult<T>` for each. Used by the Scrum-Master when racing strategies under N≥2. |
+
+### Spec adapters
+
+`SpecAdapter` is the pluggable surface that syncs `.tdd/` entities to/from an external tracker. The skill ships two implementations:
+
+- `markdownAdapter` (instance) / `MarkdownAdapter` (class) – the default; treats the on-disk Markdown + JSON pair as the source of truth.
+- `JiraAdapter` (constructed with `JiraAdapterConfig`) – mirrors features/stories/ACs to JIRA hierarchy. Configured by the project's `design.pre-hook.md` in scaffolded projects.
+
+Implement your own adapter against the `SpecAdapter` interface (with the `SyncEventHooks` lifecycle) to bridge to Linear, GitHub Issues, or any other tracker.
 
 ## Integration with sibling skills
 


### PR DESCRIPTION
## Summary

Every CLI bin, MCP tool, JS/TS export, and agent prompt the three workflow skills surface is now visible from each skill's README. A new consumer can land on any README and find how to invoke any feature without opening SKILL.md.

- **lakebase-scm-workflows/README.md**: new cheat-sheet rows + Operations subsections for `lakebase-adopt-tdd`, `lakebase-infra-runner`, `lakebase-feature-status`. New JS/TS exports section grouping every primitive by area (branches, connection, schema, migrate, bootstrap, GitHub, env-file, infra-runner, backups). Subpath import notes for `/lakebase`, `/github`, `/git`, `/util`.
- **lakebase-tdd-workflows/README.md**: new `lakebase-infra-runner` row, expanded Operations (cycles, smells, compare/promote/synthesize, gates+integrity), new Agents section with `@skill/agent` invocations and when-delegated notes, new "Under the covers" section covering every public `scripts/tdd/` export by area.
- **lakebase-release-workflows/README.md** (new): human-facing companion. When to use, two/three-tier branch conventions, "every merge IS a release" framing, the four-phase release shape, how-to notes (pick layout, cut release, roll back, direct `cutBackup`), status of orchestrator primitives, sibling-skill integration.

Workflow-orchestrated edits (2 parallel agents for the two existing READMEs, plus a hand-authored release-workflows README). 247 net insertions across the two existing READMEs. SKILL.md files untouched.

## Test plan

- [x] grep audit confirms no em-dashes (U+2014) in any of the three files
- [x] grep audit confirms no FEIP ticket references in README body prose
- [x] No code changes; tests unaffected
- [ ] Manual smoke: open each README in a viewer and confirm the new feature list aligns with the kit's actual surface

This pull request and its description were written by Isaac.