### PR TITLE
Spike carry-forward + per-experiment cap (FEIP-7211 / FEIP-7218)

### DIFF
--- a/scripts/tdd/compare-experiments.ts
+++ b/scripts/tdd/compare-experiments.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { listExperiments, readOutcomes } from "./experiment";
-import type { ExperimentOutcomes, ExperimentTag, TagOutcome } from "./experiment";
+import type { ExperimentCap, ExperimentOutcomes, ExperimentTag, TagOutcome } from "./experiment";
 import { listArtifacts } from "./artifacts";
 
 export interface ExperimentRow {
@@ -12,10 +12,12 @@ export interface ExperimentRow {
   tests_failed?: number;
   schema_diff_summary?: string;
   code_diff_lines?: number;
-  signal: "winning" | "stalled" | "abandoned" | "running" | "unknown";
+  signal: "winning" | "stalled" | "abandoned" | "running" | "unknown" | "capped";
   // Structured-payload fields (FEIP-7092 slice 4). Backwards compatible:
   // older callers reading the prior shape ignore these.
   by_tag?: Partial<Record<ExperimentTag, TagOutcome>>;
+  /** Set when checkPerExperimentCap has stopped this experiment. */
+  capped?: ExperimentCap;
   cycle_count: number;
   artifact_count: number;
   duration_ms?: number;
@@ -97,6 +99,7 @@ export function compareExperiments(tddDir: string, featureId: string): Compariso
       code_diff_lines: o?.code_diff_lines,
       signal: classifySignal(o),
       by_tag: o?.by_tag,
+      capped: o?.capped,
       cycle_count: readCycleCount(exp.dir),
       artifact_count: listArtifacts(tddDir, featureId, exp.experiment_slug).length,
       duration_ms: readDurationMs(exp.dir),
@@ -116,6 +119,11 @@ export function compareExperiments(tddDir: string, featureId: string): Compariso
 
 function classifySignal(o: ExperimentOutcomes | null): ExperimentRow["signal"] {
   if (!o) return "unknown";
+  // A capped experiment is a distinct signal: the orchestrator stopped
+  // it, the PO has not yet remediated. Comes before status-based
+  // classification so a capped-then-still-marked-running outcome reads
+  // as "capped" rather than "running".
+  if (o.capped) return "capped";
   if (o.status === "succeeded" && (o.tests_failed ?? 0) === 0 && (o.tests_passed ?? 0) > 0) {
     return "winning";
   }

--- a/scripts/tdd/comparison-report.ts
+++ b/scripts/tdd/comparison-report.ts
@@ -130,8 +130,8 @@ function renderRecommendationBlock(report: ComparisonReport): string {
 function renderExperimentTable(rows: ExperimentRow[]): string {
   if (rows.length === 0) return `_No experiments cut yet._`;
   const header = [
-    "| Experiment | Branch | Status | Signal | Cycles | Tests pass / fail | Code diff | Runtime | Artifacts |",
-    "|---|---|---|---|---|---|---|---|---|",
+    "| Experiment | Branch | Status | Signal | Cycles | Tests pass / fail | Cap | Code diff | Runtime | Artifacts |",
+    "|---|---|---|---|---|---|---|---|---|---|",
   ];
   const body = rows.map((r) => {
     const tests =
@@ -140,7 +140,12 @@ function renderExperimentTable(rows: ExperimentRow[]): string {
         : `${r.tests_passed ?? 0} / ${r.tests_failed ?? 0}`;
     const codeDiff = r.code_diff_lines === undefined ? "-" : `${r.code_diff_lines} lines`;
     const runtime = r.duration_ms === undefined ? "-" : formatDurationMs(r.duration_ms);
-    return `| \`${r.experiment_slug}\` | \`${r.branch_id}\` | ${r.status} | ${r.signal} | ${r.cycle_count} | ${tests} | ${codeDiff} | ${runtime} | ${r.artifact_count} |`;
+    const cap = r.capped
+      ? r.capped.reason === "max_cycles"
+        ? `${r.capped.reason} (>=${r.capped.cap_value} @ cycle ${r.capped.at_cycle})`
+        : `${r.capped.reason} (>=${r.capped.cap_value}m${r.capped.at_minutes ? ` @ ${r.capped.at_minutes}m` : ""})`
+      : "-";
+    return `| \`${r.experiment_slug}\` | \`${r.branch_id}\` | ${r.status} | ${r.signal} | ${r.cycle_count} | ${tests} | ${cap} | ${codeDiff} | ${runtime} | ${r.artifact_count} |`;
   });
   return [...header, ...body].join("\n");
 }
@@ -184,17 +189,22 @@ function renderSchemaDiffTable(rows: ExperimentRow[]): string {
 function renderDecisionBlock(report: ComparisonReport): string {
   const slugs = report.rows.map((r) => `\`${r.experiment_slug}\``);
   const winners = report.rows.filter((r) => r.signal === "winning").map((r) => r.experiment_slug);
+  const cappedSlugs = report.rows.filter((r) => r.signal === "capped").map((r) => r.experiment_slug);
   const winnerLine =
     winners.length === 1
       ? `Substrate signal indicates a single winner: \`${winners[0]}\`.`
       : winners.length > 1
         ? `Substrate signal indicates multiple winning experiments: ${winners.map((s) => `\`${s}\``).join(", ")}.`
         : `No experiment is currently signalling "winning"; substrate recommendation is \`${report.recommendation}\`.`;
+  const cappedLine =
+    cappedSlugs.length > 0
+      ? `\nCapped experiment(s) awaiting PO remediation: ${cappedSlugs.map((s) => `\`${s}\``).join(", ")}. For each, choose: \`extend\` (raise the cap and resume), \`abandon\` (archive this experiment, let siblings continue), or \`continue-suite\` (leave capped, decide at end).\n`
+      : "";
   return [
     `## HITL decision`,
     ``,
     winnerLine,
-    ``,
+    cappedLine,
     `Choose one path forward (the Scrum-Master orchestrator will route accordingly):`,
     ``,
     `1. **Promote** \`<slug>\` - take a single experiment to the feature PR as-is. Loser branches are archived.`,

--- a/scripts/tdd/design-spec-gate.ts
+++ b/scripts/tdd/design-spec-gate.ts
@@ -4,12 +4,29 @@ import { readMasterTestList } from "./test-list";
 import type { TestList, TestListItem } from "./test-list";
 import { readAcLayer } from "./run-cycle";
 import type { AcLayer } from "./experiment";
+import { collectSpikeInputs, type SpikeInput } from "./spike-carryforward";
 
 export interface ExperimentStrategy {
   /** Human-readable strategy label, e.g. "postgres-arrays" or "json-blob". */
   name: string;
   /** One-sentence summary of the design choice this strategy makes. */
   rationale: string;
+}
+
+export interface PerExperimentCap {
+  /**
+   * Maximum number of cycles a single experiment may run before the
+   * orchestrator caps it. Independent of the race-level wall-clock
+   * budget; one runaway experiment burns its own cycles, not the
+   * shared phase budget. Undefined or non-positive = no cap.
+   */
+  max_cycles?: number;
+  /**
+   * Maximum wall-clock budget for a single experiment, in minutes.
+   * Distinct from the race-level wall-clock budget. Undefined or
+   * non-positive = no cap.
+   */
+  max_wall_clock_minutes?: number;
 }
 
 export interface BudgetProposal {
@@ -19,6 +36,13 @@ export interface BudgetProposal {
   wall_clock_minutes: number;
   /** Number of Navigator+Driver agent pairs available. */
   agent_pairs: number;
+  /**
+   * Per-experiment caps. When set, the orchestrator stops a single
+   * experiment's cycles when its cap is hit and surfaces "experiment
+   * X capped" to the PO without starving its siblings. Optional;
+   * absent means no per-experiment cap is enforced (legacy behavior).
+   */
+  per_experiment?: PerExperimentCap;
 }
 
 export interface ExperimentPlan {
@@ -28,6 +52,14 @@ export interface ExperimentPlan {
   strategies: ExperimentStrategy[];
   budget: BudgetProposal;
   rationale: string;
+  /**
+   * Spike notes that reference this feature, surfaced from
+   * `.tdd/spikes/<slug>/notes.md` by `collectSpikeInputs`. The gate
+   * analyzer populates this automatically when matching spikes exist;
+   * the orchestrator presents them to the PO at Gate 4 and the PO
+   * decides which to keep via `attachSpikeInputs`.
+   */
+  spike_inputs?: SpikeInput[];
 }
 
 export interface OpinionGap {
@@ -101,12 +133,22 @@ export function analyzeForGate(
       concurrent_branches: mode === "N=1" ? 1 : Math.min(gaps.length, 3),
       wall_clock_minutes: 180,
       agent_pairs: mode === "N=1" ? 1 : 2,
+      // Default per-experiment caps: 30 cycles + 60 min wall-clock.
+      // Generous enough that healthy TDD work never trips them; tight
+      // enough that a runaway agent loop doesn't starve siblings.
+      // Project-level config overrides via the orchestrator before
+      // writePlan is called.
+      per_experiment: { max_cycles: 30, max_wall_clock_minutes: 60 },
     },
     rationale:
       mode === "N=1"
         ? "Fewer than 2 opinion gaps detected – refine iteratively on a single branch."
         : `${gaps.length} opinion gaps detected – race up to 3 parallel strategies, then HITL chooses promote vs synthesize.`,
   };
+  const spike_inputs = collectSpikeInputs({ tddDir, featureId });
+  if (spike_inputs.length > 0) {
+    proposed.spike_inputs = spike_inputs;
+  }
   return { feature_id: featureId, opinion_gaps: gaps, proposed_plan: proposed, transition_blockers };
 }
 

--- a/scripts/tdd/experiment-cap.ts
+++ b/scripts/tdd/experiment-cap.ts
@@ -1,0 +1,167 @@
+// Per-experiment cost/timeout cap. Race-level budget
+// (concurrent_branches, wall_clock_minutes across all experiments)
+// does not cover "one runaway experiment burns the budget while two
+// healthy ones finish." This module is the single seam the
+// orchestrator calls each cycle to ask "should I cap this one?" and
+// record the decision back onto outcomes.json.
+//
+// Cap semantics:
+//   - `max_cycles` cap fires when an experiment has accumulated
+//     >= max_cycles cycles. The cycle that pushes the count to the
+//     threshold is the at_cycle; further cycles are refused.
+//   - `max_wall_clock_minutes` cap fires when an experiment's elapsed
+//     wall-clock crosses the threshold. Elapsed is computed from the
+//     timeline.json's first "cut" entry (when present) and the caller's
+//     `now` (defaults to Date.now()).
+//
+// A capped experiment's outcome status is NOT auto-changed (the PO
+// chooses continue / extend / abandon at the remediation prompt).
+// The status flip happens explicitly via the existing
+// writeOutcomes / promoteExperiment paths.
+
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { readOutcomes, writeOutcomes, type ExperimentCap, type ExperimentOutcomes } from "./experiment";
+import type { PerExperimentCap } from "./design-spec-gate";
+
+export interface CheckPerExperimentCapArgs {
+  tddDir: string;
+  featureId: string;
+  experimentSlug: string;
+  /**
+   * Per-experiment cap from the plan. Pass
+   * `plan.budget.per_experiment` directly. Undefined or empty = no
+   * cap; the helper returns `{ capped: false }`.
+   */
+  cap?: PerExperimentCap;
+  /**
+   * Cycle count for this experiment so far. Caller supplies this so
+   * the helper stays a pure function over disk reads it can do
+   * itself + the one piece of context it cannot.
+   */
+  cycleCount: number;
+  /**
+   * Override for the timestamp used to compute elapsed wall-clock.
+   * Defaults to `Date.now()`. The BDD harness passes a fixed value.
+   */
+  now?: number;
+}
+
+export interface CheckPerExperimentCapResult {
+  capped: boolean;
+  /** Populated when `capped` is true. */
+  hit?: ExperimentCap;
+}
+
+/**
+ * Pure check: should this experiment be capped right now? Reads
+ * timeline.json from disk to compute elapsed wall-clock when a
+ * wall-clock cap is configured. Does NOT mutate outcomes.json;
+ * `recordExperimentCap` is the writer.
+ *
+ * Cycle cap evaluates before wall-clock cap so a cycle-bound
+ * experiment that is also slow returns the cycle reason
+ * (deterministic for the BDD harness; both are informational
+ * anyway).
+ */
+export function checkPerExperimentCap(args: CheckPerExperimentCapArgs): CheckPerExperimentCapResult {
+  const cap = args.cap;
+  if (!cap) return { capped: false };
+
+  if (cap.max_cycles && cap.max_cycles > 0 && args.cycleCount >= cap.max_cycles) {
+    return {
+      capped: true,
+      hit: {
+        reason: "max_cycles",
+        at_cycle: args.cycleCount,
+        cap_value: cap.max_cycles,
+      },
+    };
+  }
+
+  if (cap.max_wall_clock_minutes && cap.max_wall_clock_minutes > 0) {
+    const startedAtMs = readExperimentStartMs(args.tddDir, args.featureId, args.experimentSlug);
+    if (startedAtMs !== undefined) {
+      const now = args.now ?? Date.now();
+      const elapsedMin = (now - startedAtMs) / 60_000;
+      if (elapsedMin >= cap.max_wall_clock_minutes) {
+        return {
+          capped: true,
+          hit: {
+            reason: "max_wall_clock_minutes",
+            at_cycle: args.cycleCount,
+            at_minutes: Math.round(elapsedMin * 10) / 10,
+            cap_value: cap.max_wall_clock_minutes,
+          },
+        };
+      }
+    }
+  }
+
+  return { capped: false };
+}
+
+export interface RecordExperimentCapArgs {
+  tddDir: string;
+  featureId: string;
+  experimentSlug: string;
+  hit: ExperimentCap;
+}
+
+/**
+ * Persist a cap-hit onto outcomes.json. Idempotent: re-running with
+ * the same `hit` is a no-op; passing a different `hit` overwrites the
+ * existing record (the orchestrator's "extend cap" path eventually
+ * clears it via `clearExperimentCap`).
+ *
+ * Throws if outcomes.json does not exist (cutExperiment has not run
+ * yet, so there is nothing to cap).
+ */
+export function recordExperimentCap(args: RecordExperimentCapArgs): ExperimentOutcomes {
+  const outcomes = readOutcomes(args.tddDir, args.featureId, args.experimentSlug);
+  if (!outcomes) {
+    throw new Error(
+      `recordExperimentCap: outcomes.json not found for ${args.featureId}/${args.experimentSlug}`
+    );
+  }
+  outcomes.capped = { ...args.hit };
+  writeOutcomes(args.tddDir, args.featureId, args.experimentSlug, outcomes);
+  return outcomes;
+}
+
+/**
+ * Clear a previously-recorded cap (PO chose "extend cap" or
+ * "continue"). No-op when no cap is currently recorded.
+ */
+export function clearExperimentCap(args: {
+  tddDir: string;
+  featureId: string;
+  experimentSlug: string;
+}): ExperimentOutcomes | null {
+  const outcomes = readOutcomes(args.tddDir, args.featureId, args.experimentSlug);
+  if (!outcomes) return null;
+  if (!outcomes.capped) return outcomes;
+  delete outcomes.capped;
+  writeOutcomes(args.tddDir, args.featureId, args.experimentSlug, outcomes);
+  return outcomes;
+}
+
+function readExperimentStartMs(
+  tddDir: string,
+  featureId: string,
+  slug: string
+): number | undefined {
+  const file = join(tddDir, "experiments", featureId, slug, "timeline.json");
+  if (!existsSync(file)) return undefined;
+  try {
+    const payload = JSON.parse(readFileSync(file, "utf8")) as {
+      entries?: Array<{ ts?: string; kind?: string }>;
+    };
+    const cut = payload.entries?.find((e) => e.kind === "cut");
+    if (!cut?.ts) return undefined;
+    const ms = Date.parse(cut.ts);
+    return Number.isFinite(ms) ? ms : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/scripts/tdd/experiment.ts
+++ b/scripts/tdd/experiment.ts
@@ -75,6 +75,17 @@ export function tagRunCount(outcomes: ExperimentOutcomes, tag: ExperimentTag): n
   return slot ? slot.passed + slot.failed : 0;
 }
 
+export interface ExperimentCap {
+  /** Stable reason code so renderers and the orchestrator can dispatch. */
+  reason: "max_cycles" | "max_wall_clock_minutes";
+  /** Cycle number the cap fired on (cycles past this one are not run). */
+  at_cycle: number;
+  /** Wall-clock minutes elapsed when the cap fired (informational). */
+  at_minutes?: number;
+  /** Cap threshold from the plan, copied here so the renderer needn't look it up. */
+  cap_value: number;
+}
+
 export interface ExperimentOutcomes {
   tests_passed?: number;
   tests_failed?: number;
@@ -88,6 +99,14 @@ export interface ExperimentOutcomes {
   // (e.g. e2e-row-perma-red in FEIP-7094). Sum across tags is not enforced
   // to match the totals – mid-cycle reporting and untagged tests are valid.
   by_tag?: Partial<Record<ExperimentTag, TagOutcome>>;
+  /**
+   * Per-experiment cap-hit record. Set by `recordExperimentCap` when
+   * the orchestrator's `checkPerExperimentCap` fires. The comparison
+   * report renders "capped" alongside pass/fail; the orchestrator
+   * surfaces a remediation menu (continue / extend cap / abandon) to
+   * the PO. Absent when the experiment ran within its caps.
+   */
+  capped?: ExperimentCap;
 }
 
 export interface CutExperimentArgs extends BranchLookupOpts {

--- a/scripts/tdd/spike-carryforward.ts
+++ b/scripts/tdd/spike-carryforward.ts
@@ -1,0 +1,172 @@
+// Spike learning carry-forward into the design-spec gate.
+//
+// `cutSpike` already preserves notes on disk after branch teardown
+// (`.tdd/spikes/<slug>/notes.md`). When the related feature shows up
+// for its design-spec gate, the orchestrator should not have to ask
+// the human to remember the spike. This module scans for spikes that
+// reference an upcoming feature and proposes attaching their notes
+// onto the feature's `plan.json` under `rationale.spike_inputs[]`.
+//
+// Convention for tagging a spike with a feature:
+//   1. YAML frontmatter at the top of `notes.md`:
+//        ---
+//        for_feature: F1-checkout
+//        ---
+//   2. A body line anywhere in `notes.md` that begins with one of:
+//        For feature: F1-checkout
+//        Feature: F1-checkout
+//        feature_id: F1-checkout
+//        for_feature: F1-checkout
+//      (case-insensitive on the key; the feature id itself is matched
+//      verbatim so `F1` does NOT match a spike tagged `F1-checkout`.)
+//
+// Neither tag is mandatory. Spikes left untagged remain on disk and
+// the carry-forward primitive simply skips them.
+
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
+import { join } from "path";
+
+export interface SpikeInput {
+  /** Spike directory name under `.tdd/spikes/`. */
+  slug: string;
+  /** Absolute path to the spike's notes.md. */
+  notes_path: string;
+  /** First non-blank lines of notes.md, capped at ~200 characters. */
+  preview: string;
+  /** Which tagging marker matched ("frontmatter" or one of the body-line keys). */
+  matched_marker: string;
+}
+
+export interface CollectSpikeInputsArgs {
+  tddDir: string;
+  featureId: string;
+}
+
+/**
+ * Scan `<tddDir>/spikes/` and return every spike that references
+ * `featureId` via the documented tagging conventions. Results are
+ * sorted by spike slug for deterministic output.
+ *
+ * Returns an empty array when no spikes match or the spikes/
+ * directory does not exist; never throws on a per-spike parse error
+ * (a malformed notes.md is treated as "untagged").
+ */
+export function collectSpikeInputs(args: CollectSpikeInputsArgs): SpikeInput[] {
+  const spikesDir = join(args.tddDir, "spikes");
+  if (!existsSync(spikesDir)) return [];
+  const out: SpikeInput[] = [];
+  for (const slug of readdirSync(spikesDir)) {
+    const dir = join(spikesDir, slug);
+    if (!statSync(dir).isDirectory()) continue;
+    const notesPath = join(dir, "notes.md");
+    if (!existsSync(notesPath)) continue;
+    let content: string;
+    try {
+      content = readFileSync(notesPath, "utf8");
+    } catch {
+      continue;
+    }
+    const match = matchFeatureMarker(content, args.featureId);
+    if (!match) continue;
+    out.push({
+      slug,
+      notes_path: notesPath,
+      preview: extractPreview(content),
+      matched_marker: match,
+    });
+  }
+  return out.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+const BODY_LINE_KEYS = ["for feature", "feature", "feature_id", "for_feature"];
+
+function matchFeatureMarker(content: string, featureId: string): string | undefined {
+  const frontmatter = extractFrontmatter(content);
+  if (frontmatter) {
+    for (const key of ["for_feature", "feature_id", "feature"]) {
+      const re = new RegExp(`^\\s*${key}\\s*:\\s*(\\S+)\\s*$`, "im");
+      const m = frontmatter.match(re);
+      if (m && m[1] === featureId) return `frontmatter:${key}`;
+    }
+  }
+  for (const key of BODY_LINE_KEYS) {
+    // Allow leading and trailing markdown decoration (* _ > whitespace)
+    // around the key and the value so `**For feature:** F1` matches.
+    const re = new RegExp(
+      `^[*_\\s>]*${escapeRegex(key)}[*_\\s]*:[*_\\s]*(\\S+)[*_\\s]*$`,
+      "im"
+    );
+    const m = content.match(re);
+    if (m && m[1] === featureId) return `body:${key}`;
+  }
+  return undefined;
+}
+
+function extractFrontmatter(content: string): string | undefined {
+  if (!content.startsWith("---")) return undefined;
+  const end = content.indexOf("\n---", 3);
+  if (end < 0) return undefined;
+  return content.slice(3, end);
+}
+
+function extractPreview(content: string): string {
+  const body = content.replace(/^---[\s\S]*?\n---\s*\n?/, "").trim();
+  const head = body.split("\n").filter((l) => l.trim().length > 0).slice(0, 3).join(" ");
+  return head.length > 200 ? head.slice(0, 197) + "..." : head;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export interface AttachSpikeInputsArgs {
+  tddDir: string;
+  featureId: string;
+  /**
+   * Spike slugs to attach. Use `collectSpikeInputs` to discover
+   * candidates and the orchestrator/PO to whittle the list down.
+   */
+  slugs: string[];
+}
+
+export interface AttachSpikeInputsResult {
+  /** Spike inputs written to the plan. */
+  attached: SpikeInput[];
+  /** Slugs the caller passed that did not resolve to a tagged spike. */
+  unresolved: string[];
+}
+
+/**
+ * Persist `spike_inputs` onto `<tddDir>/features/<featureId>/plan.json`
+ * under the existing `rationale` block. Re-running with the same slugs
+ * is a no-op (idempotent); passing an empty slug list clears the field.
+ * Throws if plan.json does not exist (the gate has not run yet).
+ */
+export function attachSpikeInputs(args: AttachSpikeInputsArgs): AttachSpikeInputsResult {
+  const planPath = join(args.tddDir, "features", args.featureId, "plan.json");
+  if (!existsSync(planPath)) {
+    throw new Error(
+      `attachSpikeInputs: plan.json not found at ${planPath}. Run the design-spec gate first.`
+    );
+  }
+  const candidates = collectSpikeInputs({ tddDir: args.tddDir, featureId: args.featureId });
+  const bySlug = new Map(candidates.map((c) => [c.slug, c]));
+  const attached: SpikeInput[] = [];
+  const unresolved: string[] = [];
+  for (const slug of args.slugs) {
+    const hit = bySlug.get(slug);
+    if (hit) {
+      attached.push(hit);
+    } else {
+      unresolved.push(slug);
+    }
+  }
+  const plan = JSON.parse(readFileSync(planPath, "utf8")) as Record<string, unknown>;
+  if (attached.length === 0) {
+    delete plan.spike_inputs;
+  } else {
+    plan.spike_inputs = attached;
+  }
+  writeFileSync(planPath, JSON.stringify(plan, null, 2) + "\n");
+  return { attached, unresolved };
+}

--- a/tests/bdd/experiment-cap.test.ts
+++ b/tests/bdd/experiment-cap.test.ts
@@ -1,0 +1,314 @@
+// BDD coverage for the per-experiment cost/timeout cap primitive.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  checkPerExperimentCap,
+  clearExperimentCap,
+  recordExperimentCap,
+} from "../../scripts/tdd/experiment-cap";
+import { readOutcomes } from "../../scripts/tdd/experiment";
+
+function mkTempTdd(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `experiment-cap-${prefix}-`));
+}
+
+function rm(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+function seedExperiment(
+  tddDir: string,
+  featureId: string,
+  slug: string,
+  opts: { cutAt?: string } = {}
+): void {
+  const dir = path.join(tddDir, "experiments", featureId, slug);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "branch.txt"), `feature-${slug}`);
+  fs.writeFileSync(path.join(dir, "outcomes.json"), JSON.stringify({ status: "running" }, null, 2) + "\n");
+  const timeline = {
+    entries: [{ ts: opts.cutAt ?? "2026-06-02T08:00:00.000Z", kind: "cut", branch: `feature-${slug}` }],
+  };
+  fs.writeFileSync(path.join(dir, "timeline.json"), JSON.stringify(timeline, null, 2) + "\n");
+}
+
+describe("checkPerExperimentCap: no cap configured", () => {
+  it("returns capped=false when cap is undefined", () => {
+    const result = checkPerExperimentCap({
+      tddDir: "/tmp/anywhere",
+      featureId: "F1",
+      experimentSlug: "exp",
+      cycleCount: 1000,
+    });
+    expect(result).toEqual({ capped: false });
+  });
+
+  it("returns capped=false when cap is an empty object", () => {
+    const result = checkPerExperimentCap({
+      tddDir: "/tmp/anywhere",
+      featureId: "F1",
+      experimentSlug: "exp",
+      cap: {},
+      cycleCount: 1000,
+    });
+    expect(result.capped).toBe(false);
+  });
+
+  it("treats max_cycles <= 0 as no cap", () => {
+    const result = checkPerExperimentCap({
+      tddDir: "/tmp/anywhere",
+      featureId: "F1",
+      experimentSlug: "exp",
+      cap: { max_cycles: 0 },
+      cycleCount: 100,
+    });
+    expect(result.capped).toBe(false);
+  });
+});
+
+describe("checkPerExperimentCap: max_cycles", () => {
+  let tddDir: string;
+  beforeEach(() => {
+    tddDir = mkTempTdd("cycles");
+    seedExperiment(tddDir, "F1", "exp");
+  });
+  afterEach(() => rm(tddDir));
+
+  it("fires when cycleCount reaches the threshold", () => {
+    const result = checkPerExperimentCap({
+      tddDir,
+      featureId: "F1",
+      experimentSlug: "exp",
+      cap: { max_cycles: 10 },
+      cycleCount: 10,
+    });
+    expect(result.capped).toBe(true);
+    expect(result.hit?.reason).toBe("max_cycles");
+    expect(result.hit?.at_cycle).toBe(10);
+    expect(result.hit?.cap_value).toBe(10);
+  });
+
+  it("does not fire when cycleCount is below the threshold", () => {
+    const result = checkPerExperimentCap({
+      tddDir,
+      featureId: "F1",
+      experimentSlug: "exp",
+      cap: { max_cycles: 10 },
+      cycleCount: 9,
+    });
+    expect(result.capped).toBe(false);
+  });
+
+  it("fires deterministically before the wall-clock cap when both could trip", () => {
+    const result = checkPerExperimentCap({
+      tddDir,
+      featureId: "F1",
+      experimentSlug: "exp",
+      cap: { max_cycles: 5, max_wall_clock_minutes: 30 },
+      cycleCount: 5,
+      now: Date.parse("2026-06-02T09:00:00.000Z"), // 1h elapsed from cut
+    });
+    expect(result.hit?.reason).toBe("max_cycles");
+  });
+});
+
+describe("checkPerExperimentCap: max_wall_clock_minutes", () => {
+  let tddDir: string;
+  beforeEach(() => {
+    tddDir = mkTempTdd("wallclock");
+    seedExperiment(tddDir, "F1", "exp", { cutAt: "2026-06-02T08:00:00.000Z" });
+  });
+  afterEach(() => rm(tddDir));
+
+  it("fires when elapsed minutes meet the threshold", () => {
+    const result = checkPerExperimentCap({
+      tddDir,
+      featureId: "F1",
+      experimentSlug: "exp",
+      cap: { max_wall_clock_minutes: 30 },
+      cycleCount: 1,
+      now: Date.parse("2026-06-02T08:30:00.000Z"),
+    });
+    expect(result.capped).toBe(true);
+    expect(result.hit?.reason).toBe("max_wall_clock_minutes");
+    expect(result.hit?.cap_value).toBe(30);
+    expect(result.hit?.at_minutes).toBeGreaterThanOrEqual(30);
+  });
+
+  it("does not fire when elapsed minutes are below the threshold", () => {
+    const result = checkPerExperimentCap({
+      tddDir,
+      featureId: "F1",
+      experimentSlug: "exp",
+      cap: { max_wall_clock_minutes: 30 },
+      cycleCount: 1,
+      now: Date.parse("2026-06-02T08:15:00.000Z"),
+    });
+    expect(result.capped).toBe(false);
+  });
+
+  it("silently skips the wall-clock check when no timeline.json exists", () => {
+    const bareTdd = mkTempTdd("bare");
+    try {
+      fs.mkdirSync(path.join(bareTdd, "experiments", "F1", "exp"), { recursive: true });
+      const result = checkPerExperimentCap({
+        tddDir: bareTdd,
+        featureId: "F1",
+        experimentSlug: "exp",
+        cap: { max_wall_clock_minutes: 1 },
+        cycleCount: 1,
+        now: Date.parse("2099-01-01T00:00:00.000Z"),
+      });
+      expect(result.capped).toBe(false);
+    } finally {
+      rm(bareTdd);
+    }
+  });
+});
+
+describe("recordExperimentCap + clearExperimentCap", () => {
+  let tddDir: string;
+  beforeEach(() => {
+    tddDir = mkTempTdd("record");
+    seedExperiment(tddDir, "F1", "exp");
+  });
+  afterEach(() => rm(tddDir));
+
+  it("persists the cap hit onto outcomes.json", () => {
+    recordExperimentCap({
+      tddDir,
+      featureId: "F1",
+      experimentSlug: "exp",
+      hit: { reason: "max_cycles", at_cycle: 10, cap_value: 10 },
+    });
+    const outcomes = readOutcomes(tddDir, "F1", "exp")!;
+    expect(outcomes.capped).toEqual({ reason: "max_cycles", at_cycle: 10, cap_value: 10 });
+  });
+
+  it("overwrites an existing cap on subsequent calls", () => {
+    recordExperimentCap({
+      tddDir,
+      featureId: "F1",
+      experimentSlug: "exp",
+      hit: { reason: "max_cycles", at_cycle: 10, cap_value: 10 },
+    });
+    recordExperimentCap({
+      tddDir,
+      featureId: "F1",
+      experimentSlug: "exp",
+      hit: { reason: "max_wall_clock_minutes", at_cycle: 12, cap_value: 60, at_minutes: 61.2 },
+    });
+    const outcomes = readOutcomes(tddDir, "F1", "exp")!;
+    expect(outcomes.capped?.reason).toBe("max_wall_clock_minutes");
+    expect(outcomes.capped?.at_minutes).toBe(61.2);
+  });
+
+  it("throws when outcomes.json does not exist", () => {
+    const empty = mkTempTdd("empty");
+    try {
+      expect(() =>
+        recordExperimentCap({
+          tddDir: empty,
+          featureId: "F1",
+          experimentSlug: "exp",
+          hit: { reason: "max_cycles", at_cycle: 1, cap_value: 1 },
+        })
+      ).toThrow(/outcomes\.json not found/);
+    } finally {
+      rm(empty);
+    }
+  });
+
+  it("clearExperimentCap removes the capped field; second call is a no-op", () => {
+    recordExperimentCap({
+      tddDir,
+      featureId: "F1",
+      experimentSlug: "exp",
+      hit: { reason: "max_cycles", at_cycle: 10, cap_value: 10 },
+    });
+    clearExperimentCap({ tddDir, featureId: "F1", experimentSlug: "exp" });
+    expect(readOutcomes(tddDir, "F1", "exp")?.capped).toBeUndefined();
+    // Idempotent.
+    expect(() =>
+      clearExperimentCap({ tddDir, featureId: "F1", experimentSlug: "exp" })
+    ).not.toThrow();
+  });
+});
+
+describe("analyzeForGate populates a default per-experiment cap", () => {
+  it("proposed_plan.budget.per_experiment carries default max_cycles + max_wall_clock_minutes", async () => {
+    const { analyzeForGate } = await import("../../scripts/tdd/design-spec-gate");
+    const { writeMasterTestList } = await import("../../scripts/tdd/test-list");
+    const tddDir = mkTempTdd("analyze");
+    try {
+      fs.mkdirSync(path.join(tddDir, "features", "F1"), { recursive: true });
+      writeMasterTestList(tddDir, {
+        feature_id: "F1",
+        items: [{ id: "T1", description: "any", ac_id: "AC1", status: "pending" }],
+      });
+      const analysis = analyzeForGate(tddDir, "F1");
+      expect(analysis.proposed_plan.budget.per_experiment).toBeDefined();
+      expect(analysis.proposed_plan.budget.per_experiment?.max_cycles).toBeGreaterThan(0);
+      expect(analysis.proposed_plan.budget.per_experiment?.max_wall_clock_minutes).toBeGreaterThan(0);
+    } finally {
+      rm(tddDir);
+    }
+  });
+});
+
+describe("compareExperiments surfaces capped outcomes", () => {
+  it("classifies signal as 'capped' and copies the cap onto the experiment row", async () => {
+    const { compareExperiments } = await import("../../scripts/tdd/compare-experiments");
+    const tddDir = mkTempTdd("compare");
+    try {
+      seedExperiment(tddDir, "F1", "exp-a");
+      recordExperimentCap({
+        tddDir,
+        featureId: "F1",
+        experimentSlug: "exp-a",
+        hit: { reason: "max_cycles", at_cycle: 30, cap_value: 30 },
+      });
+      const report = compareExperiments(tddDir, "F1");
+      const row = report.rows.find((r) => r.experiment_slug === "exp-a")!;
+      expect(row.signal).toBe("capped");
+      expect(row.capped?.reason).toBe("max_cycles");
+    } finally {
+      rm(tddDir);
+    }
+  });
+});
+
+describe("comparison-report renders the cap status", () => {
+  it("includes a Cap column in the per-experiment table and a remediation line in the decision block", async () => {
+    const { renderComparisonReport } = await import("../../scripts/tdd/comparison-report");
+    const md = renderComparisonReport({
+      feature_id: "F1",
+      generated_at: "2026-06-02T08:15:00.000Z",
+      rows: [
+        {
+          experiment_slug: "exp-cap",
+          branch_id: "feature-x",
+          status: "running",
+          signal: "capped",
+          capped: { reason: "max_cycles", at_cycle: 30, cap_value: 30 },
+          cycle_count: 30,
+          artifact_count: 0,
+        },
+      ],
+      matrix: [],
+      recommendation: "continue",
+      rationale: "experiment capped, awaiting remediation",
+    });
+    expect(md).toMatch(/\| Cap \|/);
+    expect(md).toMatch(/max_cycles \(>=30 @ cycle 30\)/);
+    expect(md).toMatch(/Capped experiment\(s\) awaiting PO remediation: `exp-cap`/);
+    expect(md).toMatch(/`extend`|`abandon`|`continue-suite`/);
+  });
+});

--- a/tests/bdd/spike-carryforward.test.ts
+++ b/tests/bdd/spike-carryforward.test.ts
@@ -1,0 +1,215 @@
+// BDD coverage for the spike to design-spec carry-forward primitive.
+// Hermetic: tmpdir-based .tdd/ trees, no shell-outs.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  attachSpikeInputs,
+  collectSpikeInputs,
+} from "../../scripts/tdd/spike-carryforward";
+
+function mkTempTdd(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `spike-carryforward-${prefix}-`));
+}
+
+function rm(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+function seedSpike(tddDir: string, slug: string, notes: string): void {
+  const dir = path.join(tddDir, "spikes", slug);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "notes.md"), notes, "utf8");
+  fs.writeFileSync(path.join(dir, "branch.txt"), `spike-${slug}`, "utf8");
+}
+
+function seedPlan(tddDir: string, featureId: string, plan: Record<string, unknown>): void {
+  const dir = path.join(tddDir, "features", featureId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "plan.json"), JSON.stringify(plan, null, 2) + "\n");
+}
+
+describe("collectSpikeInputs", () => {
+  let tddDir: string;
+  beforeEach(() => {
+    tddDir = mkTempTdd("collect");
+  });
+  afterEach(() => rm(tddDir));
+
+  it("returns [] when .tdd/spikes/ does not exist", () => {
+    expect(collectSpikeInputs({ tddDir, featureId: "F1" })).toEqual([]);
+  });
+
+  it("matches a spike tagged via YAML frontmatter for_feature", () => {
+    seedSpike(
+      tddDir,
+      "explore-cart",
+      "---\nfor_feature: F1-checkout\n---\n\n# explore-cart\n\nTried postgres arrays. Worked.\n"
+    );
+    const result = collectSpikeInputs({ tddDir, featureId: "F1-checkout" });
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe("explore-cart");
+    expect(result[0].matched_marker).toBe("frontmatter:for_feature");
+    expect(result[0].preview).toContain("Tried postgres arrays");
+  });
+
+  it("matches a spike tagged via a body line `For feature:`", () => {
+    seedSpike(
+      tddDir,
+      "explore-json",
+      "# explore-json\n\nFor feature: F1-checkout\n\nTried JSON blobs. Cheaper to write.\n"
+    );
+    const result = collectSpikeInputs({ tddDir, featureId: "F1-checkout" });
+    expect(result).toHaveLength(1);
+    expect(result[0].matched_marker).toMatch(/^body:/);
+  });
+
+  it("matches multiple key variants in body lines (feature_id, feature)", () => {
+    seedSpike(tddDir, "a", "feature_id: F1\n");
+    seedSpike(tddDir, "b", "feature: F1\n");
+    seedSpike(tddDir, "c", "**For feature:** F1\n");
+    const result = collectSpikeInputs({ tddDir, featureId: "F1" });
+    expect(result.map((r) => r.slug)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not match the wrong feature id (no prefix matching)", () => {
+    seedSpike(tddDir, "explore-cart", "for_feature: F1-checkout\n");
+    expect(collectSpikeInputs({ tddDir, featureId: "F1" })).toEqual([]);
+    expect(collectSpikeInputs({ tddDir, featureId: "F1-checkout-extra" })).toEqual([]);
+  });
+
+  it("skips untagged spikes without throwing", () => {
+    seedSpike(tddDir, "no-tag", "# spike\n\nGeneric exploration; no feature reference.\n");
+    expect(collectSpikeInputs({ tddDir, featureId: "F1" })).toEqual([]);
+  });
+
+  it("returns results sorted by slug for deterministic output", () => {
+    seedSpike(tddDir, "zeta", "for_feature: F1\n");
+    seedSpike(tddDir, "alpha", "for_feature: F1\n");
+    seedSpike(tddDir, "mu", "for_feature: F1\n");
+    const result = collectSpikeInputs({ tddDir, featureId: "F1" });
+    expect(result.map((r) => r.slug)).toEqual(["alpha", "mu", "zeta"]);
+  });
+
+  it("truncates long previews and excludes frontmatter from preview text", () => {
+    const long = "a".repeat(500);
+    seedSpike(tddDir, "long", `---\nfor_feature: F1\n---\n\n${long}\n`);
+    const result = collectSpikeInputs({ tddDir, featureId: "F1" });
+    expect(result[0].preview.length).toBeLessThanOrEqual(200);
+    expect(result[0].preview).not.toContain("for_feature");
+  });
+
+  it("ignores entries in the spikes dir that are not directories with notes.md", () => {
+    fs.mkdirSync(path.join(tddDir, "spikes"), { recursive: true });
+    fs.writeFileSync(path.join(tddDir, "spikes", "stray-file.md"), "for_feature: F1\n");
+    expect(collectSpikeInputs({ tddDir, featureId: "F1" })).toEqual([]);
+  });
+});
+
+describe("attachSpikeInputs", () => {
+  let tddDir: string;
+  beforeEach(() => {
+    tddDir = mkTempTdd("attach");
+  });
+  afterEach(() => rm(tddDir));
+
+  it("writes the resolved spike inputs onto plan.json", () => {
+    seedSpike(tddDir, "explore-cart", "for_feature: F1\n\nTried arrays. Worked.\n");
+    seedPlan(tddDir, "F1", { feature_id: "F1", N: 1, mode: "N=1" });
+    const result = attachSpikeInputs({ tddDir, featureId: "F1", slugs: ["explore-cart"] });
+    expect(result.attached).toHaveLength(1);
+    expect(result.unresolved).toEqual([]);
+    const plan = JSON.parse(fs.readFileSync(path.join(tddDir, "features", "F1", "plan.json"), "utf8"));
+    expect(plan.spike_inputs).toHaveLength(1);
+    expect(plan.spike_inputs[0].slug).toBe("explore-cart");
+  });
+
+  it("reports unresolved slugs without writing them", () => {
+    seedSpike(tddDir, "real-spike", "for_feature: F1\n");
+    seedPlan(tddDir, "F1", { feature_id: "F1" });
+    const result = attachSpikeInputs({
+      tddDir,
+      featureId: "F1",
+      slugs: ["real-spike", "ghost-spike"],
+    });
+    expect(result.attached).toHaveLength(1);
+    expect(result.unresolved).toEqual(["ghost-spike"]);
+    const plan = JSON.parse(fs.readFileSync(path.join(tddDir, "features", "F1", "plan.json"), "utf8"));
+    expect(plan.spike_inputs.map((i: { slug: string }) => i.slug)).toEqual(["real-spike"]);
+  });
+
+  it("clears spike_inputs when called with an empty slug list", () => {
+    seedSpike(tddDir, "explore", "for_feature: F1\n");
+    seedPlan(tddDir, "F1", {
+      feature_id: "F1",
+      spike_inputs: [{ slug: "old", notes_path: "x", preview: "y", matched_marker: "z" }],
+    });
+    attachSpikeInputs({ tddDir, featureId: "F1", slugs: [] });
+    const plan = JSON.parse(fs.readFileSync(path.join(tddDir, "features", "F1", "plan.json"), "utf8"));
+    expect(plan.spike_inputs).toBeUndefined();
+  });
+
+  it("is idempotent: re-running with the same slugs produces the same plan.json content", () => {
+    seedSpike(tddDir, "explore", "for_feature: F1\n");
+    seedPlan(tddDir, "F1", { feature_id: "F1" });
+    attachSpikeInputs({ tddDir, featureId: "F1", slugs: ["explore"] });
+    const first = fs.readFileSync(path.join(tddDir, "features", "F1", "plan.json"), "utf8");
+    attachSpikeInputs({ tddDir, featureId: "F1", slugs: ["explore"] });
+    const second = fs.readFileSync(path.join(tddDir, "features", "F1", "plan.json"), "utf8");
+    expect(second).toBe(first);
+  });
+
+  it("throws when plan.json is missing", () => {
+    expect(() => attachSpikeInputs({ tddDir, featureId: "F1", slugs: ["x"] })).toThrow(
+      /plan\.json not found/
+    );
+  });
+});
+
+function seedFeatureDir(tddDir: string, featureId: string): void {
+  fs.mkdirSync(path.join(tddDir, "features", featureId), { recursive: true });
+}
+
+describe("analyzeForGate populates spike_inputs when spikes match", () => {
+  it("returns proposed_plan.spike_inputs containing the matching spikes", async () => {
+    const { analyzeForGate } = await import("../../scripts/tdd/design-spec-gate");
+    const { writeMasterTestList } = await import("../../scripts/tdd/test-list");
+    const tddDir = mkTempTdd("analyze");
+    try {
+      seedFeatureDir(tddDir, "F1");
+      writeMasterTestList(tddDir, {
+        feature_id: "F1",
+        items: [{ id: "T1", description: "POST /orders returns 201", ac_id: "AC1", status: "pending" }],
+      });
+      seedSpike(tddDir, "explore-cart", "for_feature: F1\n\nTried arrays.\n");
+      const analysis = analyzeForGate(tddDir, "F1");
+      expect(analysis.proposed_plan.spike_inputs).toHaveLength(1);
+      expect(analysis.proposed_plan.spike_inputs?.[0].slug).toBe("explore-cart");
+    } finally {
+      rm(tddDir);
+    }
+  });
+
+  it("omits spike_inputs from the proposed plan when no spike matches", async () => {
+    const { analyzeForGate } = await import("../../scripts/tdd/design-spec-gate");
+    const { writeMasterTestList } = await import("../../scripts/tdd/test-list");
+    const tddDir = mkTempTdd("analyze-none");
+    try {
+      seedFeatureDir(tddDir, "F1");
+      writeMasterTestList(tddDir, {
+        feature_id: "F1",
+        items: [{ id: "T1", description: "any", ac_id: "AC1", status: "pending" }],
+      });
+      const analysis = analyzeForGate(tddDir, "F1");
+      expect(analysis.proposed_plan.spike_inputs).toBeUndefined();
+    } finally {
+      rm(tddDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two TDD substrate primitives in one PR, both small.

### FEIP-7211: spike → design-spec carry-forward

`cutSpike` preserves notes at `.tdd/spikes/<slug>/notes.md` after branch teardown. When the related feature shows up for its design-spec gate, the orchestrator should not have to ask the PO to remember the spike.

- `collectSpikeInputs({ tddDir, featureId })` scans `.tdd/spikes/` for notes tagged with the upcoming feature id via YAML frontmatter (`for_feature: F1-checkout`) or a body line (`For feature:` / `feature:` / `feature_id:` / `for_feature:`, tolerant of markdown bold).
- `attachSpikeInputs` writes the resolved inputs onto `features/<F>/plan.json` under `spike_inputs`. Idempotent.
- `analyzeForGate.proposed_plan.spike_inputs` populates automatically when matching spikes exist.

### FEIP-7218: per-experiment cost/timeout cap

Race-level budget covers "all experiments" but not "one runaway experiment burns it." This adds the per-experiment cap.

- `BudgetProposal.per_experiment: { max_cycles, max_wall_clock_minutes }`. `analyzeForGate` seeds a sensible default (30 cycles + 60 min).
- `checkPerExperimentCap`: pure check on cycle count + wall-clock from `timeline.json`.
- `recordExperimentCap` / `clearExperimentCap`: outcomes.json writers.
- `ExperimentOutcomes.capped: ExperimentCap` with reason / at_cycle / cap_value / optional at_minutes.
- `compareExperiments` classifies capped experiments as a distinct `"capped"` signal.
- `comparison-report` renders a new "Cap" column and the HITL decision block lists capped experiments with `extend` / `abandon` / `continue-suite` reply options.

## Test plan

- [x] 1035/1145 tests pass (+32 net hermetic cases: 16 each)
- [x] tsc clean

This pull request and its description were written by Isaac.