### PR TITLE
fix(tdd-drive): self-heal routing for gate-blocking build smells (+ SDD/TDD docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Spec Driven Development (SDD) framing.** `lakebase-tdd-workflows` docs now name
+  the two lanes explicitly: the design lane (`/design`) is Spec Driven Development
+  (SDD), which produces and freezes the executable spec at the `spec` + `test_list`
+  gates; the build lane (`/build`) is Test Driven Development (TDD), which builds
+  against that frozen spec. Narrative added to the skill README + SKILL, the
+  spec-format reference, the design-lane agent prompts (spec-author,
+  architect-reviewer, test-strategist), and the kit README + CLAUDE.
+
 ## [0.3.0-beta.1] - 2026-06-10
 
 Second beta on the 0.3.0 line. Consume via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,6 @@ When editing scripts, always run `npm run typecheck` before committing. When add
 
 ## When proposing changes
 
-Follow `lakebase-tdd-workflows` for TDD on Lakebase-paired projects: spec → architectural review → test list → design-spec gate → cycles. The orchestrator is a deterministic driver (`lakebase-tdd-drive`), not an LLM agent: it routes phase transitions over `workflow-state.json`, spawns the role agents, and surfaces bad smells. Every gate is HITL.
+Follow `lakebase-tdd-workflows` for spec-driven, test-driven development on Lakebase-paired projects. Two lanes: the design lane is **Spec Driven Development (SDD)** (`/design`: spec → architectural review → test list → design-spec gate) and the build lane is **Test Driven Development (TDD)** (`/build`: RED → GREEN → REFACTOR cycles). SDD freezes the spec at the `spec` + `test_list` gates; TDD only builds once they pass. The orchestrator is a deterministic driver (`lakebase-tdd-drive`), not an LLM agent: it routes phase transitions over `workflow-state.json`, spawns the role agents, and surfaces bad smells. Every gate is HITL.
 
 For non-TDD work in this substrate repo itself, follow the conventions in [`CONTRIBUTING.md`](CONTRIBUTING.md): tier 1 hermetic tests required, tier 2 live tests for `scripts/lakebase/*` changes, single-seam credential rules enforced by CI grep guards.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lakebase-backed application development kit. The shared foundation that the [`la
 **Workflow domains** (kit-authored, one skill each, hosted under `skills/`):
 - **[`lakebase-scm-workflows`](skills/lakebase-scm-workflows/README.md)** – paired-branch source control, schema diff, PR flow, runner setup.
 - **[`lakebase-release-workflows`](skills/lakebase-release-workflows/SKILL.md)** – branching + release methodology for Lakebase-paired projects.
-- **[`lakebase-tdd-workflows`](skills/lakebase-tdd-workflows/README.md)** – test-driven development against paired branches, with a deterministic orchestrator and HITL gates at every phase boundary.
+- **[`lakebase-tdd-workflows`](skills/lakebase-tdd-workflows/README.md)** – spec-driven, test-driven development against paired branches: Spec Driven Development (SDD) for the design lane (`/design`) and Test Driven Development (TDD) for the build lane (`/build`), with a deterministic orchestrator and HITL gates at every phase boundary.
 - Future domains include deploying to Databricks Apps and beyond.
 
 **Shared canon** (kit-authored, unprefixed because not Lakebase-specific):

--- a/scripts/tdd/cycle-record.ts
+++ b/scripts/tdd/cycle-record.ts
@@ -25,7 +25,7 @@ import { markTestItemGreen } from "./test-list.js";
 import { listExperiments } from "./experiment.js";
 import { ensureDeployedAndVerify } from "./deploy.js";
 import { writeEscalation, type Escalation } from "./escalation.js";
-import { readSmellsLog, markSmellResolved, isBuildRefactorRoutableSmell } from "./smells.js";
+import { readSmellsLog, markSmellResolved, isBuildRefactorRoutableSmell, hasOpenBuildRefactorRoutableSmell } from "./smells.js";
 import {
   readGreenFailure,
   writeGreenFailure,
@@ -529,9 +529,28 @@ export function firstReviewPendingAc(tddDir: string, featureId: string, story: s
   return acReviewStates(tddDir, featureId, story).find((a) => a.allTestsGreen && !a.reviewed)?.acId ?? null;
 }
 
-/** First AC REVIEWed with a refactor request not yet satisfied (-> Driver REFACTOR). */
+/** First AC REVIEWed with a refactor request not yet satisfied (-> Driver REFACTOR).
+ *
+ * Two sources of "refactor pending":
+ *  1. The Navigator's REVIEW verdict explicitly requested it (refactor_requested).
+ *  2. A deterministic build-refactor-routable gate (layering-clean / ux-adherence /
+ *     import-time-build-coupling) raised a still-open BLOCKING smell for this story.
+ *     That gate IS the refactor signal, so a reviewed-but-unrefactored AC must route
+ *     to the Driver's REFACTOR even when the Navigator's verdict said refactor:false
+ *     (the bug that stalled F5: the gate blocked, the verdict said "looks good", so
+ *     no refactor was queued and the smell escalated straight to HIL instead of
+ *     self-healing). refactorAc resolves the smell + the post-refactor verify
+ *     preserves behavior; one attempt per AC, after which a residual violation
+ *     re-surfaces with no refactor pending and escalates (backstop intact).
+ */
 export function firstRefactorPendingAc(tddDir: string, featureId: string, story: string): string | null {
-  return acReviewStates(tddDir, featureId, story).find((a) => a.reviewed && a.refactorRequested && !a.refactored)?.acId ?? null;
+  const states = acReviewStates(tddDir, featureId, story);
+  const explicit = states.find((a) => a.reviewed && a.refactorRequested && !a.refactored);
+  if (explicit) return explicit.acId;
+  if (hasOpenBuildRefactorRoutableSmell(tddDir, story)) {
+    return states.find((a) => a.reviewed && !a.refactored)?.acId ?? null;
+  }
+  return null;
 }
 
 /**

--- a/scripts/tdd/orchestrator-effects.ts
+++ b/scripts/tdd/orchestrator-effects.ts
@@ -514,6 +514,10 @@ function roleTaskBody(
           `REFACTOR AC ${action.ac} in story ${s} per the Navigator's review` +
           ` (.tdd/cycles/${featureId}/${s}/${action.ac}/review.json -> refactor_notes), guided by the architecture` +
           ` (.tdd/features/${featureId}/architecture.md), the NFRs (.tdd/nfrs.md), + design guide (.tdd/design/design-guide.md).` +
+          ` If review.json has no refactor_notes, this refactor was queued by a BLOCKING build-quality gate (a layering /` +
+          ` design-adherence / import-coupling smell in .tdd/smells.json): run that gate to see the violation` +
+          ` (e.g. \`lakebase-tdd-layering-clean --project-dir .\`) and fix exactly what it flags , typically extract the` +
+          ` duplicated/misplaced code into one shared helper in its correct layer.` +
           ` Keep ALL tests green and do not change what the outer-boundary tests check, refactor only.`
         );
       }

