### PR TITLE
chore(release): v0.3.0-alpha.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.38",
+  "version": "0.3.0-alpha.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks-solutions/lakebase-app-dev-kit",
-      "version": "0.3.0-alpha.38",
+      "version": "0.3.0-alpha.39",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@databricks/appkit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks-solutions/lakebase-app-dev-kit",
-  "version": "0.3.0-alpha.38",
+  "version": "0.3.0-alpha.39",
   "description": "Lakebase-backed application development kit – shared scripts, agent skills (SCM today, TDD next), MCP server, and OpenAI Foundry tool spec. Consumed by lakebase-scm-extension and coding agents (Claude Code, Claude Desktop, OpenAI Codex, Cursor, Databricks Genie Code).",
   "type": "module",
   "private": false,


### PR DESCRIPTION
Picks up:
- **FEIP-7436** (#120): `createBranch` auto-recovers from workspace TTL caps via `history_retention_duration` probe + clamped retry. Self-heals the partner-asset-tracker workflow that was failing every `git checkout -b feature/x`.
- **FEIP-7435 prereq** (#120): `templates/` now ships in the npm package; unblocks the extension's templates/ duplication cleanup.

## Test plan
- [x] 1096/1096 hermetic vitest tests pass
- [x] typecheck clean

This pull request and its description were written by Claude.