### PR TITLE
fix(scm): tier nomenclature - features are not tiers

### DIFF
--- a/examples/feip-7422-smoke/orchestrator/00-domain.md
+++ b/examples/feip-7422-smoke/orchestrator/00-domain.md
@@ -30,6 +30,27 @@ iteration has a credible motivation that maps to a real refactor
 pattern. The smoke can therefore exercise the SCM workflow across
 five distinct schema-modifying PRs without contrived scope changes.
 
+## Tier topology: 2-tier (prod + staging)
+
+This smoke is opinionated: **the bug-tracker project is 2-tier**.
+The kit's tier nomenclature counts long-running tiers only, NOT
+feature branches:
+
+| --tiers | Long-running tiers | Where features fork from |
+|---------|-------------------|--------------------------|
+| 1 | prod | prod |
+| 2 | prod + staging | staging |
+| 3 | prod + staging + dev | dev |
+
+Iterations v1-v5 all declare `Lakebase parent: staging`, so the
+project must be 2-tier. `run-smoke.sh` enforces `--tiers 2` at
+startup; 1 or 3 are rejected because either would break the
+staging-as-parent assumption in the iteration specs.
+
+If you need a different tier topology for your own smoke, fork these
+iteration specs and replace every `Lakebase parent: staging` line
+with the parent your topology calls for.
+
 ## Iteration arc (5 PRs)
 
 | Iter | Branch | Headline change | Refactor type |

--- a/examples/feip-7422-smoke/orchestrator/run-smoke.sh
+++ b/examples/feip-7422-smoke/orchestrator/run-smoke.sh
@@ -86,14 +86,23 @@ done
 
 PROJECT_DIR="${PROJECT_DIR:-${SMOKE_ROOT_DEFAULT}/${PROJECT_NAME}}"
 
-# --tiers is required when scaffolding (architectural choice; iteration
-# specs assume 3-tier with `staging` as parent). When --skip-scaffold is
-# set the project's tier topology is already on disk, no opt-in needed.
+# --tiers is required when scaffolding (architectural choice). The
+# bug-tracker iteration specs all declare `Lakebase parent: staging`,
+# so this smoke is 2-tier (prod + staging) by definition. --tiers 1
+# (prod only) and --tiers 3 (prod + staging + dev) are rejected because
+# either would break the staging-as-parent assumption.
+#
+# Tier semantics (features are NOT tiers; they are branches):
+#   1 = prod only        (features fork from prod)
+#   2 = prod + staging   (features fork from staging)
+#   3 = prod + staging + dev (features fork from dev)
 if [[ "$SKIP_SCAFFOLD" -eq 0 ]]; then
-  if [[ "$TIERS" != "2" && "$TIERS" != "3" ]]; then
-    echo "smoke: --tiers <2|3> is required. Pick 3 for the standard smoke" >&2
-    echo "       (iteration specs assume a 'staging' parent); 2 for a flat" >&2
-    echo "       production-only flow (iteration specs will need adjustment)." >&2
+  if [[ "$TIERS" != "2" ]]; then
+    echo "smoke: --tiers 2 is required for this smoke. Got: '${TIERS:-<unset>}'." >&2
+    echo "       The bug-tracker iteration specs declare 'Lakebase parent: staging'," >&2
+    echo "       so the project must be 2-tier (prod + staging). 1-tier would have" >&2
+    echo "       features forking from prod; 3-tier would add a dev layer and require" >&2
+    echo "       rewriting every iteration spec." >&2
     exit 10
   fi
 fi

