### PR TITLE
Document spike carry-forward, per-experiment cap, MarkdownAdapter.pull

### DIFF
--- a/skills/lakebase-tdd-workflows/README.md
+++ b/skills/lakebase-tdd-workflows/README.md
@@ -110,7 +110,9 @@ Side-mode for exploration that sits outside the main flow. No test list, no gate
 
 The branch is deleted by default after notes are captured. **Spike code is never promoted into a TDD branch** – only the learning carries over.
 
-Before cutting any new experiment, the orchestrator checks the budget – at the concurrent-branch or wall-clock limit, it asks the PO to extend or stop, rather than cutting anyway.
+**Spike → design-spec carry-forward.** Tag a spike with the feature it informs (either YAML frontmatter `for_feature: F1-checkout` or a body line `For feature: F1-checkout`, with `feature:`, `feature_id:`, and `for_feature:` all accepted, tolerant of markdown bold). When that feature later goes through `analyzeForGate`, the analyzer's `proposed_plan.spike_inputs[]` automatically lists every matching spike with a short notes preview. The orchestrator surfaces these to the PO at Gate 4 and `attachSpikeInputs` persists the kept ones onto `plan.json` so the experiment record always carries the rationale.
+
+Before cutting any new experiment, the orchestrator checks the budget – at the concurrent-branch or wall-clock limit, it asks the PO to extend or stop, rather than cutting anyway. The plan also carries a `budget.per_experiment` cap (default 30 cycles + 60 minutes wall-clock) so one runaway experiment cannot starve its siblings: `checkPerExperimentCap` fires when an experiment crosses its cycle or wall-clock threshold, `recordExperimentCap` writes a `capped: { reason, at_cycle, ... }` record onto `outcomes.json`, and the comparison report tags the experiment with a `capped` signal and prompts the PO to `extend`, `abandon`, or `continue-suite`.
 
 ### 4. Cycle (RED / GREEN / REFACTOR)
 
@@ -129,6 +131,8 @@ At convergence of a parallel race, the orchestrator builds a `ComparisonReport` 
 - **Archive** (`archiveExperiment`) – move an experiment record into `_archive/` without promoting.
 
 Both promote and synthesize require `hitlApproved: true` at the function boundary; the gate cannot be skipped programmatically.
+
+Experiments that hit a per-experiment cap (`max_cycles` or `max_wall_clock_minutes`) appear in the report with signal `capped` and a new `Cap` column showing the reason. The HITL decision block then lists capped experiments separately and prompts the PO to choose `extend` (raise the cap and resume via `clearExperimentCap`), `abandon` (archive this experiment, let siblings continue), or `continue-suite` (leave it capped and decide at end).
 
 ### 7. Gates and integrity
 
@@ -229,7 +233,9 @@ import { cutExperiment, listExperiments, deleteExperiment } from "@databricks-so
 | `recordTagRun(outcomes, tag, verdict)` / `tagRunCount(outcomes, tag)` / `acLayerToTag(layer)` | Helpers for maintaining the tag-matrix bookkeeping on `outcomes.json`. |
 | `deleteExperiment(args)` | Tear down a Lakebase branch and (optionally) the on-disk experiment record. HITL-gated. |
 | `cutSpike(args)` / `listSpikes(tddDir)` / `deleteSpike(args)` | Same lifecycle for the spike side-mode under `.tdd/spikes/`. |
+| `collectSpikeInputs({ tddDir, featureId })` / `attachSpikeInputs(args)` | Scan `.tdd/spikes/` for notes tagged with a feature id (via YAML frontmatter or body line) and persist the resolved inputs onto the feature's `plan.json`. |
 | `archiveExperiment(args)` | Move an experiment record into `_archive/` without tearing down its branch. |
+| `checkPerExperimentCap(args)` / `recordExperimentCap(args)` / `clearExperimentCap(args)` | Per-experiment cap helpers. `checkPerExperimentCap` is a pure read; `recordExperimentCap` writes `outcomes.capped`; `clearExperimentCap` removes it on the PO's `extend` reply. |
 
 ### Cycle and runner
 
@@ -257,7 +263,7 @@ import { cutExperiment, listExperiments, deleteExperiment } from "@databricks-so
 
 | Primitive | Purpose |
 |---|---|
