### PR TITLE
fix(kit): TTL recovery falls back to 7d when history_retention_duration is undiscoverable

### DIFF
--- a/scripts/lakebase/branch-create.ts
+++ b/scripts/lakebase/branch-create.ts
@@ -295,15 +295,18 @@ async function createWithTtlRecovery(
     if (retention === undefined) {
       retention = await getProjectRetentionDuration({ projectId: instance, host });
       // Cache even an undefined probe result so we don't re-shell for it
-      // every time. callers can clear via clearRetentionCache() in tests.
+      // every time. Callers can clear via clearRetentionCache() in tests.
       cacheProjectRetention(instance, retention);
     }
-    if (!retention) {
-      // No cap to clamp against. Surface the original error with the
-      // typed wrapper so callers can route on instanceof.
-      throw new LakebaseBranchTtlTooLongError(originalTtl, err.message);
-    }
-    const clamped = minLakebaseTtl(originalTtl, retention) ?? retention;
+    // No retention discoverable (project metadata didn't expose it,
+    // get-project failed, or the field was absent). Fall back to a
+    // hardcoded 7-day TTL: it fits inside almost every workspace
+    // policy and is the value the typed error message itself recommends.
+    // If the workspace caps below 7 days too, the retry will fail and
+    // we'll surface the typed error so the user can manually override.
+    const FALLBACK_TTL = "604800s";
+    const effectiveRetention = retention ?? FALLBACK_TTL;
+    const clamped = minLakebaseTtl(originalTtl, effectiveRetention) ?? effectiveRetention;
     if (clamped === originalTtl) {
       // Retention is >= originalTtl; clamping won't help. Original cap
       // applies; rethrow typed.
@@ -311,7 +314,8 @@ async function createWithTtlRecovery(
     }
     process.stderr.write(
       `[lakebase-branch-create] workspace TTL cap rejected '${originalTtl}' for ` +
-        `project '${instance}'; retrying with retention-clamped '${clamped}'.\n`,
+        `project '${instance}'; retrying with ` +
+        (retention ? `retention-clamped '${clamped}'.\n` : `hardcoded fallback '${clamped}' (history_retention_duration not discoverable).\n`),
     );
     const retrySpec = { ...specObj, ttl: clamped };
     try {

--- a/tests/bdd/branch-create-ttl-recovery.test.ts
+++ b/tests/bdd/branch-create-ttl-recovery.test.ts
@@ -251,7 +251,61 @@ describe("createBranch – TTL auto-recovery (FEIP-7436)", () => {
     expect(getCachedProjectRetention("test-project")).toBe("604800s");
   });
 
-  it("throws LakebaseBranchTtlTooLongError when get-project returns no retention duration", async () => {
+  it("retries with hardcoded 7d fallback when get-project returns no retention duration", async () => {
+    // Previously this threw without retrying. Now: when retention is
+    // undiscoverable, fall back to 604800s (the value the typed error
+    // message recommends) so creates against workspaces with restrictive
+    // caps + bare project metadata still succeed.
+    let targetCreated = false;
+    mockGetBranchByName.mockImplementation((branchName: string) => {
+      if (branchName === "staging") return Promise.resolve(fakeBranch("staging", "production"));
+      if (branchName === "feature-x") {
+        return Promise.resolve(targetCreated ? fakeBranch("feature-x", "staging") : undefined);
+      }
+      return Promise.resolve(undefined);
+    });
+    mockGetProjectRetentionDuration.mockResolvedValue(undefined);
+
+    const capError = Object.assign(new Error("Command failed"), {
+      stderr: "Error: expiration time exceeds the maximum expiration time",
+    });
+    mockExecFile
+      .mockImplementationOnce(execFileCallbackShape({ error: capError }))
+      .mockImplementationOnce((...args: unknown[]) => {
+        targetCreated = true;
+        const cb = args[args.length - 1] as (
+          err: Error | null,
+          value?: { stdout: string; stderr: string },
+        ) => void;
+        cb(null, {
+          stdout: '{"name":"projects/test-project/branches/feature-x"}',
+          stderr: "",
+        });
+      });
+
+    const result = await createBranch({
+      instance: "test-project",
+      branch: "feature-x",
+      parentBranch: "staging",
+      ttl: "2592000s",
+    });
+
+    // Retry happened with the hardcoded 604800s fallback.
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+    const secondCallArgs = mockExecFile.mock.calls[1][1] as string[];
+    const specIdx = secondCallArgs.indexOf("--json");
+    const retrySpec = JSON.parse(secondCallArgs[specIdx + 1]) as { spec: { ttl?: string } };
+    expect(retrySpec.spec.ttl).toBe("604800s");
+
+    // Stderr documents that we used the hardcoded fallback (not retention).
+    expect(stderrChunks.join("")).toMatch(
+      /workspace TTL cap rejected '2592000s'.*hardcoded fallback '604800s'.*history_retention_duration not discoverable/,
+    );
+
+    expect(result.nameLeaf).toBe("feature-x");
+  });
+
+  it("throws LakebaseBranchTtlTooLongError when the fallback retry also hits the cap", async () => {
     mockGetBranchByName.mockImplementation((branchName: string) => {
       if (branchName === "staging") return Promise.resolve(fakeBranch("staging", "production"));
       return Promise.resolve(undefined);
@@ -261,7 +315,10 @@ describe("createBranch – TTL auto-recovery (FEIP-7436)", () => {
     const capError = Object.assign(new Error("Command failed"), {
       stderr: "Error: expiration time exceeds the maximum expiration time",
     });
-    mockExecFile.mockImplementationOnce(execFileCallbackShape({ error: capError }));
+    // Both create attempts fail with the cap (workspace caps below 7d).
+    mockExecFile
+      .mockImplementationOnce(execFileCallbackShape({ error: capError }))
+      .mockImplementationOnce(execFileCallbackShape({ error: capError }));
 
     await expect(
       createBranch({
@@ -272,8 +329,8 @@ describe("createBranch – TTL auto-recovery (FEIP-7436)", () => {
       }),
     ).rejects.toThrow(LakebaseBranchTtlTooLongError);
 
-    // Only one create-branch attempt was made (no retry without a cap to clamp against).
-    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    // Both the original and fallback attempts ran.
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
   });
 
   it("does not probe get-project when no TTL was set (noExpiry path)", async () => {


### PR DESCRIPTION
Follow-up to FEIP-7436. The initial recovery bailed (typed throw) when the get-project probe returned undefined, defeating the auto-recovery for projects whose payload doesn't expose history_retention_duration. Observed on partner-asset-tracker 2026-06-02.

Now: undiscoverable retention -> hardcoded 7d fallback (the value the typed error message itself recommends). Worst case (fallback also caps): typed throw, user can manually override.

1097/1097 hermetic tests pass.

This pull request and its description were written by Claude.