--- a/scripts/lakebase/create-project.cli.ts
+++ b/scripts/lakebase/create-project.cli.ts
@@ -18,7 +18,7 @@ interface ParsedArgs {
   privateRepo?: boolean;
   language?: "java" | "kotlin" | "python" | "nodejs";
   runnerType?: "self-hosted" | "github-hosted";
-  tiers?: 2 | 3;
+  tiers?: 1 | 2 | 3;
   enableE2e?: boolean;
   enableInfra?: boolean;
   skipCommands?: boolean;
@@ -59,13 +59,17 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--tiers": {
         const v = Number.parseInt(argv[++i], 10);
-        if (v !== 2 && v !== 3) {
+        if (v !== 1 && v !== 2 && v !== 3) {
           process.stderr.write(
-            `--tiers: expected 2 (production + features) or 3 (production + staging + features). Got: ${argv[i]}\n`,
+            `--tiers: expected 1, 2, or 3. Got: ${argv[i]}\n` +
+              `  1 = prod only (features fork from prod)\n` +
+              `  2 = prod + staging (features fork from staging)\n` +
+              `  3 = prod + staging + dev (features fork from dev)\n` +
+              `  Features are short-lived branches, NOT counted as tiers.\n`,
           );
           out.help = true;
         } else {
-          out.tiers = v as 2 | 3;
+          out.tiers = v as 1 | 2 | 3;
         }
         break;
       }
@@ -110,10 +114,13 @@ Flags:
   --public            Make the GitHub repo public (default: private)
   --language          java | kotlin | python | nodejs    (default: java)
   --runner            self-hosted | github-hosted        (default: self-hosted)
-  --tiers             2 (prod + features) or 3 (prod + staging + features).
-                      When omitted, no staging is cut + the project is 2-tier
-                      by default. Architectural choice; surface this in your
-                      wizard rather than picking silently.
+  --tiers             1, 2, or 3. Tier count (features are NOT tiers).
+                        1 = prod only           (features fork from prod)
+                        2 = prod + staging      (features fork from staging)
+                        3 = prod + staging + dev (features fork from dev)
+                      When omitted, defaults to 1 (prod only, no extra tiers
+                      cut). Architectural choice; surface this in your wizard
+                      rather than picking silently.
   --enable-e2e        Force-enable Playwright E2E wire-up (FEIP-7094)
   --no-e2e            Force-disable Playwright E2E wire-up
                       (default: on for --language nodejs, off otherwise)

--- a/scripts/lakebase/create-project.ts
+++ b/scripts/lakebase/create-project.ts
@@ -45,21 +45,24 @@ export interface CreateProjectArgs {
   /**
    * Lakebase tier topology for this project. An architectural choice
    * the caller (typically a wizard) should surface to the user rather
-   * than picking silently.
+   * than picking silently. Features are short-lived branches, NOT
+   * tiers; they are not counted in this number.
    *
-   *   2 (or undefined) - production + feature branches. Simple,
-   *                       greenfield-friendly.
-   *   3                 - production + staging + feature branches.
-   *                       PSA-style 3-tier flow where features merge
-   *                       into staging and staging promotes to
-   *                       production via a separate release PR.
+   *   1 (or undefined) - prod only. Features fork from prod.
+   *   2                 - prod + staging. Features fork from staging.
+   *                       Staging accumulates merged features between
+   *                       release windows; releases promote staging
+   *                       to prod via a separate PR.
+   *   3                 - prod + staging + dev. Features fork from dev.
+   *                       Dev accumulates day-to-day feature integration;
+   *                       periodically dev is promoted to staging.
    *
-   * When `tiers === 3`, scaffolding cuts a `staging` Lakebase branch
-   * (no_expiry, parent = production) so feature work has a non-prod
-   * parent to fork from. The kit's PSA-convention TTL defaults then
-   * fork feature branches off `staging` automatically.
+   * Scaffolding cuts the extra tiers off prod (staging) and off staging
+   * (dev) via `createLongRunningBranch` (Lakebase no_expiry + git push
+   * to origin). When `tiers === 1` (or omitted), only the prod default
+   * branch exists.
    */
-  tiers?: 2 | 3;
+  tiers?: 1 | 2 | 3;
   /** Lay down the .tdd/ scaffold from templates/tdd-bootstrap/ (default: true). */
   enableTdd?: boolean;
   /**
@@ -327,28 +330,26 @@ export async function createProject(
   });
 
   // ── Step 8b: Long-running tier setup (architectural choice) ───
-  // When tiers === 3 the project follows the PSA-convention 3-tier
-  // flow (production -> staging -> features). The substrate's
-  // createLongRunningBranch primitive is the only supported path to
-  // cut a tier: it creates BOTH the Lakebase side (no_expiry, forked
-  // from the project default) AND the git side (forked from `main`,
-  // pushed to origin), enforcing "every git branch gets a Lakebase
-  // branch" for tiers too. Anything that calls createBranch directly
-  // for a tier is bypassing the SCM workflow and is wrong.
+  // Tier semantics (features are NOT tiers, they are short-lived branches):
+  //   tiers === 1 (default): prod only. No extra tiers cut.
+  //   tiers === 2: cut staging (off prod).
+  //   tiers === 3: cut staging (off prod) + dev (off staging).
   //
-  // When tiers !== 3 (default), do nothing: the project is 2-tier
-  // (features fork directly from production).
+  // The substrate's createLongRunningBranch primitive is the only
+  // supported path to cut a tier: it creates BOTH the Lakebase side
+  // (no_expiry, forked from the named parent) AND the git side
+  // (forked + pushed to origin), enforcing "every git branch gets a
+  // Lakebase branch" for tiers too.
   //
-  // Runs AFTER commitAndPush because createLongRunningBranch's git
-  // side does `git fetch origin main` + `git push -u origin staging`,
-  // which requires origin to already have `main`.
-  if (tiers === 3) {
+  // Runs AFTER commitAndPush because createLongRunningBranch needs
+  // origin to already have the parent ref (e.g. main, staging).
+  if (tiers === 2 || tiers === 3) {
     if (!useGithub) {
       warnings.push(
-        "tiers === 3 requires a GitHub repository (createLongRunningBranch pushes the tier's git side to origin). Staging tier was NOT cut.",
+        `tiers === ${tiers} requires a GitHub repository (createLongRunningBranch pushes the tier's git side to origin). Extra tiers were NOT cut.`,
       );
     } else {
-      report("Cutting staging tier (tiers=3) via createLongRunningBranch...");
+      report(`Cutting staging tier (tiers=${tiers}) via createLongRunningBranch...`);
       try {
         await createLongRunningBranch({
           name: "staging",
@@ -358,13 +359,26 @@ export async function createProject(
           databricksHost: host,
         });
       } catch (err) {
-        // Non-fatal: surface as a warning so the project still exists
-        // but the user knows the tier wasn't cut. They can retry via
-        // `lakebase-branch create-paired --branch staging --no-expiry` or
-        // the dedicated tier-creation CLI flow.
         warnings.push(
-          `tiers === 3 requested but createLongRunningBranch for staging failed: ${err instanceof Error ? err.message : String(err)}.`,
+          `tiers === ${tiers} requested but createLongRunningBranch for staging failed: ${err instanceof Error ? err.message : String(err)}.`,
         );
+      }
+
+      if (tiers === 3) {
+        report("Cutting dev tier (tiers=3) via createLongRunningBranch (off staging)...");
+        try {
+          await createLongRunningBranch({
+            name: "dev",
+            forkFromBranch: "staging",
+            projectId: lakebaseProjectId,
+            workTreeDir: projectDir,
+            databricksHost: host,
+          });
+        } catch (err) {
+          warnings.push(
+            `tiers === 3 requested but createLongRunningBranch for dev failed: ${err instanceof Error ? err.message : String(err)}.`,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
Off-by-one fix. --tiers was treating features as a tier; corrected to count only long-running tiers (prod is always present, staging + dev are optional).

| --tiers | Long-running tiers | Feature fork parent |
|---------|-------------------|---------------------|
| 1 | prod | prod |
| 2 | prod + staging | staging |
| 3 | prod + staging + dev | dev |

This pull request and its description were written by Claude.