### PR TITLE
fix(python-template): pass --extra dev to uv run pytest

### DIFF
--- a/templates/project/common/scripts/run-tests.sh
+++ b/templates/project/common/scripts/run-tests.sh
@@ -51,7 +51,13 @@ elif [ -f "$REPO_ROOT/requirements.txt" ] || [ -f "$REPO_ROOT/pyproject.toml" ];
   fi
   echo "Running Alembic migrations..."
   uv run alembic upgrade head
-  uv run pytest "$@"
+  # pytest + httpx live in [project.optional-dependencies].dev in the
+  # Python scaffold, so they aren't installed by a default `uv run` /
+  # `uv sync`. Without --extra dev, uv falls back to a system pytest
+  # that can't see the venv's fastapi etc., and test collection crashes
+  # with ModuleNotFoundError. Pass --extra dev so uv resolves against
+  # the dev extras for the test invocation.
+  uv run --extra dev pytest "$@"
 elif [ -f "$REPO_ROOT/package.json" ]; then
   # Node.js / Knex + Jest
   echo "Running Knex migrations..."


### PR DESCRIPTION
uv run without --extra dev doesn't include [project.optional-dependencies].dev where pytest lives. Without that, uv run pytest falls back to system pytest which doesn't see the venv. Surfaced by FEIP-7422 smoke #10.

This pull request and its description were written by Claude.