### PR TITLE
feat(scm): per-tier-type paired branch primitives + create-paired-tier CLI (option B)

### DIFF
--- a/scripts/lakebase/branch.cli.ts
+++ b/scripts/lakebase/branch.cli.ts
@@ -22,6 +22,10 @@ import {
   createTestBranch,
   createUatBranch,
   createPerfBranch,
+  createFeaturePairedBranch,
+  createTestPairedBranch,
+  createUatPairedBranch,
+  createPerfPairedBranch,
 } from "./convention-branches.js";
 import {
   createPairedBranch,
@@ -139,7 +143,12 @@ Subcommands:
   create           Create a Lakebase branch (no git side-effects)
   create-paired    Create Lakebase branch + matching git branch + .env update
   create-tier <feature|test|uat|perf>
-                   Create a convention-tier branch (default fork from staging)
+                   Create a convention-tier Lakebase branch (default fork from staging).
+                   No git side-effects; use create-paired-tier for the paired variant.
+  create-paired-tier <feature|test|uat|perf>
+                   Create the convention-tier PAIRED branch (Lakebase + git + .env)
+                   atomically. The canonical way to claim a feature branch:
+                   substrate is the only path, convention TTL is applied automatically.
   delete           Delete a Lakebase branch (no git side-effects)
   delete-paired    Delete Lakebase branch + local git branch + remote git branch
   checkout-paired  Equivalent of post-checkout hook (sync .env to current git branch)
@@ -292,6 +301,42 @@ async function main(): Promise<number> {
               : tier === "uat"
                 ? await createUatBranch(common)
                 : await createPerfBranch(common);
+        printJson(result, pretty);
+        return 0;
+      }
+
+      case "create-paired-tier": {
+        // Atomic paired (Lakebase + git + .env) + convention TTL per tier.
+        // This is the canonical "claim a feature branch" primitive: every
+        // git branch gets a Lakebase branch via the substrate, with the
+        // convention TTL (30d feature / 14d test / 14d uat / 7d perf).
+        const tier = args.positional as Tier | undefined;
+        if (!tier || !["feature", "test", "uat", "perf"].includes(tier)) {
+          process.stderr.write(
+            `create-paired-tier: expected one of feature|test|uat|perf as the first positional arg.\n`
+          );
+          return 2;
+        }
+        if (!requireFlags("create-paired-tier", args, ["instance", "branch"]))
+          return 2;
+        const common = {
+          instance: args.instance!,
+          branch: args.branch!,
+          parentBranch: args.parentBranch,
+          ttl: args.ttl,
+          cwd: args.cwd ?? process.cwd(),
+          createGitBranch: !args.noGitBranch,
+          syncEnv: !args.noSyncEnv,
+          database: args.database,
+        };
+        const result =
+          tier === "feature"
+            ? await createFeaturePairedBranch(common)
+            : tier === "test"
+              ? await createTestPairedBranch(common)
+              : tier === "uat"
+                ? await createUatPairedBranch(common)
+                : await createPerfPairedBranch(common);
         printJson(result, pretty);
         return 0;
       }

--- a/scripts/lakebase/convention-branches.ts
+++ b/scripts/lakebase/convention-branches.ts
@@ -29,6 +29,10 @@
 import { createBranch as createLakebaseBranch } from "./branch-create.js";
 import { LakebaseBranchInfo, BranchLookupOpts } from "./branch-utils.js";
 import { KIT_TIMEOUTS, formatLakebaseTtl } from "./kit-config.js";
+import {
+  createPairedBranch,
+  type CreatePairedBranchResult,
+} from "./paired-branch.js";
 
 /**
  * Tier defaults. Exported so tests + future tickets can introspect.
@@ -127,5 +131,105 @@ export async function createPerfBranch(
     parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.perf.parentBranch,
     ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.perf.ttl,
     strictParent: args.strictParent,
+  });
+}
+
+// ─── Per-tier-type PAIRED helpers (atomic Lakebase + git + .env) ─────
+//
+// These combine the substrate's createPairedBranch atomicity with the
+// per-tier convention TTL. They are the canonical "claim a feature branch"
+// (or test/uat/perf) primitive: callers (TDD agents, smoke orchestrators,
+// humans) MUST use these instead of calling createPairedBranch directly,
+// because createPairedBranch defaults to no_expiry: true (which is wrong
+// for finite-lifetime tier branches and would silently create what
+// looks like a long-running tier).
+//
+// All four take CreateConventionPairedBranchArgs (CreateConventionBranchArgs
+// + cwd + paired flags). Each forwards to createPairedBranch with the
+// convention TTL pre-filled.
+
+export interface CreateConventionPairedBranchArgs extends CreateConventionBranchArgs {
+  /** Project directory (must contain .git/; .env is updated if syncEnv=true). */
+  cwd: string;
+  /** Create+switch a git branch with the same sanitized name. Default: true. */
+  createGitBranch?: boolean;
+  /** Update .env to point at the new branch's endpoint. Default: true. */
+  syncEnv?: boolean;
+  /** Default: 120_000. Lakebase ready-state poll budget. */
+  readyTimeoutMs?: number;
+  /** Default: "databricks_postgres". */
+  database?: string;
+}
+
+/**
+ * Cut a feature-tier paired branch (Lakebase + git + .env sync) with the
+ * 30-day convention TTL. Forks from `staging` by default. Atomic via
+ * createPairedBranch: if the Lakebase side fails, no git branch is left
+ * dangling.
+ */
+export async function createFeaturePairedBranch(
+  args: CreateConventionPairedBranchArgs,
+): Promise<CreatePairedBranchResult> {
+  return createPairedBranch({
+    instance: args.instance,
+    branch: args.branch,
+    parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.feature.parentBranch,
+    ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.feature.ttl,
+    cwd: args.cwd,
+    createGitBranch: args.createGitBranch,
+    syncEnv: args.syncEnv,
+    readyTimeoutMs: args.readyTimeoutMs,
+    database: args.database,
+  });
+}
+
+/** Cut a test-tier paired branch (Lakebase + git + .env) with the 14-day convention TTL. */
+export async function createTestPairedBranch(
+  args: CreateConventionPairedBranchArgs,
+): Promise<CreatePairedBranchResult> {
+  return createPairedBranch({
+    instance: args.instance,
+    branch: args.branch,
+    parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.test.parentBranch,
+    ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.test.ttl,
+    cwd: args.cwd,
+    createGitBranch: args.createGitBranch,
+    syncEnv: args.syncEnv,
+    readyTimeoutMs: args.readyTimeoutMs,
+    database: args.database,
+  });
+}
+
+/** Cut a uat-tier paired branch (Lakebase + git + .env) with the 14-day convention TTL. */
+export async function createUatPairedBranch(
+  args: CreateConventionPairedBranchArgs,
+): Promise<CreatePairedBranchResult> {
+  return createPairedBranch({
+    instance: args.instance,
+    branch: args.branch,
+    parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.uat.parentBranch,
+    ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.uat.ttl,
+    cwd: args.cwd,
+    createGitBranch: args.createGitBranch,
+    syncEnv: args.syncEnv,
+    readyTimeoutMs: args.readyTimeoutMs,
+    database: args.database,
+  });
+}
+
+/** Cut a perf-tier paired branch (Lakebase + git + .env) with the 7-day convention TTL. */
+export async function createPerfPairedBranch(
+  args: CreateConventionPairedBranchArgs,
+): Promise<CreatePairedBranchResult> {
+  return createPairedBranch({
+    instance: args.instance,
+    branch: args.branch,
+    parentBranch: args.parentBranch ?? CONVENTION_TIER_DEFAULTS.perf.parentBranch,
+    ttl: args.ttl ?? CONVENTION_TIER_DEFAULTS.perf.ttl,
+    cwd: args.cwd,
+    createGitBranch: args.createGitBranch,
+    syncEnv: args.syncEnv,
+    readyTimeoutMs: args.readyTimeoutMs,
+    database: args.database,
   });
 }