--- a/scripts/tdd/smells.ts
+++ b/scripts/tdd/smells.ts
@@ -261,6 +261,25 @@ export function isBuildRefactorRoutableSmell(name: string): boolean {
   return BUILD_REFACTOR_ROUTABLE.has(name);
 }
 
+/**
+ * True iff an OPEN (unresolved) build-refactor-routable smell is recorded for
+ * this story (or feature-wide, for a legacy story-less entry). The deterministic
+ * gate that raised it (layering-clean, ux-adherence, import-time-build-coupling)
+ * IS the refactor signal, so a reviewed AC should be routed to the Driver's
+ * REFACTOR even when the Navigator's verdict said refactor:false. The refactor
+ * then resolves the smell (refactorAc) and the post-refactor verify preserves
+ * behavior; if a residual violation remains it re-surfaces with no refactor
+ * pending and escalates (the backstop stays intact).
+ */
+export function hasOpenBuildRefactorRoutableSmell(tddDir: string, story_id?: string): boolean {
+  return readSmellsLog(tddDir).detected.some(
+    (d) =>
+      !d.resolution &&
+      isBuildRefactorRoutableSmell(d.smell) &&
+      (story_id === undefined || d.story_id === undefined || d.story_id === story_id),
+  );
+}
+
 const CYCLE_STALL_THRESHOLD = 3;
 const FRAGILITY_RATIO_FAILED_TESTS = 3;
 const TEST_COST_SPIRAL_FACTOR = 2;

