### PR TITLE
refactor(smoke): tag iteration specs with author: Feature Requester frontmatter

### DIFF
--- a/examples/feip-7422-smoke/orchestrator/iterations/v1-initial-domain.md
+++ b/examples/feip-7422-smoke/orchestrator/iterations/v1-initial-domain.md
@@ -1,3 +1,7 @@
+---
+author: Feature Requester
+---
+
 # v1: Initial Domain
 
 A team has started using a shared bug tracker. Right now nothing

--- a/examples/feip-7422-smoke/orchestrator/iterations/v2-add-owners.md
+++ b/examples/feip-7422-smoke/orchestrator/iterations/v2-add-owners.md
@@ -1,3 +1,7 @@
+---
+author: Feature Requester
+---
+
 # v2: Add Owners
 
 The team has been using the bug tracker for a few weeks. Bugs are

--- a/examples/feip-7422-smoke/orchestrator/iterations/v3-status-table.md
+++ b/examples/feip-7422-smoke/orchestrator/iterations/v3-status-table.md
@@ -1,3 +1,7 @@
+---
+author: Feature Requester
+---
+
 # v3: First-class Status Workflow
 
 The team's three states (just-filed, someone-is-working-on-it, done)

--- a/examples/feip-7422-smoke/orchestrator/iterations/v4-split-bug-entity.md
+++ b/examples/feip-7422-smoke/orchestrator/iterations/v4-split-bug-entity.md
@@ -1,3 +1,7 @@
+---
+author: Feature Requester
+---
+
 # v4: Reproduction Steps
 
 The team has been filing bugs for a while, and the description

--- a/examples/feip-7422-smoke/orchestrator/iterations/v5-list-view.md
+++ b/examples/feip-7422-smoke/orchestrator/iterations/v5-list-view.md
@@ -1,3 +1,7 @@
+---
+author: Feature Requester
+---
+
 # v5: A View of the Bug List
 
 So far the team has been retrieving bugs one at a time by

--- a/tests/bdd/feip-7422-smoke.test.ts
+++ b/tests/bdd/feip-7422-smoke.test.ts
@@ -77,6 +77,16 @@ describe("FEIP-7422 smoke: iteration specs are well-formed (feature.md voice)", 
     describe(iter, () => {
       const md = fs.readFileSync(path.join(SMOKE_DIR, "iterations", `${iter}.md`), "utf8");
 
+      it("carries YAML frontmatter declaring author: Feature Requester", () => {
+        // Every artifact in the kit's workflow records the ROLE that
+        // authored it (not the person). Iteration specs ARE feature.md
+        // files, authored by the feature requester. Spec Author /
+        // Architect Reviewer / Test Strategist / driver+navigator
+        // outputs each carry their own role in this frontmatter slot
+        // when they land.
+        expect(md).toMatch(/^---\n[\s\S]*?\bauthor:\s*Feature Requester\b[\s\S]*?\n---\n/);
+      });
+
       it("has a top-level H1 title", () => {
         expect(md).toMatch(/^#\s+v\d/m);
       });


### PR DESCRIPTION
Adds YAML frontmatter `author: Feature Requester` to each iteration spec, with a BDD assertion enforcing it. Companion FEIP filed for propagating the role-author convention across every artifact type the TDD pipeline produces.

This pull request and its description were written by Claude.