### PR TITLE
feat(kit): auto-recover from workspace TTL cap + ship templates/ in npm package (FEIP-7436, FEIP-7435 prereq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dist",
     "scripts",
     "skills",
+    "templates",
     "install.sh",
     "README.md",
     "LICENSE.md"

--- a/scripts/lakebase/branch-create.ts
+++ b/scripts/lakebase/branch-create.ts
@@ -20,11 +20,15 @@ import {
   LakebaseBranchInfo,
   LakebaseBranchTtlTooLongError,
   BranchLookupOpts,
+  cacheProjectRetention,
   getBranchByName,
+  getCachedProjectRetention,
   getDefaultBranch,
   isTtlTooLongError,
+  minLakebaseTtl,
   projectPath,
 } from "./branch-utils.js";
+import { getProjectRetentionDuration } from "./lakebase-project.js";
 import { KIT_TIMEOUTS } from "./kit-config.js";
 
 const execFileP = promisify(execFile);
@@ -204,20 +208,7 @@ export async function createBranch(args: CreateBranchArgs): Promise<LakebaseBran
   } else if (args.noExpiry ?? true) {
     specObj.no_expiry = true;
   }
-  const spec = JSON.stringify({ spec: specObj });
-  try {
-    await dbcli(
-      ["postgres", "create-branch", projectPath(args.instance), sanitized, "--json", spec],
-      args.host
-    );
-  } catch (err) {
-    // Detect the workspace-TTL-policy rejection and rewrap with a typed,
-    // actionable message. Other errors bubble through as-is.
-    if (err instanceof LakebaseBranchError && specObj.ttl && isTtlTooLongError(err.message)) {
-      throw new LakebaseBranchTtlTooLongError(specObj.ttl, err.message);
-    }
-    throw err;
-  }
+  await createWithTtlRecovery(args.instance, sanitized, specObj, args.host);
 
   return waitForBranchReady({
     instance: args.instance,
@@ -257,6 +248,87 @@ function leafOf(pathOrName: string | undefined): string | undefined {
   if (!pathOrName) return undefined;
   const segments = pathOrName.split("/");
   return segments[segments.length - 1] || undefined;
+}
+
+/**
+ * Run `databricks postgres create-branch` with workspace-TTL auto-recovery
+ * (FEIP-7436). When the workspace rejects the requested TTL as exceeding
+ * its maximum branch-expiration policy, this helper:
+ *
+ *   1. Probes `databricks postgres get-project` for the project's
+ *      `history_retention_duration` (a conservative upper bound for the
+ *      workspace cap; the API does not directly expose the cap itself).
+ *   2. Retries the create with `min(originalTtl, retentionDuration)`. The
+ *      retention duration is cached per-instance for the rest of the
+ *      session via {@link cacheProjectRetention} so subsequent creates
+ *      against the same project don't re-shell get-project.
+ *   3. If retention duration is missing OR the retry STILL hits the cap,
+ *      throws {@link LakebaseBranchTtlTooLongError} with both attempted
+ *      TTLs surfaced in the message.
+ *
+ * No extra API calls on the happy path: the get-project probe only fires
+ * after a TTL rejection. Non-TTL errors bubble through the first attempt
+ * untouched.
+ */
+async function createWithTtlRecovery(
+  instance: string,
+  sanitized: string,
+  specObj: { source_branch: string; no_expiry?: boolean; ttl?: string },
+  host: string | undefined,
+): Promise<void> {
+  const originalTtl = specObj.ttl;
+  try {
+    await dbcli(
+      ["postgres", "create-branch", projectPath(instance), sanitized, "--json", JSON.stringify({ spec: specObj })],
+      host,
+    );
+    return;
+  } catch (err) {
+    // Only attempt recovery when this looks like the workspace-TTL-cap
+    // rejection AND we actually had a TTL set (no_expiry: true requests
+    // never hit this code path).
+    if (!(err instanceof LakebaseBranchError) || !originalTtl || !isTtlTooLongError(err.message)) {
+      throw err;
+    }
+    // Resolve retention duration: prefer per-session cache, then probe.
+    let retention = getCachedProjectRetention(instance);
+    if (retention === undefined) {
+      retention = await getProjectRetentionDuration({ projectId: instance, host });
+      // Cache even an undefined probe result so we don't re-shell for it
+      // every time. callers can clear via clearRetentionCache() in tests.
+      cacheProjectRetention(instance, retention);
+    }
+    if (!retention) {
+      // No cap to clamp against. Surface the original error with the
+      // typed wrapper so callers can route on instanceof.
+      throw new LakebaseBranchTtlTooLongError(originalTtl, err.message);
+    }
+    const clamped = minLakebaseTtl(originalTtl, retention) ?? retention;
+    if (clamped === originalTtl) {
+      // Retention is >= originalTtl; clamping won't help. Original cap
+      // applies; rethrow typed.
+      throw new LakebaseBranchTtlTooLongError(originalTtl, err.message);
+    }
+    process.stderr.write(
+      `[lakebase-branch-create] workspace TTL cap rejected '${originalTtl}' for ` +
+        `project '${instance}'; retrying with retention-clamped '${clamped}'.\n`,
+    );
+    const retrySpec = { ...specObj, ttl: clamped };
+    try {
+      await dbcli(
+        ["postgres", "create-branch", projectPath(instance), sanitized, "--json", JSON.stringify({ spec: retrySpec })],
+        host,
+      );
+    } catch (retryErr) {
+      if (retryErr instanceof LakebaseBranchError && isTtlTooLongError(retryErr.message)) {
+        throw new LakebaseBranchTtlTooLongError(
+          clamped,
+          `Workspace rejected retention-clamped TTL '${clamped}' (original '${originalTtl}'): ${retryErr.message}`,
+        );
+      }
+      throw retryErr;
+    }
+  }
 }
 
 async function dbcli(args: string[], host?: string): Promise<string> {

--- a/scripts/lakebase/branch-utils.ts
+++ b/scripts/lakebase/branch-utils.ts
@@ -61,6 +61,56 @@ export function isTtlTooLongError(stderr: string): boolean {
   return /expiration time exceeds the maximum expiration time/i.test(stderr);
 }
 
+/**
+ * Parse a Lakebase-format TTL string ("<seconds>s") to integer seconds.
+ * Returns undefined for malformed input. Pure; used in TTL-clamp math.
+ */
+export function parseLakebaseTtl(ttl: string | undefined): number | undefined {
+  if (!ttl) return undefined;
+  const m = ttl.trim().match(/^(\d+)s?$/);
+  if (!m) return undefined;
+  const n = Number.parseInt(m[1], 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
+ * Return the smaller of two Lakebase-format TTL strings (min by seconds).
+ * Returns the parseable one when only one parses; undefined when neither
+ * does. Used to clamp a requested TTL against the workspace cap.
+ */
+export function minLakebaseTtl(
+  a: string | undefined,
+  b: string | undefined,
+): string | undefined {
+  const sa = parseLakebaseTtl(a);
+  const sb = parseLakebaseTtl(b);
+  if (sa === undefined && sb === undefined) return undefined;
+  if (sa === undefined) return `${sb}s`;
+  if (sb === undefined) return `${sa}s`;
+  return `${Math.min(sa, sb)}s`;
+}
+
+// Per-instance cache of the project's `history_retention_duration`.
+// Populated lazily by `createBranch` on the first TTL-too-long retry
+// path; subsequent branch creates against the same instance reuse the
+// cached value rather than re-shelling get-project. Cleared via
+// {@link clearRetentionCache} (kept for tests; production agents never
+// need to invalidate this cache because the project's retention policy
+// is stable for the duration of any agent's lifetime).
+const RETENTION_CACHE = new Map<string, string | undefined>();
+
+export function getCachedProjectRetention(instance: string): string | undefined {
+  return RETENTION_CACHE.get(instance);
+}
+
+export function cacheProjectRetention(instance: string, ttl: string | undefined): void {
+  RETENTION_CACHE.set(instance, ttl);
+}
+
+export function clearRetentionCache(): void {
+  RETENTION_CACHE.clear();
+}
+
 export interface LakebaseBranchInfo {
   /**
    * Lakebase-side opaque uid, e.g. `br-broad-sky-d2k5gewt`. Returned by

--- a/scripts/lakebase/lakebase-project.ts
+++ b/scripts/lakebase/lakebase-project.ts
@@ -173,6 +173,63 @@ export async function getProjectInfo(args: LakebaseProjectArgs): Promise<Lakebas
   };
 }
 
+/**
+ * Pure helper: extract the protobuf-Duration `history_retention_duration`
+ * from a parsed `databricks postgres get-project -o json` payload.
+ * Returns the duration as a Lakebase-format TTL string ("<seconds>s") or
+ * undefined when the field is absent / unparseable.
+ *
+ * The Lakebase API does not directly expose the workspace's maximum
+ * branch-expiration policy, but the project's `history_retention_duration`
+ * is a conservative upper bound for branch TTLs: a branch cannot retain
+ * history longer than the project does. {@link createBranch} uses this to
+ * recover from `LakebaseBranchTtlTooLongError` by retrying with a clamped
+ * TTL.
+ */
+export function findHistoryRetentionDuration(parsed: Record<string, unknown>): string | undefined {
+  // Two-shape tolerance: protobuf-style snake_case AND lower-camelCase,
+  // matching the API's actual-vs-documented JSON encoding drift.
+  const raw =
+    (parsed.history_retention_duration as string | undefined) ??
+    (parsed.historyRetentionDuration as string | undefined);
+  if (!raw || typeof raw !== "string") return undefined;
+  // Tolerate "604800s", "604800", "Ns" – normalise to "<seconds>s".
+  const m = raw.trim().match(/^(\d+)s?$/);
+  if (!m) return undefined;
+  const seconds = Number.parseInt(m[1], 10);
+  if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
+  return `${seconds}s`;
+}
+
+/**
+ * Query a Lakebase project's `history_retention_duration` and return it
+ * as a Lakebase-format TTL string ("<seconds>s"). Returns undefined when
+ * the project does not exist, the CLI fails, or the field is absent.
+ *
+ * The kit caches the result per-instance for the rest of the session via
+ * the branch-utils retention cache (see {@link cacheProjectRetention}) so
+ * repeated branch creates against the same instance pay the get-project
+ * cost at most once.
+ */
+export async function getProjectRetentionDuration(
+  args: LakebaseProjectArgs,
+): Promise<string | undefined> {
+  const name = args.projectId.startsWith("projects/") ? args.projectId : `projects/${args.projectId}`;
+  let raw: string;
+  try {
+    raw = await dbcli(["postgres", "get-project", name, "-o", "json"], args.host);
+  } catch {
+    return undefined;
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+  return findHistoryRetentionDuration(parsed);
+}
+
 async function dbcli(args: string[], host?: string): Promise<string> {
   const trimmedHost = host?.replace(/\/+$/, "");
   const env = trimmedHost ? { ...process.env, DATABRICKS_HOST: trimmedHost } : process.env;

--- a/tests/bdd/branch-create-ttl-recovery.test.ts
+++ b/tests/bdd/branch-create-ttl-recovery.test.ts
@@ -1,0 +1,356 @@
+// FEIP-7436: TTL auto-recovery for createBranch. Workspaces cap branch
+// expiration policy below the kit's 30-day default; the kit now catches
+// the cap rejection, probes the project's history_retention_duration,
+// and retries with a clamped TTL.
+//
+// This test covers:
+//   1. Pure parse/min helpers (parseLakebaseTtl, minLakebaseTtl,
+//      findHistoryRetentionDuration) - fully hermetic, no mocks.
+//   2. createBranch retry contract end-to-end via mocks:
+//      - first create-branch call rejects with the workspace-cap pattern
+//      - get-project probe returns a retention duration
+//      - retry create-branch with min(originalTtl, retention) succeeds
+//      - per-instance retention cache means subsequent creates skip the probe
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  parseLakebaseTtl,
+  minLakebaseTtl,
+  clearRetentionCache,
+  getCachedProjectRetention,
+  LakebaseBranchTtlTooLongError,
+  type LakebaseBranchInfo,
+} from "../../scripts/lakebase/branch-utils.js";
+import { findHistoryRetentionDuration } from "../../scripts/lakebase/lakebase-project.js";
+
+describe("parseLakebaseTtl (FEIP-7436)", () => {
+  it("parses '<seconds>s' to integer seconds", () => {
+    expect(parseLakebaseTtl("604800s")).toBe(604800);
+    expect(parseLakebaseTtl("2592000s")).toBe(2592000);
+  });
+
+  it("tolerates bare integer (no trailing s)", () => {
+    expect(parseLakebaseTtl("3600")).toBe(3600);
+  });
+
+  it("returns undefined for malformed input", () => {
+    expect(parseLakebaseTtl("")).toBeUndefined();
+    expect(parseLakebaseTtl(undefined)).toBeUndefined();
+    expect(parseLakebaseTtl("7d")).toBeUndefined();
+    expect(parseLakebaseTtl("abc")).toBeUndefined();
+    expect(parseLakebaseTtl("0s")).toBeUndefined();
+    expect(parseLakebaseTtl("-100s")).toBeUndefined();
+  });
+});
+
+describe("minLakebaseTtl (FEIP-7436)", () => {
+  it("returns the smaller of two parseable TTLs", () => {
+    expect(minLakebaseTtl("2592000s", "604800s")).toBe("604800s");
+    expect(minLakebaseTtl("604800s", "2592000s")).toBe("604800s");
+  });
+
+  it("returns the parseable one when the other is malformed", () => {
+    expect(minLakebaseTtl("604800s", "garbage")).toBe("604800s");
+    expect(minLakebaseTtl(undefined, "604800s")).toBe("604800s");
+  });
+
+  it("returns undefined when neither parses", () => {
+    expect(minLakebaseTtl(undefined, undefined)).toBeUndefined();
+    expect(minLakebaseTtl("nope", "")).toBeUndefined();
+  });
+});
+
+describe("findHistoryRetentionDuration (FEIP-7436)", () => {
+  it("reads protobuf-style snake_case history_retention_duration", () => {
+    expect(findHistoryRetentionDuration({ history_retention_duration: "604800s" })).toBe(
+      "604800s",
+    );
+  });
+
+  it("reads lower-camelCase historyRetentionDuration", () => {
+    expect(findHistoryRetentionDuration({ historyRetentionDuration: "1209600s" })).toBe(
+      "1209600s",
+    );
+  });
+
+  it("tolerates bare-integer encoding from the API", () => {
+    expect(findHistoryRetentionDuration({ history_retention_duration: "604800" })).toBe(
+      "604800s",
+    );
+  });
+
+  it("returns undefined when the field is missing or unparseable", () => {
+    expect(findHistoryRetentionDuration({})).toBeUndefined();
+    expect(findHistoryRetentionDuration({ history_retention_duration: "" })).toBeUndefined();
+    expect(findHistoryRetentionDuration({ history_retention_duration: "7d" })).toBeUndefined();
+    expect(
+      findHistoryRetentionDuration({ history_retention_duration: 12345 as unknown as string }),
+    ).toBeUndefined();
+  });
+});
+
+// ─── end-to-end retry contract ───────────────────────────────────
+
+const mockGetBranchByName = vi.fn();
+const mockGetDefaultBranch = vi.fn();
+const mockGetProjectRetentionDuration = vi.fn();
+const mockExecFile = vi.fn();
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  );
+  return {
+    ...actual,
+    execFile: (...args: unknown[]) => mockExecFile(...args),
+  };
+});
+
+vi.mock("../../scripts/lakebase/branch-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../../scripts/lakebase/branch-utils.js")>(
+    "../../scripts/lakebase/branch-utils.js",
+  );
+  return {
+    ...actual,
+    getBranchByName: (...args: unknown[]) => mockGetBranchByName(...args),
+    getDefaultBranch: (...args: unknown[]) => mockGetDefaultBranch(...args),
+    projectPath: () => "projects/test-project",
+  };
+});
+
+vi.mock("../../scripts/lakebase/lakebase-project.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../scripts/lakebase/lakebase-project.js")
+  >("../../scripts/lakebase/lakebase-project.js");
+  return {
+    ...actual,
+    getProjectRetentionDuration: (...args: unknown[]) =>
+      mockGetProjectRetentionDuration(...args),
+  };
+});
+
+const { createBranch } = await import("../../scripts/lakebase/branch-create.js");
+
+function fakeBranch(leaf: string, sourceLeaf: string | undefined): LakebaseBranchInfo {
+  return {
+    name: `projects/test-project/branches/${leaf}`,
+    nameLeaf: leaf as LakebaseBranchInfo["nameLeaf"],
+    uid: `br-${leaf}` as LakebaseBranchInfo["uid"],
+    state: "READY",
+    isDefault: false,
+    sourceBranchName: sourceLeaf
+      ? `projects/test-project/branches/${sourceLeaf}`
+      : undefined,
+  } as LakebaseBranchInfo;
+}
+
+/**
+ * Build a fake execFile shape compatible with util.promisify(execFile).
+ *
+ * Node attaches a custom promisify resolver to the real `execFile` that
+ * makes `await promisify(execFile)(...)` resolve to `{ stdout, stderr }`.
+ * When we `vi.mock("node:child_process")` and swap in our own function,
+ * that custom symbol is lost; promisify falls back to the default
+ * `cb(err, value)` wrap that resolves to the second positional arg. So
+ * we feed it the object directly via `cb(null, { stdout, stderr })`.
+ */
+function execFileCallbackShape(
+  result: { stdout?: string; stderr?: string; error?: Error & { stderr?: string } },
+) {
+  return (...args: unknown[]) => {
+    const cb = args[args.length - 1] as (
+      err: (Error & { stderr?: string }) | null,
+      value?: { stdout: string; stderr: string },
+    ) => void;
+    if (result.error) {
+      cb(result.error);
+    } else {
+      cb(null, { stdout: result.stdout ?? "", stderr: result.stderr ?? "" });
+    }
+  };
+}
+
+let stderrChunks: string[] = [];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let stderrSpy: any;
+
+beforeEach(() => {
+  mockGetBranchByName.mockReset();
+  mockGetDefaultBranch.mockReset();
+  mockGetProjectRetentionDuration.mockReset();
+  mockExecFile.mockReset();
+  clearRetentionCache();
+  stderrChunks = [];
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderrChunks.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+});
+
+describe("createBranch – TTL auto-recovery (FEIP-7436)", () => {
+  it("retries with a retention-clamped TTL when workspace rejects the original", async () => {
+    // Parent lookup: 'staging' exists. Target lookup: returns undefined
+    // on the idempotency check (pre-create), then a READY branch on the
+    // wait-for-ready poll (post-create). State tracked via the execFile
+    // call counter: target lookups before any successful create-branch
+    // return undefined; after, return the READY branch.
+    let targetCreated = false;
+    mockGetBranchByName.mockImplementation((branchName: string) => {
+      if (branchName === "staging") return Promise.resolve(fakeBranch("staging", "production"));
+      if (branchName === "feature-x") {
+        return Promise.resolve(targetCreated ? fakeBranch("feature-x", "staging") : undefined);
+      }
+      return Promise.resolve(undefined);
+    });
+    mockGetProjectRetentionDuration.mockResolvedValue("604800s");
+
+    // First create-branch call: rejects with the workspace-cap error.
+    // Second create-branch call (the retry with clamped TTL): succeeds.
+    const capError = Object.assign(new Error("Command failed"), {
+      stderr:
+        "Error: expiration time exceeds the maximum expiration time [TraceId: abc]",
+    });
+    mockExecFile
+      .mockImplementationOnce(execFileCallbackShape({ error: capError }))
+      .mockImplementationOnce((...args: unknown[]) => {
+        targetCreated = true;
+        const cb = args[args.length - 1] as (
+          err: Error | null,
+          value?: { stdout: string; stderr: string },
+        ) => void;
+        cb(null, { stdout: '{"name":"projects/test-project/branches/feature-x"}', stderr: "" });
+      });
+
+    const result = await createBranch({
+      instance: "test-project",
+      branch: "feature-x",
+      parentBranch: "staging",
+      ttl: "2592000s", // 30d, will be clamped to 604800s (7d)
+    });
+
+    // Two create-branch attempts; second one used the clamped TTL.
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+    const secondCallArgs = mockExecFile.mock.calls[1][1] as string[];
+    const specIdx = secondCallArgs.indexOf("--json");
+    expect(specIdx).toBeGreaterThan(-1);
+    const retrySpec = JSON.parse(secondCallArgs[specIdx + 1]) as { spec: { ttl?: string } };
+    expect(retrySpec.spec.ttl).toBe("604800s");
+
+    // Stderr documents the recovery to the user.
+    expect(stderrChunks.join("")).toMatch(
+      /workspace TTL cap rejected '2592000s'.*retrying with retention-clamped '604800s'/,
+    );
+
+    // The retry succeeded; result is the wait-for-ready output.
+    expect(result.nameLeaf).toBe("feature-x");
+    // Retention is cached for the rest of the session.
+    expect(getCachedProjectRetention("test-project")).toBe("604800s");
+  });
+
+  it("throws LakebaseBranchTtlTooLongError when get-project returns no retention duration", async () => {
+    mockGetBranchByName.mockImplementation((branchName: string) => {
+      if (branchName === "staging") return Promise.resolve(fakeBranch("staging", "production"));
+      return Promise.resolve(undefined);
+    });
+    mockGetProjectRetentionDuration.mockResolvedValue(undefined);
+
+    const capError = Object.assign(new Error("Command failed"), {
+      stderr: "Error: expiration time exceeds the maximum expiration time",
+    });
+    mockExecFile.mockImplementationOnce(execFileCallbackShape({ error: capError }));
+
+    await expect(
+      createBranch({
+        instance: "test-project",
+        branch: "feature-x",
+        parentBranch: "staging",
+        ttl: "2592000s",
+      }),
+    ).rejects.toThrow(LakebaseBranchTtlTooLongError);
+
+    // Only one create-branch attempt was made (no retry without a cap to clamp against).
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not probe get-project when no TTL was set (noExpiry path)", async () => {
+    mockGetBranchByName.mockImplementation((branchName: string) => {
+      if (branchName === "staging") return Promise.resolve(fakeBranch("staging", "production"));
+      if (branchName === "tier-x") return Promise.resolve(fakeBranch("tier-x", "staging"));
+      return Promise.resolve(undefined);
+    });
+    mockExecFile.mockImplementationOnce(
+      execFileCallbackShape({ stdout: '{"name":"projects/test-project/branches/tier-x"}' }),
+    );
+
+    await createBranch({
+      instance: "test-project",
+      branch: "tier-x",
+      parentBranch: "staging",
+      // No ttl, no noExpiry override → default no_expiry: true path.
+    });
+
+    expect(mockGetProjectRetentionDuration).not.toHaveBeenCalled();
+  });
+
+  it("reuses cached retention duration across creates against the same instance", async () => {
+    const created = { "feature-a": false, "feature-b": false };
+    mockGetBranchByName.mockImplementation((branchName: string) => {
+      if (branchName === "staging") return Promise.resolve(fakeBranch("staging", "production"));
+      if (branchName === "feature-a") {
+        return Promise.resolve(created["feature-a"] ? fakeBranch("feature-a", "staging") : undefined);
+      }
+      if (branchName === "feature-b") {
+        return Promise.resolve(created["feature-b"] ? fakeBranch("feature-b", "staging") : undefined);
+      }
+      return Promise.resolve(undefined);
+    });
+    mockGetProjectRetentionDuration.mockResolvedValue("604800s");
+
+    const capError = Object.assign(new Error("Command failed"), {
+      stderr: "Error: expiration time exceeds the maximum expiration time",
+    });
+
+    const successOf = (branch: keyof typeof created) =>
+      (...args: unknown[]) => {
+        created[branch] = true;
+        const cb = args[args.length - 1] as (
+          err: Error | null,
+          value?: { stdout: string; stderr: string },
+        ) => void;
+        cb(null, {
+          stdout: `{"name":"projects/test-project/branches/${branch}"}`,
+          stderr: "",
+        });
+      };
+
+    // First create: hits cap, probes get-project, caches retention, retries.
+    mockExecFile
+      .mockImplementationOnce(execFileCallbackShape({ error: capError }))
+      .mockImplementationOnce(successOf("feature-a"));
+    await createBranch({
+      instance: "test-project",
+      branch: "feature-a",
+      parentBranch: "staging",
+      ttl: "2592000s",
+    });
+
+    // Second create against the same instance: hits cap, should reuse the
+    // cached retention (NOT call get-project again), and retry once.
+    mockExecFile
+      .mockImplementationOnce(execFileCallbackShape({ error: capError }))
+      .mockImplementationOnce(successOf("feature-b"));
+    await createBranch({
+      instance: "test-project",
+      branch: "feature-b",
+      parentBranch: "staging",
+      ttl: "2592000s",
+    });
+
+    // get-project was called exactly ONCE across both creates.
+    expect(mockGetProjectRetentionDuration).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Two changes, both required to unblock the partner-asset-tracker workflow that surfaced them 2026-06-02:

## FEIP-7436: workspace TTL auto-recovery

Workspaces enforce a max branch-expiration policy that the Lakebase API does not directly expose. The kit's `createFeatureBranch` defaults to a 30-day TTL; partner-asset-tracker's workspace caps below this and rejects with `expiration time exceeds the maximum expiration time`. Previously the user had to set `LAKEBASE_KIT_FEATURE_BRANCH_TTL_MS` manually and restart their editor.

`createBranch` now self-heals: on a TTL-too-long rejection it probes `databricks postgres get-project` for `history_retention_duration` (a conservative upper bound for the cap) and retries with `min(originalTtl, retention)`. Retention is cached per-instance for the rest of the session so repeated creates against the same project pay the get-project cost at most once. Happy-path branches (TTL within cap, or `noExpiry: true`) incur zero extra API calls.

New helpers:
- `parseLakebaseTtl` / `minLakebaseTtl` in branch-utils (TTL math)
- `findHistoryRetentionDuration` in lakebase-project (JSON parse)
- `cacheProjectRetention` / `getCachedProjectRetention` / `clearRetentionCache` (per-instance memo)

14 new hermetic BDD tests cover the parse helpers, the min-clamp math, the retry contract (cap -> probe -> clamp -> retry succeeds), the no-retention bail-out (typed throw), the noExpiry no-probe path, and the cache-reuse contract across creates.

## FEIP-7435 prerequisite: ship templates in the npm package

The kit's `templates/project/` tree was excluded from the published `files` array; npm installs of the kit landed without templates and consumers fell back to passing `templatesDir` explicitly (the duplication FEIP-7435 is eliminating). Adding `templates` to `files` so `findTemplatesDir` resolves correctly from `node_modules/` and the extension can drop its own copy without breaking the runtime path.

## Test plan
- [x] 1096/1096 hermetic vitest tests pass
- [x] typecheck clean
- [ ] Future: extension PR (FEIP-7435) bumps the kit pin to alpha.39, deletes its templates/project/, drops templatesDir override; expects unchanged runtime behavior

This pull request and its description were written by Claude.