### PR TITLE
chore(release): v0.3.0-alpha.37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.36",
+  "version": "0.3.0-alpha.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.36",
+      "version": "0.3.0-alpha.37",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.36",
+  "version": "0.3.0-alpha.37",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": false,


### PR DESCRIPTION
Pulls today's substrate additions into a tagged release so the extension can pin to a tag instead of a SHA.

- FEIP-7211 spike carry-forward
- FEIP-7218 per-experiment cap
- FEIP-7424 command-drift detector
- FEIP-7425 lakebase-update-commands bin
- MarkdownAdapter.pull reader
- adoptLakebaseProject brownfield primitive

This pull request and its description were written by Isaac.