--- a/skills/lakebase-tdd-workflows/README.md
+++ b/skills/lakebase-tdd-workflows/README.md
@@ -1,6 +1,13 @@
 # lakebase-tdd-workflows
 
-Substrate for test-driven development on paired Lakebase branches. Canonical Beck-style RED → GREEN → REFACTOR composed with paired-branch primitives (cheap experiments, parent-aware schema diff, real per-branch databases) and HITL gates at every phase boundary.
+Substrate for spec-driven, test-driven development on paired Lakebase branches. Canonical Beck-style RED → GREEN → REFACTOR composed with paired-branch primitives (cheap experiments, parent-aware schema diff, real per-branch databases) and HITL gates at every phase boundary.
+
+**Two disciplines, back to back.** The kit runs the design lane as **Spec Driven Development (SDD)** and the build lane as **Test Driven Development (TDD)**:
+
+- **Design lane = SDD** (`/design`). Spec Author, Architect Reviewer, and Test Strategist turn intent into a gated, executable spec – feature spec, stories, ACs, architecture notes, and a Beck-ordered test list – before any product code exists. The spec is the artifact that drives everything downstream.
+- **Build lane = TDD** (`/build`). RED → GREEN → REFACTOR cycles turn that approved spec into working software on a paired branch, one test-list item at a time. The test list authored by SDD is the build lane's horizon.
+
+SDD produces the spec; TDD consumes it. The HITL gates between them (`spec`, `test_list`) are where the spec is frozen before a single line of product code is written.
 
 This README is the human-facing overview. The agent's operating contract – hard rules, function names, code patterns – lives in [`SKILL.md`](SKILL.md).
 
@@ -50,15 +57,17 @@ The substrate API keeps "experiment" as the noun for the rigorous TDD branch; it
 
 ## Phases and gates
 
-| Phase | Output | HITL gate |
-|---|---|---|
-| 0 Discovery | Draft `feature-spec.{md,json}` + `story.{md,json}` + `ac.{md,json}` per AC | **Gate 1 – Draft spec** |
-| 1 Architectural review | Layer + architectural_notes populated; `architecture.md` summary | **Gate 2 – Architectural lens** |
-| 2 Test-list construction | Ordered `test-list.{md,json}` at feature level | **Gate 3 – Test list ordering** |
-| 3 Design-spec gate | Experiment plan in `selection-log.md` (N, strategies, budget) | **Gate 4 – Experiment plan** |
-| 4 Implementation | Per-experiment cycles producing tests + code | Continuous: smells; final: promote / synthesize choice |
+Phases 0–3 are the **SDD (Spec Driven Development)** lane: they produce and freeze the spec. Phase 4 is the **TDD (Test Driven Development)** lane: it builds against that frozen spec.
 
-Each phase has a defined predecessor + artifact contract. The orchestrator refuses to transition if prior artifacts are missing or invalid.
+| Phase | Lane | Output | HITL gate |
+|---|---|---|---|
+| 0 Discovery | SDD | Draft `feature-spec.{md,json}` + `story.{md,json}` + `ac.{md,json}` per AC | **Gate 1 – Draft spec** |
+| 1 Architectural review | SDD | Layer + architectural_notes populated; `architecture.md` summary | **Gate 2 – Architectural lens** |
+| 2 Test-list construction | SDD | Ordered `test-list.{md,json}` at feature level | **Gate 3 – Test list ordering** |
+| 3 Design-spec gate | SDD | Experiment plan in `selection-log.md` (N, strategies, budget) | **Gate 4 – Experiment plan** |
+| 4 Implementation | TDD | Per-experiment cycles producing tests + code | Continuous: smells; final: promote / synthesize choice |
+
+Each phase has a defined predecessor + artifact contract. The orchestrator refuses to transition if prior artifacts are missing or invalid. The SDD-to-TDD handoff is hard: the build lane cannot start until the `spec` and `test_list` gates are approved, so TDD always builds against a frozen, reviewed spec.
 
 ## Operations
 
