### PR TITLE
feat(kit): --tiers flag + default design.pre-hook.md + orchestrator delegates branch creation to substrate

### DIFF
--- a/examples/feip-7422-smoke/orchestrator/run-smoke.sh
+++ b/examples/feip-7422-smoke/orchestrator/run-smoke.sh
@@ -55,6 +55,7 @@ PROJECT_NAME="bug-tracker"
 PROJECT_DIR=""
 SKIP_SCAFFOLD=0
 KEEP_ON_FAILURE=1
+TIERS=""                      # 2 or 3; required architectural choice, no default
 ITERATIONS=(v1-initial-domain v2-add-owners v3-status-table v4-split-bug-entity v5-list-view)
 
 ORCHESTRATOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -74,6 +75,7 @@ while [[ $# -gt 0 ]]; do
     --resume)            RESUME_AT="$2"; shift 2 ;;
     --project-name)      PROJECT_NAME="$2"; shift 2 ;;
     --project-dir)       PROJECT_DIR="$2"; shift 2 ;;
+    --tiers)             TIERS="$2"; shift 2 ;;
     --skip-scaffold)     SKIP_SCAFFOLD=1; shift ;;
     --keep-on-failure)   KEEP_ON_FAILURE=1; shift ;;
     --no-keep-on-failure) KEEP_ON_FAILURE=0; shift ;;