-| `analyzeForGate(input, options?)` | The design-spec analyzer. Scans the approved test list for opinion-gap signals and returns an `ExperimentPlan` proposal (N, strategies, budget, rationale). |
+| `analyzeForGate(input, options?)` | The design-spec analyzer. Scans the approved test list for opinion-gap signals and returns an `ExperimentPlan` proposal (N, strategies, budget incl. `per_experiment` default cap, rationale, plus `spike_inputs[]` populated automatically from any tagged spike under `.tdd/spikes/`). |
 | `recordPlan(tddDir, plan, deciderEmail?)` | Persist an approved plan to `plan.json` and append the decision to `selection-log.md`. |
 | `readPlan(tddDir, featureId)` / `writePlan(tddDir, plan)` | Direct plan IO. |
 | `checkE2eGate({ tddDir, featureId })` | Pre-merge guard: refuses to advance if any `[E2E]`-tagged AC is still red. |
@@ -327,7 +333,7 @@ import { cutExperiment, listExperiments, deleteExperiment } from "@databricks-so
 
 `SpecAdapter` is the pluggable surface that syncs `.tdd/` entities to/from an external tracker. The skill ships two implementations:
 
-- `markdownAdapter` (instance) / `MarkdownAdapter` (class) – the default; treats the on-disk Markdown + JSON pair as the source of truth.
+- `markdownAdapter` (instance) / `MarkdownAdapter` (class) – the default; treats the on-disk Markdown + JSON pair as the source of truth. `pushFeature` / `pushStory` / `pushAC` emit typed external_ids (`markdown:feature:<id>` / `markdown:story:<feature>:<id>` / `markdown:ac:_:<story>:<id>`). `pull(externalId, ctx)` resolves the matching entity from disk and also accepts the legacy `markdown:<id>` shape via a tree scan for backward compatibility.
 - `JiraAdapter` (constructed with `JiraAdapterConfig`) – mirrors features/stories/ACs to JIRA hierarchy. Configured by the project's `design.pre-hook.md` in scaffolded projects.
 
 Implement your own adapter against the `SpecAdapter` interface (with the `SyncEventHooks` lifecycle) to bridge to Linear, GitHub Issues, or any other tracker.

--- a/skills/lakebase-tdd-workflows/SKILL.md
+++ b/skills/lakebase-tdd-workflows/SKILL.md
@@ -85,14 +85,23 @@ Concrete invocations of the substrate primitives.
 ```ts
 import { analyzeForGate, recordPlan, writePlan } from "@databricks-solutions/lakebase-app-dev-kit/tdd/design-spec-gate";
 import { canCutAnotherExperiment } from "@databricks-solutions/lakebase-app-dev-kit/tdd/budget";
+import { attachSpikeInputs } from "@databricks-solutions/lakebase-app-dev-kit/tdd/spike-carryforward";
 
 const analysis = analyzeForGate(".tdd", "F1");
-// analysis.opinion_gaps[]  – items the analyzer flagged as opinion gaps
-// analysis.proposed_plan   – { mode: "N=1" | "N>=2", N, strategies[], budget, rationale }
+// analysis.opinion_gaps[]            – items the analyzer flagged as opinion gaps
+// analysis.proposed_plan              – { mode: "N=1" | "N>=2", N, strategies[], budget, rationale }
+// analysis.proposed_plan.budget.per_experiment
+//                                     – default cap { max_cycles: 30, max_wall_clock_minutes: 60 }
+//                                       the orchestrator can override before writePlan
+// analysis.proposed_plan.spike_inputs – auto-populated from `.tdd/spikes/<slug>/notes.md`
+//                                       entries tagged with `for_feature: F1` (frontmatter
+//                                       or body line). Surface to PO at Gate 4; pass the
+//                                       kept slugs to attachSpikeInputs.
 
 // Surface to PO. On Gate 4 approval, persist:
 recordPlan(".tdd", analysis.proposed_plan, "kevin@example.com");
 writePlan(".tdd", analysis.proposed_plan);
+attachSpikeInputs({ tddDir: ".tdd", featureId: "F1", slugs: ["explore-cart-storage"] });
 
 // Before cutting any experiment, check the budget:
 const ok = canCutAnotherExperiment(".tdd", "F1");
@@ -134,6 +143,8 @@ await deleteExperiment({
 ```ts
 import { cutSpike, listSpikes, deleteSpike }
   from "@databricks-solutions/lakebase-app-dev-kit/tdd/spike";
