### PR TITLE
fix(kit): use createLongRunningBranch for staging + /design Step 0 mandates substrate

### DIFF
--- a/examples/feip-7422-smoke/orchestrator/run-smoke.sh
+++ b/examples/feip-7422-smoke/orchestrator/run-smoke.sh
@@ -232,14 +232,12 @@ run_iteration() {
   feature_id="$(iteration_feature_id "$iter")"
 
   # 1. Return to trunk before staging the feature spec. The orchestrator
-  # does NOT `git checkout -b` here: branch creation is the substrate's
-  # responsibility, invoked from /design's pre-hook
-  # (templates/project/common/.claude/commands/design.pre-hook.md ships
-  # with the kit). The pre-hook calls `lakebase-branch create-paired`
-  # which atomically creates the Lakebase branch + git branch, so the
-  # invariant "every git branch gets a Lakebase branch" can't be broken
-  # by a partial failure here.
-  log "  step 1: return to trunk; /design's pre-hook will claim the paired branch"
+  # does NOT do branch creation itself: that's the kit's responsibility
+  # via /design's mandatory Step 0 (see
+  # templates/project/common/.claude/commands/design.md). /design's
+  # body enforces the substrate-only-path invariant at the kit level;
+  # the smoke just invokes /design and trusts the contract.
+  log "  step 1: return to trunk; /design's Step 0 claims the paired branch via substrate"
   git checkout main >/dev/null 2>&1 || git checkout master >/dev/null 2>&1
   git pull --ff-only origin "$(git branch --show-current)" || true
 

--- a/scripts/lakebase/create-project.ts
+++ b/scripts/lakebase/create-project.ts
@@ -18,7 +18,7 @@ import {
   getDefaultBranchId,
 } from "./lakebase-project.js";
 import { scaffoldAll } from "./scaffold.js";
-import { createBranch } from "./branch-create.js";
+import { createLongRunningBranch } from "./long-running-branch.js";
 import { enableE2eForProject } from "./enable-e2e.js";
 import { enableInfraForProject } from "./enable-infra.js";
 import { setupRunner } from "./runner-setup.js";
@@ -216,39 +216,6 @@ export async function createProject(
     host,
   });
 