@@ -83,6 +85,18 @@ while [[ $# -gt 0 ]]; do
 done
 
 PROJECT_DIR="${PROJECT_DIR:-${SMOKE_ROOT_DEFAULT}/${PROJECT_NAME}}"
+
+# --tiers is required when scaffolding (architectural choice; iteration
+# specs assume 3-tier with `staging` as parent). When --skip-scaffold is
+# set the project's tier topology is already on disk, no opt-in needed.
+if [[ "$SKIP_SCAFFOLD" -eq 0 ]]; then
+  if [[ "$TIERS" != "2" && "$TIERS" != "3" ]]; then
+    echo "smoke: --tiers <2|3> is required. Pick 3 for the standard smoke" >&2
+    echo "       (iteration specs assume a 'staging' parent); 2 for a flat" >&2
+    echo "       production-only flow (iteration specs will need adjustment)." >&2
+    exit 10
+  fi
+fi
 
 # ─── prereqs ──────────────────────────────────────────────────
 
@@ -187,6 +201,7 @@ scaffold_project() {
       --github-owner "$GITHUB_OWNER" \
       --language python \
       --runner github-hosted \
+      --tiers "$TIERS" \
       --enable-e2e
   ) || { err "scaffold failed"; exit 1; }
 
@@ -216,15 +231,21 @@ run_iteration() {
   local feature_id
   feature_id="$(iteration_feature_id "$iter")"
 
-  # 1. branch (kit's post-checkout hook creates the paired Lakebase branch)
-  log "  step 1: checkout -b $branch (post-checkout hook will pair Lakebase)"
+  # 1. Return to trunk before staging the feature spec. The orchestrator
+  # does NOT `git checkout -b` here: branch creation is the substrate's
+  # responsibility, invoked from /design's pre-hook
+  # (templates/project/common/.claude/commands/design.pre-hook.md ships
+  # with the kit). The pre-hook calls `lakebase-branch create-paired`
+  # which atomically creates the Lakebase branch + git branch, so the
+  # invariant "every git branch gets a Lakebase branch" can't be broken
+  # by a partial failure here.
+  log "  step 1: return to trunk; /design's pre-hook will claim the paired branch"
   git checkout main >/dev/null 2>&1 || git checkout master >/dev/null 2>&1
   git pull --ff-only origin "$(git branch --show-current)" || true
-  git checkout -b "$branch"
 
   # 2. Stage the .tdd/features/<feature-id>/feature.md from the iteration
-  # spec. /design + /build read this directory; the kit's TDD workflow
-  # contract is .tdd/features/<id>/{feature.md,feature.json}+ subtree.
+  # spec. /design reads this; the kit's TDD workflow contract is
+  # .tdd/features/<id>/{feature.md,feature.json,...}.
   log "  step 2: stage .tdd/features/${feature_id}/feature.md"
   local feature_dir=".tdd/features/${feature_id}"
   mkdir -p "$feature_dir"
@@ -232,13 +253,13 @@ run_iteration() {
     cp "$spec" "$feature_dir/feature.md"
   fi
 
-  # 3. /design <feature-id>: the skill expects a positional feature id,
-  # NOT the spec text. It reads $feature_dir/feature.md from disk.
-  log "  step 3: claude -p '/design ${feature_id}'"
+  # 3. /design <feature-id>: the kit-shipped pre-hook claims the paired
+  # feature branch via the substrate BEFORE phase 1 runs. The
+  # orchestrator never touches `git checkout -b`.
+  log "  step 3: claude -p '/design ${feature_id}' (pre-hook claims branch via substrate)"
   claude -p "/design ${feature_id}"
 
-  # 4. /build <feature-id>: same shape; reads test-list.json that /design
-  # produced.
+  # 4. /build <feature-id>: reads test-list.json that /design produced.
   log "  step 4: claude -p '/build ${feature_id}'"
   claude -p "/build ${feature_id}"
 

--- a/scripts/lakebase/create-project.cli.ts
+++ b/scripts/lakebase/create-project.cli.ts
@@ -18,6 +18,7 @@ interface ParsedArgs {
   privateRepo?: boolean;
   language?: "java" | "kotlin" | "python" | "nodejs";
   runnerType?: "self-hosted" | "github-hosted";
+  tiers?: 2 | 3;
   enableE2e?: boolean;
   enableInfra?: boolean;
   skipCommands?: boolean;
@@ -56,6 +57,18 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "--runner":
         out.runnerType = argv[++i] as ParsedArgs["runnerType"];
         break;
+      case "--tiers": {
+        const v = Number.parseInt(argv[++i], 10);
+        if (v !== 2 && v !== 3) {
+          process.stderr.write(
+            `--tiers: expected 2 (production + features) or 3 (production + staging + features). Got: ${argv[i]}\n`,
+          );
+          out.help = true;
+        } else {
+          out.tiers = v as 2 | 3;
+        }
+        break;
+      }
       case "--enable-e2e":
         out.enableE2e = true;
         break;
@@ -97,6 +110,10 @@ Flags:
   --public            Make the GitHub repo public (default: private)
   --language          java | kotlin | python | nodejs    (default: java)
   --runner            self-hosted | github-hosted        (default: self-hosted)
+  --tiers             2 (prod + features) or 3 (prod + staging + features).
+                      When omitted, no staging is cut + the project is 2-tier
+                      by default. Architectural choice; surface this in your
+                      wizard rather than picking silently.
   --enable-e2e        Force-enable Playwright E2E wire-up (FEIP-7094)
   --no-e2e            Force-disable Playwright E2E wire-up
                       (default: on for --language nodejs, off otherwise)
@@ -139,6 +156,7 @@ async function main(): Promise<number> {
       privateRepo: args.privateRepo,
       language: args.language,
       runnerType: args.runnerType,
+      tiers: args.tiers,
       enableE2e: args.enableE2e,
       enableInfra: args.enableInfra,
       skipCommands: args.skipCommands,

--- a/scripts/lakebase/create-project.ts
+++ b/scripts/lakebase/create-project.ts
@@ -18,6 +18,7 @@ import {
   getDefaultBranchId,
 } from "./lakebase-project.js";
 import { scaffoldAll } from "./scaffold.js";
+import { createBranch } from "./branch-create.js";
 import { enableE2eForProject } from "./enable-e2e.js";
 import { enableInfraForProject } from "./enable-infra.js";
 import { setupRunner } from "./runner-setup.js";
@@ -41,6 +42,24 @@ export interface CreateProjectArgs {
   language?: "java" | "kotlin" | "python" | "nodejs";
   /** CI runner type (default: 'self-hosted'). */
   runnerType?: "self-hosted" | "github-hosted";
+  /**
+   * Lakebase tier topology for this project. An architectural choice
+   * the caller (typically a wizard) should surface to the user rather
+   * than picking silently.
+   *
+   *   2 (or undefined) - production + feature branches. Simple,
+   *                       greenfield-friendly.
+   *   3                 - production + staging + feature branches.
+   *                       PSA-style 3-tier flow where features merge
+   *                       into staging and staging promotes to
+   *                       production via a separate release PR.
+   *
+   * When `tiers === 3`, scaffolding cuts a `staging` Lakebase branch
+   * (no_expiry, parent = production) so feature work has a non-prod
+   * parent to fork from. The kit's PSA-convention TTL defaults then
+   * fork feature branches off `staging` automatically.
+   */
+  tiers?: 2 | 3;
   /** Lay down the .tdd/ scaffold from templates/tdd-bootstrap/ (default: true). */
   enableTdd?: boolean;
   /**
@@ -122,6 +141,7 @@ export async function createProject(
   const enableInfra =
     input.enableInfra !== undefined ? input.enableInfra : language === "nodejs";
   const skipCommands = input.skipCommands === true;
+  const tiers = input.tiers;
   const warnings: string[] = [];
 
   if (useGithub && !input.githubOwner) {
@@ -195,6 +215,39 @@ export async function createProject(
     projectId: lakebaseProjectId,
     host,
   });
+
+  // ── Step 4b: Tier topology (architectural choice surfaced by the caller) ─
+  // When tiers === 3, cut a `staging` Lakebase branch (no_expiry) off
+  // production. The PSA-convention TTL helpers
+  // (createFeatureBranch/createTestBranch/...) then default to `staging`
+  // as the parent, so subsequent feature work forks off it cleanly.
+  // When tiers !== 3 (default), do nothing - the project is 2-tier
+  // (features fork directly from production).
+  if (tiers === 3) {
+    if (!defaultBranchId) {
+      warnings.push(
+        "tiers === 3 was requested but the project's default branch isn't ready yet; staging tier was NOT cut. Cut it manually via `lakebase-branch create --branch staging --parent-branch production --no-expiry`.",
+      );
+    } else {
+      report("Cutting staging tier (tiers=3)...");
+      try {
+        await createBranch({
+          instance: lakebaseProjectId,
+          host,
+          branch: "staging",
+          parentBranch: defaultBranchId,
+          noExpiry: true,
+        });
+      } catch (err) {
+        // Non-fatal: surface as a warning so the project still exists
+        // but the user knows the tier wasn't cut. They can retry the
+        // bare create-branch call manually.
+        warnings.push(
+          `tiers === 3 requested but staging tier creation failed: ${err instanceof Error ? err.message : String(err)}. Cut it manually via \`lakebase-branch create --branch staging --parent-branch production --no-expiry\`.`,
+        );
+      }
+    }
+  }
 
   // ── Step 5: Scaffold (templates + language project) ───────────
   report("Scaffolding project files...");

--- a/templates/project/common/.claude/commands/design.pre-hook.md
+++ b/templates/project/common/.claude/commands/design.pre-hook.md
@@ -1,0 +1,67 @@
+# /design pre-hook: claim a paired feature branch via the substrate
+
+Runs before `/design`'s phase 1 (Spec Author). Enforces the kit's
+invariant: **every git branch gets a Lakebase branch**, and the
+substrate's `lakebase-branch create-paired` is the only supported path
+to create one. The hook makes that the default for every scaffold,
+not a per-project opt-in.
+
+## Pre-hook job
+
+Before any design work, ensure a paired Lakebase + git branch exists
+for the feature being designed. The feature id is the positional
+argument to `/design` (e.g. `F1-initial-domain`).
+
+1. Read `LAKEBASE_PROJECT_ID` from the project's `.env`.
+2. Derive the git branch name from the feature id by stripping the
+   leading `F<N>-` and prefixing `feature/`:
+   - `F1-initial-domain` -> `feature/initial-domain`
+   - `F2-add-owners` -> `feature/add-owners`
+3. Pick the parent branch:
+   - If `LAKEBASE_BASE_BRANCH` is set in `.env`, use that.
+   - Else if the project has a `staging` branch (3-tier scaffold), use `staging`.
+   - Else use the project default branch (2-tier scaffold; usually `production`).
+4. Invoke the substrate primitive:
+
+   ```bash
+   npx --yes --package=github:databricks-solutions/lakebase-app-dev-kit \
+     lakebase-branch create-paired \
+       --instance "$LAKEBASE_PROJECT_ID" \
+       --branch "feature/$SLUG" \
+       --parent-branch "${LAKEBASE_BASE_BRANCH:-<staging-or-production>}" \
+       --cwd "$PWD" \
+       --pretty
+   ```
+
+   `lakebase-branch create-paired` wraps the substrate's
+   `createPairedBranch`. The atomic sequence:
+   - Create the Lakebase branch first (with TTL auto-recovery if the
+     workspace caps below the kit's default).
+   - Run `git checkout -b feature/$SLUG`. The kit's `post-checkout`
+     hook fires + populates `.env` credentials from the Lakebase side.
+   - If the Lakebase create fails, no git branch is left dangling.
+
+5. If `create-paired` errors with `branch already exists`, the branch
+   was claimed in a prior session - skip and proceed to phase 1.
+
+## Why this lives here
+
+The kit ships this as a default `design.pre-hook.md` so every
+scaffolded project enforces the "no git branch without Lakebase
+branch" invariant out of the box. Without it, agents or humans could
+shell out to `git checkout -b` directly and create an orphan git
+branch that the post-checkout hook then races to populate, sometimes
+succeeding sometimes not (depends on workspace auth state). The
+substrate is the single source of truth for branch creation; this
+pre-hook makes that real.
+
+Projects that want to extend this gesture (claim a JIRA epic, post to
+Slack, etc.) can append to this file. The kit's `lakebase-update-commands`
+won't clobber a pre-hook that diverges from the default.
+
+## Override
+
+To skip the pre-hook for a specific design run (e.g. when continuing
+work on an already-claimed branch), pass `--skip-pre-hook` to
+`/design`. The skill respects this flag and proceeds directly to
+phase 1 without invoking this hook.

--- a/tests/bdd/deploy-claude-commands.test.ts
+++ b/tests/bdd/deploy-claude-commands.test.ts
@@ -35,14 +35,19 @@ describe("deployClaudeCommands", () => {
   });
   afterEach(() => rmTempProject(targetDir));
 
-  it("writes design.md and build.md under .claude/commands/", async () => {
+  it("writes design.md, design.pre-hook.md, and build.md under .claude/commands/", async () => {
     const result = await deployClaudeCommands(targetDir, { templatesDir: REPO_TEMPLATES });
     expect(result.written.sort()).toEqual(
-      [path.join(".claude", "commands", "build.md"), path.join(".claude", "commands", "design.md")].sort()
+      [
+        path.join(".claude", "commands", "build.md"),
+        path.join(".claude", "commands", "design.md"),
+        path.join(".claude", "commands", "design.pre-hook.md"),
+      ].sort()
     );
     expect(result.skipped).toEqual([]);
     expect(fs.existsSync(path.join(targetDir, ".claude", "commands", "design.md"))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, ".claude", "commands", "build.md"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, ".claude", "commands", "design.pre-hook.md"))).toBe(true);
   });
 
   it("substitutes ${KIT_VERSION_AT_SCAFFOLD} with the real kit version", async () => {
@@ -142,9 +147,17 @@ describe("scaffoldStaticAll integration", () => {
       language: "nodejs",
     });
     expect(result.claudeCommands.sort()).toEqual(
-      [path.join(".claude", "commands", "build.md"), path.join(".claude", "commands", "design.md")].sort()
+      [
+        path.join(".claude", "commands", "build.md"),
+        path.join(".claude", "commands", "design.md"),
+        path.join(".claude", "commands", "design.pre-hook.md"),
+      ].sort()
     );
     expect(fs.existsSync(path.join(targetDir, ".claude", "commands", "design.md"))).toBe(true);
+    // The default design.pre-hook.md (which claims a paired feature branch
+    // via the substrate before /design phase 1) ships in every scaffold so
+    // "every git branch gets a Lakebase branch" is enforced by default.
+    expect(fs.existsSync(path.join(targetDir, ".claude", "commands", "design.pre-hook.md"))).toBe(true);
   });
 
   it("skipCommands=true skips the scaffold and reports an empty claudeCommands list", async () => {


### PR DESCRIPTION
Restores the kit's invariant: **every git branch gets a Lakebase branch, the substrate is the only creation path.**

Surfaced by the FEIP-7422 smoke that whenever something shelled out to `git checkout -b` directly, the post-checkout hook tried to create the Lakebase side as a fallback. The hook can fail (auth mismatch, TTL cap, etc.) and leaves an orphan git branch behind, breaking the invariant.

Three coordinated changes:

**A. Default `design.pre-hook.md` in the kit template.** Tells `/design` to invoke `lakebase-branch create-paired` BEFORE phase 1, claiming the paired branch atomically via the substrate. The hook ships in every fresh scaffold so the invariant is enforced by default.

**B. Smoke orchestrator no longer does `git checkout -b`.** Iteration loop returns to trunk, stages `.tdd/features/<id>/feature.md`, then calls `/design <id>` which fires the pre-hook + claims the branch via the substrate.

**C. `lakebase-create-project --tiers <2|3>`.** Architectural choice the caller (typically a wizard) surfaces to the user rather than picking silently. When `--tiers 3`, scaffold cuts a `staging` Lakebase branch (no_expiry, parent=production) so feature work forks off it per the kit's PSA-convention TTL defaults.

## Test plan
- [x] 1098/1098 hermetic vitest tests pass (existing claude-commands assertions updated for the new pre-hook file)
- [x] typecheck clean
- [ ] Future: run the FEIP-7422 smoke with --tiers 3 to verify the new pre-hook + scaffold pathway end-to-end

This pull request and its description were written by Claude.