### PR TITLE
chore(release): v0.3.0-alpha.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.37",
+  "version": "0.3.0-alpha.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.37",
+      "version": "0.3.0-alpha.38",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",
@@ -20,7 +20,9 @@
         "tweetsodium": "^0.0.5"
       },
       "bin": {
+        "lakebase-adopt-tdd": "dist/scripts/lakebase/adopt-tdd.cli.js",
         "lakebase-branch": "dist/scripts/lakebase/branch.cli.js",
+        "lakebase-ci-app-endpoint": "dist/scripts/lakebase/ci-app-endpoint.cli.js",
         "lakebase-create-project": "dist/scripts/lakebase/create-project.cli.js",
         "lakebase-cut-backup": "dist/scripts/lakebase/cut-backup.cli.js",
         "lakebase-detect-language": "dist/scripts/lakebase/detect-language.cli.js",
@@ -28,10 +30,12 @@
         "lakebase-feature-status": "dist/scripts/tdd/feature-status.cli.js",
         "lakebase-get-connection": "dist/scripts/lakebase/get-connection.cli.js",
         "lakebase-github-token": "dist/scripts/github/auth.cli.js",
+        "lakebase-infra-runner": "dist/scripts/lakebase/infra-runner.cli.js",
         "lakebase-mcp-server": "dist/apps/mcp-server/index.js",
-        "lakebase-migrate": "dist/scripts/lakebase/migrate.cli.js",
         "lakebase-pr": "dist/scripts/github/pr.cli.js",
-        "lakebase-schema-diff": "dist/scripts/lakebase/schema-diff.cli.js"
+        "lakebase-schema-diff": "dist/scripts/lakebase/schema-diff.cli.js",
+        "lakebase-schema-migrate": "dist/scripts/lakebase/schema-migrate.cli.js",
+        "lakebase-update-commands": "dist/scripts/lakebase/update-commands.cli.js"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.37",
+  "version": "0.3.0-alpha.38",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": false,


### PR DESCRIPTION
Bumps kit to v0.3.0-alpha.38. Picks up:

- **FEIP-7423** (#118): `getCiAppEndpoint` primitive + pr.yml `LAKEBASE_APP_ENDPOINT` export + conditional webServer in the playwright.config.ts template. Closes the gap where FEIP-7094 Phase 2's project-root Playwright step had nothing populating `BASE_URL` from the paired-branch deployment.

## Test plan
- [x] 1082/1082 hermetic vitest tests pass
- [x] typecheck clean
- [x] build emits all bins including `lakebase-ci-app-endpoint`

This pull request and its description were written by Claude.