@@ -150,9 +159,9 @@ Three flows – shown as what you'd prompt your agent to do, using a cart-checko
 
 The project-level slash commands `/design` and `/build` are the canonical entry points. They're thin wrappers around this substrate, scaffolded into new projects by `lakebase-create-project` under `.claude/commands/` (opt-out via `--skip-commands`). Projects extend them with their own concerns (JIRA hierarchy, IDE branch suggestions, manual review gates) by dropping sibling `design.{pre,post}-hook.md` or `build.{pre,post}-hook.md` files next to the scaffolded command. If a slash command isn't installed in your project, just describe what you want to your agent directly; the prompts below work either way.
 
-### 1. Author a feature spec
+### 1. Author a feature spec (the SDD lane)
 
-Just describe what you want to build. The design agent walks Spec Author → Architect Reviewer → Test Strategist and asks you to sign off at each HITL gate; you don't need to tell it about schemas, file layout, IDs, or which questions to ask – that's its job.
+This is Spec Driven Development: you produce the spec before any product code. Just describe what you want to build. The design agent walks Spec Author → Architect Reviewer → Test Strategist and asks you to sign off at each HITL gate; you don't need to tell it about schemas, file layout, IDs, or which questions to ask – that's its job.
 
 > `/design`
 
@@ -162,9 +171,9 @@ Just describe what you want to build. The design agent walks Spec Author → Arc
 
 When you're done, your `.tdd/features/F1-checkout/` tree has the feature, stories, ACs, architecture notes, and an ordered test list. If you'd rather author by hand, copy `templates/tdd-bootstrap/.tdd/` into your project and edit the files using [`references/spec-format.md`](references/spec-format.md) as the layout reference.
 
-### 2. Build a feature end-to-end (the N=1 default)
+### 2. Build a feature end-to-end (the TDD lane, N=1 default)
 
-The most common flow. One feature, one branch, iterative refinement. The branch IS the feature.
+This is Test Driven Development against the spec the SDD lane froze. The most common flow. One feature, one branch, iterative refinement. The branch IS the feature.
 
 > `/build F1-checkout`
 
@@ -203,8 +212,8 @@ For when you want to run something directly without the agent. Most TDD work goe
 
 ## Project-level entry points
 
-- **`/design`** – wraps Spec Author + Architect Reviewer + Test Strategist phases. Scaffolded into new projects by `lakebase-create-project`. Project-specific JIRA hierarchy creation lives in `design.pre-hook.md`.
-- **`/build`** – wraps Orchestrator. Scaffolded into new projects by `lakebase-create-project`. Project-specific PR/merge ceremony lives in `build.post-hook.md`.
+- **`/design`** – the **SDD (Spec Driven Development)** lane: wraps Spec Author + Architect Reviewer + Test Strategist phases to produce the gated, executable spec. Scaffolded into new projects by `lakebase-create-project`. Project-specific JIRA hierarchy creation lives in `design.pre-hook.md`.
+- **`/build`** – the **TDD (Test Driven Development)** lane: wraps the Orchestrator running RED → GREEN → REFACTOR against the frozen spec. Scaffolded into new projects by `lakebase-create-project`. Project-specific PR/merge ceremony lives in `build.post-hook.md`.
 - **`/ship`** – lives in `lakebase-release-workflows`. Not part of this skill.
 
 The substrate itself ships no installed slash commands; the scaffolder writes the command files into the project at `lakebase-create-project` time (templated, with a kit-version pin). The substrate's runtime surface stays skills + agents + scripts + CLI bins. The MCP server (`apps/mcp-server/`) exposes the tool surface for MCP-capable consumers.