+import { collectSpikeInputs, attachSpikeInputs }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/spike-carryforward";
 
 await cutSpike({
   instance: "proj-checkout",
@@ -141,6 +152,8 @@ await cutSpike({
   spikeSlug: "explore-cart-storage",
   branch: "spike-explore-cart-storage",
   parentBranch: "staging",
+  // Tag the notes so future design-spec gates pick it up:
+  notes: "---\nfor_feature: F1-checkout\n---\n\n# explore-cart-storage\n\nTried postgres arrays. Worked.\n",
 });
 
 // Notes captured, branch deleted by default (throwaway).
@@ -150,6 +163,18 @@ await deleteSpike({
   spikeSlug: "explore-cart-storage",
 });
 // Notes preserved at .tdd/spikes/explore-cart-storage/notes.md.
+
+// When the related feature shows up at the design-spec gate, surface
+// the spike's learning to the PO:
+const inputs = collectSpikeInputs({ tddDir: ".tdd", featureId: "F1-checkout" });
+// inputs[].slug, .notes_path, .preview (capped at ~200 chars), .matched_marker
+// Accepts YAML frontmatter (for_feature / feature_id / feature) and body lines
+// (`For feature:`, `feature:`, `feature_id:`, `for_feature:`, tolerant of
+// markdown bold like `**For feature:**`). Feature id is matched verbatim, no
+// prefix match.
+
+// On PO approval, persist the kept slugs onto plan.json:
+attachSpikeInputs({ tddDir: ".tdd", featureId: "F1-checkout", slugs: ["explore-cart-storage"] });
 ```
 
 ### Cycle (RED → GREEN → REFACTOR)
@@ -202,16 +227,70 @@ if (hits.length) {
 }
 ```
 
+### Per-experiment cap (every cycle, N≥2)
+
+```ts
+import { checkPerExperimentCap, recordExperimentCap, clearExperimentCap }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/experiment-cap";
+import { readPlan } from "@databricks-solutions/lakebase-app-dev-kit/tdd/design-spec-gate";
+
+// Each cycle, after recording the runner outcome and before queuing
+// the next one, ask the substrate if this experiment is over its cap.
+const plan = readPlan(".tdd", "F1");
+const check = checkPerExperimentCap({
+  tddDir: ".tdd",
+  featureId: "F1",
+  experimentSlug: "exp-postgres-arrays",
+  cap: plan?.budget.per_experiment,
+  cycleCount: listCycles(scope).length,
+  // now: optional override for the BDD harness.
+});
+if (check.capped) {
+  recordExperimentCap({
+    tddDir: ".tdd",
+    featureId: "F1",
+    experimentSlug: "exp-postgres-arrays",
+    hit: check.hit!,
+  });
+  // outcomes.json now carries { capped: { reason, at_cycle, cap_value, at_minutes? } }.
+  // Surface to PO with the three reply options:
+  //   extend         – raise the cap on plan.json and call clearExperimentCap()
+  //   abandon        – archiveExperiment + let siblings continue
+  //   continue-suite – leave capped on disk, decide at end-of-race
+}
+
+// On the PO's "extend" reply, raise the cap and clear the capped record:
+clearExperimentCap({
+  tddDir: ".tdd",
+  featureId: "F1",
+  experimentSlug: "exp-postgres-arrays",
+});
+```
+
+The default cap (30 cycles, 60 minutes wall-clock) is seeded by `analyzeForGate`. Cycle cap is evaluated before wall-clock cap so a cycle-bound experiment that is also slow returns the `max_cycles` reason deterministically.
+
 ### Compare (N≥2 convergence)
 
 ```ts
 import { compareExperiments }
   from "@databricks-solutions/lakebase-app-dev-kit/tdd/compare-experiments";
+import { renderComparisonReport, writeComparisonReport }
+  from "@databricks-solutions/lakebase-app-dev-kit/tdd/comparison-report";
 
 const report = compareExperiments(".tdd", "F1");
-// report.rows[].signal       – "winning" | "stalled" | "abandoned" | "running" | "unknown"
+// report.rows[].signal       – "winning" | "stalled" | "abandoned" | "running"
+//                              | "capped" | "unknown"
+// report.rows[].capped       – populated when a per-experiment cap fired:
+//                              { reason: "max_cycles" | "max_wall_clock_minutes",
+//                                at_cycle, cap_value, at_minutes? }
 // report.recommendation      – "promote" | "synthesize" | "continue" | "abandon-all"
 // report.rationale           – short explanation surfaced to the PO
+
+// Render to markdown and persist next to the feature so the PO reads one
+// file end-to-end (the HITL decision block lists any capped experiments
+// with the extend / abandon / continue-suite reply options inline).
+const md = renderComparisonReport(report);
+writeComparisonReport({ tddDir: ".tdd", featureId: "F1", report });
 ```
 
 ### Promote (N≥2, single winner)


### PR DESCRIPTION
Brings the lakebase-tdd-workflows README + SKILL.md current with the substrate primitives shipped today: spike carry-forward, per-experiment cap, MarkdownAdapter.pull, and the comparison-report cap rendering.

No code, no tests. Doc-only.

This pull request and its description were written by Isaac.