### PR TITLE
Document drift detector + lakebase-update-commands + e2e verification recipe

### DIFF
--- a/skills/lakebase-scm-workflows/README.md
+++ b/skills/lakebase-scm-workflows/README.md
@@ -72,6 +72,12 @@ Each operation has a CLI bin AND a matching MCP tool. JS/TS callers can also imp
 **Workflow drift** (`lakebase_workflow_drift` MCP tool, `verifyProject` JS export)
 - Checks that a project's `.githooks/` and `.github/workflows/*.yml` match the templates `lakebase-create-project` would lay down today. Exposed as an MCP tool and via `verifyProject(projectDir)` / `verifyHooks(projectDir)` / `verifyWorkflows(projectDir)` from the package; `lakebase-doctor` rolls this into its overall health check.
 
+**Scaffolded-file drift** (`detectScaffoldedDrift` JS export, `detectCommandDrift` JS export)
+- One umbrella primitive that reports drift across every scaffolded surface that stamps a kit version pin: `.github/workflows/*.yml` (via `detectWorkflowDrift`) and `.claude/commands/*.md` (via `detectCommandDrift`). Each command entry carries the project's pinned version (`Pinned to:`) plus the kit's current version, with the placeholder substitution re-applied so version-pin updates alone never register as drift. Hook files (`<name>.{pre,post}-hook.md`) are excluded from the walk: substrate doesn't own them.
+
+**Slash-command refresh** (`lakebase-update-commands`)
+- Refresh a scaffolded project's `.claude/commands/{design,build}.md` from the kit's current templates. Interactive per-file confirm by default; `--force` skips the prompt for unattended use; `--dry-run` previews without writing; `--json` emits a structured report. Hook files are NEVER touched. Sibling to `updateWorkflows` for the workflow surface; both consume the matching drift detector's vocabulary.
+
 Run any bin with `--help` for the full subcommand + flag reference.
 
 ## Under the covers
@@ -164,6 +170,46 @@ Happens when the post-checkout hook is missing, disabled, or you switched branch
 
 The agent reads the current git branch, calls `lakebase-get-connection --output dsn --write-env` for that branch, and confirms the new `DATABASE_URL`. If you hit this often, ask: "Reinstall the git hooks" – that runs `bash .githooks/install.sh`.
 
