### PR TITLE
fix(pkg): export ./package.json so consumers can require.resolve it

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "module": "./dist/scripts/index.js",
   "types": "./dist/scripts/index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "types": "./dist/scripts/index.d.ts",

--- a/tests/bdd/build-bin-coverage.test.ts
+++ b/tests/bdd/build-bin-coverage.test.ts
@@ -47,13 +47,23 @@ function parseTsupEntries(): Map<string, string> {
 }
 
 describe("build/bin coverage", () => {
-  const pkg = readJson<{ bin?: Record<string, string> }>(
-    path.join(REPO_ROOT, "package.json"),
-  );
+  const pkg = readJson<{
+    bin?: Record<string, string>;
+    exports?: Record<string, unknown>;
+  }>(path.join(REPO_ROOT, "package.json"));
   const tsupEntries = parseTsupEntries();
 
   it("package.json declares at least one bin", () => {
     expect(pkg.bin && Object.keys(pkg.bin).length > 0).toBe(true);
+  });
+
+  it("exports exposes ./package.json so consumers can require.resolve it", () => {
+    // The extension does require.resolve("@databricks-solutions/lakebase-app-dev-kit/package.json")
+    // to find the kit package root (then walks to templates/). With an `exports`
+    // field present, Node refuses any subpath not listed, so package.json must be
+    // explicitly exported or the resolve throws ERR_PACKAGE_PATH_NOT_EXPORTED at
+    // runtime (the "Install Reference Playwright Config" command failed this way).
+    expect(pkg.exports?.["./package.json"]).toBe("./package.json");
   });
 
   it("every script-side bin entry maps to a tsup entry", () => {


### PR DESCRIPTION
The `exports` field gated every subpath, so `require.resolve("@databricks-solutions/lakebase-app-dev-kit/package.json")` (used by the SCM extension to locate the kit root + walk to `templates/`) threw `ERR_PACKAGE_PATH_NOT_EXPORTED` at runtime and warned at webpack bundle time. The "Install Reference Playwright Config" command degraded to an error.

Adds `"./package.json": "./package.json"` to `exports`, plus a `build-bin-coverage` guard test so it can't silently regress. package.json-only; dist unchanged.

This pull request and its description were written by Isaac.