--- a/skills/lakebase-tdd-workflows/SKILL.md
+++ b/skills/lakebase-tdd-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lakebase-tdd-workflows
-description: "Test-driven development against paired Lakebase branches. Canonical Beck-style RED-GREEN-REFACTOR composed with paired-branch primitives (cheap experiments, parent-aware schema diff, real per-branch databases). Use when planning a new feature, running design-spec gates, running TDD cycles, comparing parallel experiments, or detecting workflow bad smells. Imports software-design-principles canon. Builds on lakebase-scm-workflows + lakebase-release-workflows."
+description: "Spec-driven, test-driven development against paired Lakebase branches. The design lane is Spec Driven Development (SDD); the build lane is canonical Beck-style Test Driven Development (RED-GREEN-REFACTOR), composed with paired-branch primitives (cheap experiments, parent-aware schema diff, real per-branch databases). Use when planning a new feature, running design-spec gates, running TDD cycles, comparing parallel experiments, or detecting workflow bad smells. Imports software-design-principles canon. Builds on lakebase-scm-workflows + lakebase-release-workflows."
 user-invocable: true
 ---
 
@@ -28,7 +28,9 @@ See [`agents/navigator.md`](agents/navigator.md) and [`agents/driver.md`](agents
 
 ## Phases and gates
 
-Gates are keyed (not numbered): `spec` / `plan` / `test_list` / `promote` / `deploy`. The design lane runs PER STORY (it streams), and experiments + plans are per-story.
+The kit composes two disciplines: the **design lane is Spec Driven Development (SDD)** – spec drafting, architectural review, test-list construction, all driven by `/design` – and the **build lane is Test Driven Development (TDD)** – the RED → GREEN → REVIEW → REFACTOR cycles driven by `/build`. SDD freezes the spec at the `spec` + `test_list` gates; TDD only starts once they are approved, so the build always runs against a reviewed spec.
+
+Gates are keyed (not numbered): `spec` / `plan` / `test_list` / `promote` / `deploy`. The SDD lane runs PER STORY (it streams), and experiments + plans are per-story.
 
 | Step (per story unless noted) | Output | HITL gate |
 |---|---|---|
@@ -56,8 +58,8 @@ Tier 2:  /plan  /design  /build  /deploy   (run ONE phase, then stop + suggest n
 
 - **`/sprint [name]`** (Tier 1, the top-level orchestrator): runs the whole sprint as one continuous flow, plan to the plan gate, then claim + drive each backlog feature `design` -> `build` -> `deploy`. Re-invoked per cycle; resumable (halts at the next HITL gate for the human, continues on re-run). `lakebase-tdd-drive --sprint <name>`.
 - **`/plan [name]`** (Tier 2, sprint planning, ABOVE the per-feature loop): the **Spec Author** proposes the candidate breakdown (`.tdd/planning/feature-proposals.md`); the **Architect** t-shirt-sizes the candidates (`.tdd/planning/estimates.json`, XS/S/M/L/XL); the **Product Owner** commits the backlog by authoring a `feature-request.md` per feature that fits sprint capacity; the deterministic `sync-backlog` step projects `.tdd/sprints/<name>/backlog.json` (committed ids + sizes); the **sprint plan gate** is the HITL checkpoint. Stops there (does not flow into design). Requires project intake (`product-overview.md` + `nfrs.md`, +`design-brief.md` for UI) as a precondition. `--sprint <name> --plan-only`.
-- **`/design <feature-id>`**: claims the paired branch (Step 0), enforces the feature's `feature-request.md` + project intake (Step 0.5, a precondition, NOT a gate), then drives the per-story design lane to the spec gates. `--only design`.
-- **`/build <feature-id>`**: the TDD cycles + per-story acceptance, to ready-for-review (requires design done). `--only build`.
+- **`/design <feature-id>`**: the **SDD (Spec Driven Development)** lane. Claims the paired branch (Step 0), enforces the feature's `feature-request.md` + project intake (Step 0.5, a precondition, NOT a gate), then drives the per-story design lane (Spec Author -> Architect Reviewer -> Test Strategist) to the spec + test_list gates, producing the executable spec. `--only design`.
+- **`/build <feature-id>`**: the **TDD (Test Driven Development)** lane. RED -> GREEN -> REVIEW -> REFACTOR cycles + per-story acceptance against the frozen spec, to ready-for-review (requires the SDD lane done). `--only build`.
 - **`/deploy <feature-id> [--target local] [--story <s>]`**: deploys the merged feature (or one story's branch) + verifies reachable + feature-verify; the **deploy gate** is the working-software review the PO signs off (the local target is the only one implemented; remote release is the scaffolded `merge.yml`). `--only deploy`. For a hands-on review the human can run `./scripts/run-dev.sh` to serve the app locally (migrates + hot-reload) and open it in a browser.
 - **`/spike <slug> [--for <feature>]`**: throwaway exploration on its own paired branch, OUTSIDE the workflow (no gates). Notes carry forward into a feature's design-spec gate; code is never promoted. `lakebase-tdd-spike`.
 

--- a/skills/lakebase-tdd-workflows/agents/architect-reviewer.md
+++ b/skills/lakebase-tdd-workflows/agents/architect-reviewer.md
@@ -12,7 +12,7 @@ color: purple
 
 # Architect Reviewer
 
-You apply the architectural lens to a draft spec: every acceptance criterion gets a layer assignment, cross-cutting concerns are owned, and the design respects the canon before any test list is built.
+You are the middle role in the **Spec Driven Development (SDD)** lane. You apply the architectural lens to a draft spec: every acceptance criterion gets a layer assignment, cross-cutting concerns are owned, and the design respects the canon before any test list is built. SDD means the spec carries the architecture, so the build lane (Test Driven Development) inherits it rather than improvising it.
 
 **Operating rules (all roles):** work in the project root with relative `.tdd/` paths; produce conformant artifacts from this prompt (the conformance CLI validates against the bundled schemas, never read `*.schema.json`); never run a filesystem-wide scan (`find /`). Detail: [agent-operating-rules.md](../references/agent-operating-rules.md).
 

--- a/skills/lakebase-tdd-workflows/agents/spec-author.md
+++ b/skills/lakebase-tdd-workflows/agents/spec-author.md
@@ -13,7 +13,7 @@ color: blue
 
 # Spec Author
 
-You are the business analyst. You work *with* the Product Owner to turn the Feature Requester's open-ended, plain-English intent into a structured draft spec the rest of the workflow builds against. You are phase 0 of `/design`, and you hand off to the Architect Reviewer. You do not decide the technical shape (Architect) or what gets built (PO): you translate intent into structure faithfully, and surface every ambiguity back to the PO rather than resolving it.
+You are the business analyst, and the first role in the **Spec Driven Development (SDD)** lane. You work *with* the Product Owner to turn the Feature Requester's open-ended, plain-English intent into a structured draft spec the rest of the workflow builds against. You are phase 0 of `/design`, and you hand off to the Architect Reviewer. In SDD the spec is the deliverable that drives everything downstream: the build lane (Test Driven Development) cannot start until the spec you open is reviewed and frozen at its gate. You do not decide the technical shape (Architect) or what gets built (PO): you translate intent into structure faithfully, and surface every ambiguity back to the PO rather than resolving it.
 
 **Operating rules (all roles):** work in the project root with relative `.tdd/` paths; produce conformant artifacts from this prompt (the conformance CLI validates against the bundled schemas, never read `*.schema.json`); never run a filesystem-wide scan (`find /`). Detail: [agent-operating-rules.md](../references/agent-operating-rules.md).
 

--- a/skills/lakebase-tdd-workflows/agents/test-strategist.md
+++ b/skills/lakebase-tdd-workflows/agents/test-strategist.md
@@ -12,7 +12,7 @@ color: green
 
 # Test Strategist
 
-You convert an architecturally-annotated feature into a Beck-style ordered test list. The order you choose drives the design momentum of the cycles that follow.
+You are the final role in the **Spec Driven Development (SDD)** lane, and the bridge to Test Driven Development (TDD). You convert an architecturally-annotated feature into a Beck-style ordered test list. The order you choose drives the design momentum of the cycles that follow. The test list is the SDD lane's last artifact and the TDD lane's first input: once it is frozen at the test_list gate, the build lane works through it one item at a time.
 
 **Operating rules (all roles):** work in the project root with relative `.tdd/` paths; produce conformant artifacts from this prompt (the conformance CLI validates against the bundled schemas, never read `*.schema.json`); never run a filesystem-wide scan (`find /`). Detail: [agent-operating-rules.md](../references/agent-operating-rules.md).
 

--- a/skills/lakebase-tdd-workflows/references/spec-format.md
+++ b/skills/lakebase-tdd-workflows/references/spec-format.md
@@ -2,6 +2,8 @@
 
 The on-disk `.tdd/` layout that the lakebase-tdd-workflows substrate reads and writes. Portable, tool-agnostic. Every structured element has both a markdown narrative (for humans) and a JSON contract (for agents, validation, and adapter sync).
 
+This `.tdd/` tree is the artifact of **Spec Driven Development (SDD)**: the design lane (`/design`) writes the feature spec, stories, ACs, architecture, and ordered test list here, and freezes them at the `spec` + `test_list` gates. The **Test Driven Development (TDD)** build lane (`/build`) then reads this tree as its source of truth, never the other way around: the spec drives the code.
+
 ## Directory layout
 
 ```

--- a/tests/bdd/tdd-layering-self-heal.test.ts
+++ b/tests/bdd/tdd-layering-self-heal.test.ts
@@ -76,6 +76,20 @@ describe("pendingEscalation: layering-violation self-heals while a refactor is p
     expect(probe.pendingEscalation()).toBeNull(); // NOT a HIL halt , the driver handles it
   });
 
+  it("self-heals on a gate-blocking smell even when the Navigator verdict was refactor:false (the F5 bug)", () => {
+    writeSmellsLog(tdd, [{ smell: "layering-violation", cycle_ids: [], detail: "duplicated render/error block across routes" }]);
+    // The Navigator REVIEWed AC1 and recorded "looks good" (refactor:false), yet the
+    // deterministic layering gate flagged a BLOCKING violation. Before the fix this
+    // left no refactor pending, so the blocking smell escalated straight to HIL.
+    writeJson(join(tdd, "cycles", F, S, "AC1", "review-verdict.json"), { refactor: false, notes: "AC behavior is correct" });
+    reviewAc(tdd, F, S, "AC1");
+    // The gate IS the refactor signal: a reviewed-but-unrefactored AC is now treated
+    // as refactor-pending, so the Driver's refactor turn is dispatched...
+    expect(firstRefactorPendingAc(tdd, F, S)).toBe("AC1");
+    // ...and the escalation is suppressed (no HIL halt) while that refactor is pending.
+    expect(diskArtifactProbe(tdd, F, S).pendingEscalation()).toBeNull();
+  });
+
   it("still HALTS (terminal) when the same smell has no refactor pending", () => {
     writeSmellsLog(tdd, [{ smell: "layering-violation", cycle_ids: [], detail: "flat app/models.py vs declared app/models/ package" }]);
     // no review / refactor pending


### PR DESCRIPTION
## What

Two changes on this branch, both ahead of `main`:

1. **Self-heal routing fix** (`4bbca71`) — `fix(tdd-drive): route a gate-blocking build smell to the Driver refactor (not HIL)`. A build-phase smell that blocks a gate is now routed to the Driver's refactor step instead of escalating to the human, so the workflow self-heals in-loop.
2. **SDD/TDD framing docs** (`241e3c4`) — name the two disciplines explicitly across `lakebase-tdd-workflows`: the design lane (`/design`) is Spec Driven Development (SDD), the build lane (`/build`) is Test Driven Development (TDD). SDD freezes the spec at the `spec` + `test_list` gates; TDD builds against it. Updated the skill README + SKILL, the spec-format reference, the design-lane agents (spec-author, architect-reviewer, test-strategist), and the kit README + CLAUDE + CHANGELOG (Unreleased, no version bump).

## Notes

- No release/version bump.
- Full test suite passed on pre-push (2281 passed).

This pull request and its description were written by Isaac.