--- a/scripts/lakebase/paired-branch.ts
+++ b/scripts/lakebase/paired-branch.ts
@@ -135,6 +135,23 @@ export interface CreatePairedBranchArgs {
   readyTimeoutMs?: number;
   /** Default: "databricks_postgres". */
   database?: string;
+  /**
+   * Lakebase-format TTL string ("<seconds>s", e.g. "2592000s" = 30 days)
+   * for the Lakebase branch. Mutually exclusive with `noExpiry: true`.
+   * When neither is set, createBranch's default (`no_expiry: true`)
+   * applies - which is wrong for feature/test/uat/perf branches that
+   * should expire. Per-tier-type wrappers in convention-branches.ts
+   * (createFeaturePairedBranch / createTestPairedBranch / ...) plumb the
+   * right convention TTL here.
+   */
+  ttl?: string;
+  /**
+   * When true, force `no_expiry: true` on the Lakebase branch. Use for
+   * long-running tiers (production, staging). Mutually exclusive with
+   * `ttl`. When neither is set, createBranch's default fires (no_expiry
+   * true), but new callers should be explicit.
+   */
+  noExpiry?: boolean;
 }
 
 export interface CreatePairedBranchResult {
@@ -171,10 +188,17 @@ export async function createPairedBranch(
   const database = args.database ?? process.env.PGDATABASE ?? DEFAULT_DATABASE;
 
   // 1. Create Lakebase branch (idempotent if already exists with same name)
+  // TTL semantics: callers that want a tier (no expiry) pass noExpiry: true;
+  // callers that want a finite-lifetime convention branch pass ttl. If
+  // neither is set, the underlying createBranch defaults to no_expiry: true
+  // (legacy behavior); per-tier-type wrappers in convention-branches.ts are
+  // the supported way to pick the right convention TTL.
   const branch = await createBranch({
     instance: args.instance,
     branch: args.branch,
     parentBranch: args.parentBranch,
+    ttl: args.ttl,
+    noExpiry: args.noExpiry,
   });
 
   // 2. Wait for READY (createBranch already polls, but make budget explicit)

--- a/templates/project/common/.claude/commands/design.md
+++ b/templates/project/common/.claude/commands/design.md
@@ -22,11 +22,11 @@ Concretely, the agent:
    - `LAKEBASE_BASE_BRANCH` from `.env` if set (explicit override).
    - Otherwise `staging` if the project's `lakebase-branch list` shows it (3-tier scaffold).
    - Otherwise the project default branch (2-tier scaffold; usually `production`).
-4. Invokes the substrate primitive via the kit CLI:
+4. Invokes the canonical substrate primitive via the kit CLI:
 
    ```bash
    npx --yes --package=github:databricks-solutions/lakebase-app-dev-kit \
-     lakebase-branch create-paired \
+     lakebase-branch create-paired-tier feature \
        --instance "$LAKEBASE_PROJECT_ID" \
        --branch "feature/<slug>" \
        --parent-branch "<resolved-parent>" \
@@ -34,7 +34,7 @@ Concretely, the agent:
        --pretty
    ```
 
-   `create-paired` is atomic via the substrate's `createPairedBranch`: the Lakebase side comes first (with TTL auto-recovery), then `git checkout -b` triggers the post-checkout hook to populate `.env` credentials. If the Lakebase side fails, no git branch is left dangling.
+   `create-paired-tier feature` is the ONLY supported way to claim a feature branch: it combines `createPairedBranch`'s atomicity (Lakebase first, then git, then `.env` sync, all-or-nothing) with the 30-day convention TTL feature branches require. Do NOT use `create-paired` (lower-level, defaults to `no_expiry: true` which would silently create a long-running tier instead of a feature branch).
 
 5. If `create-paired` errors with `branch already exists`, the feature branch was claimed in a prior session: proceed to step 6.
 6. Run `.claude/commands/design.pre-hook.md` if present. The default pre-hook (shipped with the kit) documents this very step for reference; projects may APPEND project-specific gestures to it (claim a JIRA epic, post to Slack, etc.). The pre-hook does NOT replace step 0 above; it extends it.

--- a/tests/bdd/convention-branches-paired.test.ts
+++ b/tests/bdd/convention-branches-paired.test.ts
@@ -1,0 +1,142 @@
+// Hermetic coverage for the per-tier-type PAIRED helpers.
+//
+// createFeaturePairedBranch / createTestPairedBranch / createUatPairedBranch /
+// createPerfPairedBranch must forward the convention TTL + parent into
+// createPairedBranch. Verifies the contract that fixes the FEIP-7422 smoke
+// gap: feature branches must get the 30-day TTL, not the legacy no_expiry
+// default from createPairedBranch.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { KIT_TIMEOUTS, formatLakebaseTtl } from "../../scripts/lakebase/kit-config.js";
+
+const mockCreatePairedBranch = vi.fn();
+
+vi.mock("../../scripts/lakebase/paired-branch.js", () => ({
+  createPairedBranch: (...args: unknown[]) => mockCreatePairedBranch(...args),
+}));
+
+// Import after the mock is registered.
+const conv = await import("../../scripts/lakebase/convention-branches.js");
+
+beforeEach(() => {
+  mockCreatePairedBranch.mockReset();
+  mockCreatePairedBranch.mockResolvedValue({
+    branch: {
+      name: "projects/p/branches/feature-x",
+      uid: "br-x",
+      state: "READY",
+      isDefault: false,
+    },
+    gitBranch: "feature-x",
+    gitBranchCreated: true,
+    envSynced: true,
+    warnings: [],
+  });
+});
+
+describe("convention-branches paired: defaults", () => {
+  it("createFeaturePairedBranch forwards 30d TTL + parent=staging + cwd", async () => {
+    await conv.createFeaturePairedBranch({
+      instance: "p",
+      branch: "feature/x",
+      cwd: "/some/project",
+    });
+    expect(mockCreatePairedBranch).toHaveBeenCalledTimes(1);
+    expect(mockCreatePairedBranch.mock.calls[0][0]).toMatchObject({
+      instance: "p",
+      branch: "feature/x",
+      parentBranch: "staging",
+      ttl: formatLakebaseTtl(KIT_TIMEOUTS.featureBranchTtlMs),
+      cwd: "/some/project",
+    });
+  });
+
+  it("createTestPairedBranch forwards 14d test TTL + parent=staging", async () => {
+    await conv.createTestPairedBranch({
+      instance: "p",
+      branch: "test/x",
+      cwd: "/some/project",
+    });
+    expect(mockCreatePairedBranch.mock.calls[0][0]).toMatchObject({
+      parentBranch: "staging",
+      ttl: formatLakebaseTtl(KIT_TIMEOUTS.testBranchTtlMs),
+    });
+  });
+
+  it("createUatPairedBranch forwards 14d uat TTL + parent=staging", async () => {
+    await conv.createUatPairedBranch({
+      instance: "p",
+      branch: "uat/x",
+      cwd: "/some/project",
+    });
+    expect(mockCreatePairedBranch.mock.calls[0][0]).toMatchObject({
+      parentBranch: "staging",
+      ttl: formatLakebaseTtl(KIT_TIMEOUTS.uatBranchTtlMs),
+    });
+  });
+
+  it("createPerfPairedBranch forwards 7d perf TTL + parent=staging", async () => {
+    await conv.createPerfPairedBranch({
+      instance: "p",
+      branch: "perf/x",
+      cwd: "/some/project",
+    });
+    expect(mockCreatePairedBranch.mock.calls[0][0]).toMatchObject({
+      parentBranch: "staging",
+      ttl: formatLakebaseTtl(KIT_TIMEOUTS.perfBranchTtlMs),
+    });
+  });
+
+  it("crucially: NONE of the paired helpers set noExpiry (would silently create a tier)", async () => {
+    await conv.createFeaturePairedBranch({ instance: "p", branch: "x", cwd: "/x" });
+    expect(mockCreatePairedBranch.mock.calls[0][0].noExpiry).toBeUndefined();
+    mockCreatePairedBranch.mockClear();
+
+    await conv.createTestPairedBranch({ instance: "p", branch: "x", cwd: "/x" });
+    expect(mockCreatePairedBranch.mock.calls[0][0].noExpiry).toBeUndefined();
+    mockCreatePairedBranch.mockClear();
+
+    await conv.createUatPairedBranch({ instance: "p", branch: "x", cwd: "/x" });
+    expect(mockCreatePairedBranch.mock.calls[0][0].noExpiry).toBeUndefined();
+    mockCreatePairedBranch.mockClear();
+
+    await conv.createPerfPairedBranch({ instance: "p", branch: "x", cwd: "/x" });
+    expect(mockCreatePairedBranch.mock.calls[0][0].noExpiry).toBeUndefined();
+  });
+});
+
+describe("convention-branches paired: caller overrides", () => {
+  it("ttl override is forwarded as-is (workspace caps override the convention default)", async () => {
+    await conv.createFeaturePairedBranch({
+      instance: "p",
+      branch: "feature/x",
+      cwd: "/x",
+      ttl: "604800s",
+    });
+    expect(mockCreatePairedBranch.mock.calls[0][0].ttl).toBe("604800s");
+  });
+
+  it("parentBranch override is forwarded as-is", async () => {
+    await conv.createFeaturePairedBranch({
+      instance: "p",
+      branch: "feature/x",
+      cwd: "/x",
+      parentBranch: "production",
+    });
+    expect(mockCreatePairedBranch.mock.calls[0][0].parentBranch).toBe("production");
+  });
+
+  it("createGitBranch=false + syncEnv=false are forwarded", async () => {
+    await conv.createFeaturePairedBranch({
+      instance: "p",
+      branch: "feature/x",
+      cwd: "/x",
+      createGitBranch: false,
+      syncEnv: false,
+    });
+    expect(mockCreatePairedBranch.mock.calls[0][0]).toMatchObject({
+      createGitBranch: false,
+      syncEnv: false,
+    });
+  });
+});


### PR DESCRIPTION
Surfaced by the FEIP-7422 smoke: /design's Step 0 was invoking `lakebase-branch create-paired` which silently creates a long-running TIER (no_expiry: true is the default) instead of a finite-lifetime feature branch. Closes that gap with kit-level code, not markdown pleading.

## Changes

1. `paired-branch.ts`: `createPairedBranch` accepts `ttl` + `noExpiry` args
2. `convention-branches.ts`: 4 new per-tier-type PAIRED helpers (`createFeaturePairedBranch` 30d, `createTestPairedBranch` 14d, `createUatPairedBranch` 14d, `createPerfPairedBranch` 7d) that combine paired-branch atomicity with the convention TTL
3. `branch.cli.ts`: new `lakebase-branch create-paired-tier <feature|test|uat|perf>` subcommand
4. `design.md`: /design Step 0 mandate now invokes `create-paired-tier feature` with an imperative warning against the lower-level `create-paired`

## Test plan
- [x] typecheck clean
- [ ] Future: BDD coverage for the new primitives + CLI subcommand
- [ ] Future: smoke verifies feature branches get the 30-day TTL, not no_expiry

## Followups (filed separately)
- FEIP-7457: codify in lakebase-scm-workflows skill SKILL.md
- FEIP-7458: lakebase-scm-workflows as executable state machine with hard gate surfaces

This pull request and its description were written by Claude.