-  // ── Step 4b: Tier topology (architectural choice surfaced by the caller) ─
-  // When tiers === 3, cut a `staging` Lakebase branch (no_expiry) off
-  // production. The PSA-convention TTL helpers
-  // (createFeatureBranch/createTestBranch/...) then default to `staging`
-  // as the parent, so subsequent feature work forks off it cleanly.
-  // When tiers !== 3 (default), do nothing - the project is 2-tier
-  // (features fork directly from production).
-  if (tiers === 3) {
-    if (!defaultBranchId) {
-      warnings.push(
-        "tiers === 3 was requested but the project's default branch isn't ready yet; staging tier was NOT cut. Cut it manually via `lakebase-branch create --branch staging --parent-branch production --no-expiry`.",
-      );
-    } else {
-      report("Cutting staging tier (tiers=3)...");
-      try {
-        await createBranch({
-          instance: lakebaseProjectId,
-          host,
-          branch: "staging",
-          parentBranch: defaultBranchId,
-          noExpiry: true,
-        });
-      } catch (err) {
-        // Non-fatal: surface as a warning so the project still exists
-        // but the user knows the tier wasn't cut. They can retry the
-        // bare create-branch call manually.
-        warnings.push(
-          `tiers === 3 requested but staging tier creation failed: ${err instanceof Error ? err.message : String(err)}. Cut it manually via \`lakebase-branch create --branch staging --parent-branch production --no-expiry\`.`,
-        );
-      }
-    }
-  }
-
   // ── Step 5: Scaffold (templates + language project) ───────────
   report("Scaffolding project files...");
   await scaffoldAll({
@@ -358,6 +325,49 @@ export async function createProject(
     message: `Initial project scaffold (${langLabel} + Lakebase)`,
     push: useGithub,
   });
+
+  // ── Step 8b: Long-running tier setup (architectural choice) ───
+  // When tiers === 3 the project follows the PSA-convention 3-tier
+  // flow (production -> staging -> features). The substrate's
+  // createLongRunningBranch primitive is the only supported path to
+  // cut a tier: it creates BOTH the Lakebase side (no_expiry, forked
+  // from the project default) AND the git side (forked from `main`,
+  // pushed to origin), enforcing "every git branch gets a Lakebase
+  // branch" for tiers too. Anything that calls createBranch directly
+  // for a tier is bypassing the SCM workflow and is wrong.
+  //
+  // When tiers !== 3 (default), do nothing: the project is 2-tier
+  // (features fork directly from production).
+  //
+  // Runs AFTER commitAndPush because createLongRunningBranch's git
+  // side does `git fetch origin main` + `git push -u origin staging`,
+  // which requires origin to already have `main`.
+  if (tiers === 3) {
+    if (!useGithub) {
+      warnings.push(
+        "tiers === 3 requires a GitHub repository (createLongRunningBranch pushes the tier's git side to origin). Staging tier was NOT cut.",
+      );
+    } else {
+      report("Cutting staging tier (tiers=3) via createLongRunningBranch...");
+      try {
+        await createLongRunningBranch({
+          name: "staging",
+          forkFromBranch: "main",
+          projectId: lakebaseProjectId,
+          workTreeDir: projectDir,
+          databricksHost: host,
+        });
+      } catch (err) {
+        // Non-fatal: surface as a warning so the project still exists
+        // but the user knows the tier wasn't cut. They can retry via
+        // `lakebase-branch create-paired --branch staging --no-expiry` or
+        // the dedicated tier-creation CLI flow.
+        warnings.push(
+          `tiers === 3 requested but createLongRunningBranch for staging failed: ${err instanceof Error ? err.message : String(err)}.`,
+        );
+      }
+    }
+  }
 
   // ── Step 9: Health check (advisory) ───────────────────────────
   report("Verifying project...");

--- a/templates/project/common/.claude/commands/design.md
+++ b/templates/project/common/.claude/commands/design.md
@@ -10,6 +10,37 @@ Drives a feature from idea to spec to architect review to test list. This wraps 
 
 If `.tdd/` does not exist in the project root, this command hard-fails with a setup hint instead of lazy-initializing: the TDD workflow has invariants (`.tdd/` shape, `selection-log.md`) a lazy bootstrap cannot reconstruct. Run the project's TDD adoption bin first, or `lakebase-create-project` when starting fresh.
 
+## Step 0 (cannot skip): claim the paired branch via the substrate
+
+**Before any design phase runs, the agent MUST claim a paired Lakebase + git branch for this feature via the substrate.** This is the kit's invariant: every git branch gets a Lakebase branch, and the substrate's `lakebase-branch create-paired` is the ONLY supported creation path. Skipping this step OR shelling out to `git checkout -b` directly is a contract violation and must be refused.
+
+Concretely, the agent:
+
+1. Reads `LAKEBASE_PROJECT_ID` from the project's `.env`. If absent, hard-fails with `Lakebase project id missing; run lakebase-create-project first.`
+2. Derives the git branch name from the feature id by stripping the leading `F<N>-` and prefixing `feature/`. Example: `F1-initial-domain` -> `feature/initial-domain`.
+3. Picks the parent branch with this precedence:
+   - `LAKEBASE_BASE_BRANCH` from `.env` if set (explicit override).
+   - Otherwise `staging` if the project's `lakebase-branch list` shows it (3-tier scaffold).
+   - Otherwise the project default branch (2-tier scaffold; usually `production`).
+4. Invokes the substrate primitive via the kit CLI:
+
+   ```bash
+   npx --yes --package=github:databricks-solutions/lakebase-app-dev-kit \
+     lakebase-branch create-paired \
+       --instance "$LAKEBASE_PROJECT_ID" \
+       --branch "feature/<slug>" \
+       --parent-branch "<resolved-parent>" \
+       --cwd "$PWD" \
+       --pretty
+   ```
+
+   `create-paired` is atomic via the substrate's `createPairedBranch`: the Lakebase side comes first (with TTL auto-recovery), then `git checkout -b` triggers the post-checkout hook to populate `.env` credentials. If the Lakebase side fails, no git branch is left dangling.
+
+5. If `create-paired` errors with `branch already exists`, the feature branch was claimed in a prior session: proceed to step 6.
+6. Run `.claude/commands/design.pre-hook.md` if present. The default pre-hook (shipped with the kit) documents this very step for reference; projects may APPEND project-specific gestures to it (claim a JIRA epic, post to Slack, etc.). The pre-hook does NOT replace step 0 above; it extends it.
+
+If step 0 cannot complete, REFUSE to proceed to phase 1. Do not work around. The substrate is the only path.
+
 ## Phases (HITL-gated)
 
 1. **Spec Author** drafts `spec.md` + `feature.json` from the prompt.
@@ -23,16 +54,14 @@ Each phase is implemented by the substrate agent of the same name:
 
 References resolve through Claude Code's `@skill-name/agent-name` lookup, so agent renames inside the substrate skill stay safe.
 
-## Project pre/post hooks
-
-If `.claude/commands/design.pre-hook.md` exists in this project, it runs before phase 1. Common uses: create a JIRA epic for the feature, claim a working branch in Lakebase.
+## Project post-hook
 
 If `.claude/commands/design.post-hook.md` exists in this project, it runs after phase 3. Common uses: notify a Slack channel, assign reviewers, link the spec into a tracking doc.
 
-The hooks are owned by the project, not the substrate: this command file only consults them when present. Author the markdown files freely; one pre-hook plus one post-hook per command (no chains in v1).
+The post-hook is owned by the project, not the substrate: this command file only consults it when present. Author the markdown file freely; one post-hook per command (no chains in v1).
 
 ## Substrate version
 
 Pinned to: `${KIT_VERSION_AT_SCAFFOLD}`
 
-Bumping the kit may shift agent prompts. The future `lakebase-update-commands` bin will re-pull canonical templates while preserving the pre/post hook files above.
+Bumping the kit may shift agent prompts. The future `lakebase-update-commands` bin will re-pull canonical templates while preserving the post-hook file above.


### PR DESCRIPTION
Follow-up to PR #128. Closes two gaps from the live FEIP-7422 smoke:

1. create-project's --tiers 3 path was calling createBranch directly (raw substrate, no git side). Replaced with createLongRunningBranch which creates both sides atomically (Lakebase no_expiry + git fork-from-main + push to origin). Moved the tier cut to after commitAndPush since createLongRunningBranch needs origin to have main.

2. /design's command body now mandates 'Step 0 (cannot skip): claim the paired branch via the substrate' at the top, with imperative language + concrete CLI invocation. Prior 'common uses' mention was a soft suggestion; the new Step 0 is the first instruction the agent sees and refuses to proceed if it fails. design.pre-hook.md is now a project-owned extension point, not the canonical claim path.

Followup work captured separately: codify the substrate-only-branch-creation invariant in the lakebase-scm-workflows skill (the SCM baseline that every kit consumer follows, not TDD-only territory).

This pull request and its description were written by Claude.