+### 5. Catch drifted scaffold files and refresh them safely
+
+The kit's scaffolded surfaces (`.github/workflows/*.yml`, `.claude/commands/{design,build}.md`) stamp a kit version pin at scaffold time. As the kit evolves those project-side files lag. The drift detector surfaces the gap; the refresher closes it without touching project-owned hook files.
+
+> "Are my Lakebase scaffolded files in sync with the current kit?"
+
+The agent runs `detectScaffoldedDrift({ projectDir })` (or `lakebase-update-commands --dry-run` for the command surface specifically) and shows a report grouped by file. For the workflow surface, `updateWorkflows()` fast-forwards; for the command surface, `lakebase-update-commands` defaults to an interactive per-file confirm so a project that customised `/design` deliberately gets to keep its edits.
+
+**End-to-end verification recipe** (use this when validating a substrate change, not just the kit's hermetic BDD):
+
+```bash
+# 1. Scaffold a fresh project (any language).
+lakebase-create-project \
+  --project-name drift-smoke \
+  --parent-dir /tmp \
+  --databricks-host https://your-workspace.cloud.databricks.com \
+  --no-github \
+  --language nodejs
+
+# 2. Baseline: should be all-unchanged.
+lakebase-update-commands --project-dir /tmp/drift-smoke --dry-run
+
+# 3. Introduce drift in design.md (project customization).
+sed -i.bak 's/^# \/design/# \/design (project-customized)/' \
+  /tmp/drift-smoke/.claude/commands/design.md
+
+# 4. Detector should flag design.md as `updated` (in dry-run); build.md `unchanged`.
+lakebase-update-commands --project-dir /tmp/drift-smoke --dry-run
+
+# 5. Refresh; --force skips the per-file confirm.
+lakebase-update-commands --project-dir /tmp/drift-smoke --force
+
+# 6. Add a project-owned hook and confirm the refresher does NOT touch it.
+echo '# project hook' > /tmp/drift-smoke/.claude/commands/design.pre-hook.md
+lakebase-update-commands --project-dir /tmp/drift-smoke --force
+diff <(echo '# project hook') /tmp/drift-smoke/.claude/commands/design.pre-hook.md
+```
+
+The same flow applies to the `--enable-e2e`-scaffolded `playwright.config.ts` + `tests/e2e/smoke.spec.ts`: a future drift on those files will surface here once they're brought under the detector's umbrella. For the `[E2E]`-tag agent contract (which connects an `[E2E]` AC's outcome back to `outcomes.json`), see [`../lakebase-tdd-workflows/`](../lakebase-tdd-workflows/) under "Comparison, promote, synthesize".
+
 ## CLI cheat sheet
 
 | Bin | Purpose |
@@ -180,6 +226,7 @@ The agent reads the current git branch, calls `lakebase-get-connection --output 
 | `lakebase-github-token` | Resolve / diagnose the GitHub token via the same auth chain CI uses. |
 | `lakebase-adopt-tdd` | Drop the `.tdd/` workflow tree into an existing repo. Supports `--update`, `--force`, `--dry-run`. |
 | `lakebase-infra-runner` | Run the `[Infra]`-tag suite (schema-diff + migration status + endpoint readiness) for a branch. Used by scaffolded `test:infra` scripts. |
+| `lakebase-update-commands` | Refresh a scaffolded project's `.claude/commands/{design,build}.md` from the kit's current templates. Interactive per-file confirm by default; `--force` skips prompts, `--dry-run` previews, `--json` emits a structured report. Hook files (`<name>.{pre,post}-hook.md`) are NEVER touched. |
 | `lakebase-feature-status` | One-screen snapshot of a TDD feature's workflow state. Pairs with `lakebase-tdd-workflows`. |
 | `lakebase-mcp-server` | Stdio MCP server exposing the full tool surface (parity with the CLI bins). For Claude Desktop / OpenAI Codex / Cursor-via-MCP / Genie Code consumers. |
 
@@ -216,6 +263,10 @@ Every CLI bin is a thin wrapper around a substrate function published from `@dat
 **Project verification**:
 - `verifyProject`, `verifyHooks`, `verifyWorkflows` (drift checks against the templates `create-project` would lay down today; `lakebase-doctor` consumes these)
 - `runDoctor(args)` (the orchestrator behind `lakebase-doctor`; returns `DoctorReport` with per-check `ok` / `warn` / `fail` / `skip` status)
+
+**Scaffolded-file drift + refresh**:
+- `detectWorkflowDrift`, `detectCommandDrift`, `detectScaffoldedDrift` (per-surface + umbrella drift reports. Command entries carry pinned + current kit version; placeholder substitution is re-applied so version-pin updates do not register as drift. Hook files are excluded from the walk.)
+- `updateWorkflows`, `updateCommands` (in-place refresh primitives. `updateCommands({ force: false })` leaves drifted files alone and reports them as `preserved` so a per-file confirm flow can decide one at a time.)
 
 **GitHub** (from `./github` subpath or root):
 - `resolveGitHubToken`, `diagnoseGitHubAuth`, `tryVsCodeSession`, `tryGhAuthToken`, `GITHUB_SCOPES` (token resolution chain: env → VS Code session → `gh auth token`)

--- a/skills/lakebase-scm-workflows/SKILL.md
+++ b/skills/lakebase-scm-workflows/SKILL.md
@@ -353,6 +353,59 @@ lakebase-doctor --project-dir ~/code/proj-checkout
 
 Also reachable as the `lakebase_doctor` MCP tool. When an agent reports cryptic "auth failed" or ".env not found" symptoms, this is the first thing to run.
 
+### Scaffolded-file drift detection and refresh
+
+Scaffolded projects ship copies of the kit's templates at scaffold time. As the kit evolves, those project-side files lag behind. Two surfaces stamp a kit version pin and are eligible for the drift loop: `.github/workflows/*.yml` (via `{{LAKEBASE_KIT_VERSION}}`) and `.claude/commands/*.md` (via `${KIT_VERSION_AT_SCAFFOLD}`). Both report through one umbrella primitive.
+
+```ts
+import {
+  detectWorkflowDrift,
+  detectCommandDrift,
+  detectScaffoldedDrift,
+  updateWorkflows,
+  updateCommands,
+} from "@databricks-solutions/lakebase-app-dev-kit";
+
+// One verdict across every scaffolded surface.
+const report = detectScaffoldedDrift({ projectDir });
+// report.overall: "ok" | "drift"
+// report.workflows.files[]: WorkflowFileStatus with status drifted/missing/extra/unchanged + unified diff
+// report.commands.files[]: CommandFileEntry with pinned_version, kit_version, diff. Hook files
+//   (<name>.{pre,post}-hook.md) are excluded; substrate does not own them.
+
+// Refresh per surface. updateCommands(force: false) leaves drifted files alone
+// and reports them as "preserved" so a per-file confirm flow can decide one at a time.
+updateWorkflows({ projectDir, dryRun: false });
+updateCommands({ projectDir, dryRun: false, force: true });
+```
+
+```bash
+# Refresh design.md + build.md from the current kit. Interactive per-file
+# confirm by default; --force skips prompts for unattended use; --dry-run
+# prints outcomes without writing.
+lakebase-update-commands                              # human-readable summary
+lakebase-update-commands --dry-run                    # preview without writing
+lakebase-update-commands --force                      # unattended
+lakebase-update-commands --json                       # structured report for CI
+lakebase-update-commands --project-dir ~/code/proj    # explicit target
+```
+
+Hook files (`design.{pre,post}-hook.md`, `build.{pre,post}-hook.md`) are NEVER touched by either the detector or the refresher: substrate doesn't own them.
+
+#### How to verify end-to-end on a real project
+
+Hermetic BDD covers every code path; the end-to-end smoke is what proves the substrate-to-disk loop works against a real scaffolded tree:
+
+1. Scaffold a fresh project: `lakebase-create-project --project-name drift-smoke --parent-dir /tmp --databricks-host https://your-workspace.cloud.databricks.com --no-github --language nodejs`.
+2. Confirm baseline: `lakebase-update-commands --project-dir /tmp/drift-smoke --dry-run`. Expected: every command file reports `unchanged`.
+3. Introduce drift: hand-edit `/tmp/drift-smoke/.claude/commands/design.md` so the first line reads `# /design (project-customized)`.
+4. Detector: `lakebase-update-commands --project-dir /tmp/drift-smoke --dry-run`. Expected: `design.md` reports `updated`; `build.md` reports `unchanged`. No file content changed.
+5. Refresh: `lakebase-update-commands --project-dir /tmp/drift-smoke --force`. Expected: `design.md` reports `updated`; the file body is now byte-identical to `templates/project/common/.claude/commands/design.md` with `${KIT_VERSION_AT_SCAFFOLD}` substituted to the kit's current version.
+6. Add a hook file: `echo '# project hook' > /tmp/drift-smoke/.claude/commands/design.pre-hook.md`.
+7. Re-run `lakebase-update-commands --project-dir /tmp/drift-smoke --force`. Expected: no entry for `design.pre-hook.md`; the file is byte-identical before and after.
+
+For the `[E2E]`-tag testing story that ships alongside scaffolded Playwright projects, the drift loop matters because the same `--enable-e2e`-installed `playwright.config.ts` + smoke fixture could fall behind as the kit evolves; running `lakebase-update-commands --dry-run` in CI catches that surface drifting alongside `/design` and `/build`. See [`../lakebase-tdd-workflows/SKILL.md`](../lakebase-tdd-workflows/SKILL.md) for the runner contract that ties an `[E2E]` AC's outcome back to `outcomes.json`.
+
 ## References
 
 - [`references/get-connection.md`](references/get-connection.md) – Lakebase credential seam (DSN + Pool, OAuth refresh, fallback chain).


### PR DESCRIPTION
Brings the lakebase-scm-workflows README + SKILL.md current with the FEIP-7424 + FEIP-7425 substrate primitives shipped in PR #114. Adds an end-to-end verification recipe so a maintainer can validate the drift loop against a real scaffolded project, not just the kit's hermetic BDD.

- README "Operations": Scaffolded-file drift + Slash-command refresh entries
- README "How to use": new flow 5 with the end-to-end smoke recipe
- README CLI cheat sheet + JS/TS exports: `lakebase-update-commands` + the new detector/refresher primitives
- SKILL "Scaffolded-file drift detection and refresh" section with the verify-on-a-real-project recipe and a cross-link to the [E2E] testing story under `lakebase-tdd-workflows`

No code, no tests. Doc-only.

This pull request and its description were written by Isaac.