### PR TITLE
fix(sftdd): replay-build trusts recorded GREEN + base run-tests skips e2e (FEIP-7702)

### DIFF
--- a/scripts/sftdd/cycle-record.ts
+++ b/scripts/sftdd/cycle-record.ts
@@ -359,6 +359,31 @@ const defaultGreenVerifier: GreenVerifier = async ({ projectDir, branchId }) => 
 };
 
 /**
+ * Replay-build verifier (FEIP-7702): trust the recorded GREEN for this turn
+ * instead of re-running the full-suite honest-GREEN against the overlaid code.
+ * During a build replay the project tree at an intermediate turn carries the
+ * WHOLE recorded test set while only the current AC's code is in place, so a
+ * later AC's test is legitimately RED , re-running the full suite per turn would
+ * fail the cycle on a not-yet-built AC, which is not a regression. The corpus is
+ * the source of truth that the turn was green when recorded; the final all-ACs
+ * state is still honestly verified at the deploy gate. No deploy, no I/O.
+ */
+export const replayTrustVerifier: GreenVerifier = async () => ({
+  passed: true,
+  summary: "replay-build: trusting recorded GREEN (per-turn verify skipped; final state verified at the deploy gate)",
+});
+
+/**
+ * Pick the GREEN/REFACTOR verifier for the current environment: the
+ * replay-trust verifier when a build replay is in flight
+ * (LAKEBASE_TDD_REPLAY_BUILD_DIR set), else undefined so greenOpenCycle /
+ * refactorAc fall back to the real defaultGreenVerifier.
+ */
+export function greenVerifierForEnv(env: NodeJS.ProcessEnv = process.env): GreenVerifier | undefined {
+  return env.LAKEBASE_TDD_REPLAY_BUILD_DIR ? replayTrustVerifier : undefined;
+}
+
+/**
  * Record the runner outcome + stamp GREEN on the story's open RED cycle (red_at
  * set, green_at not). Per the "driver runs, orchestration records" contract the
  * Driver already ran the project's test command in its loop; this records that

--- a/scripts/sftdd/cycle.cli.ts
+++ b/scripts/sftdd/cycle.cli.ts
@@ -22,6 +22,7 @@ import {
   refactorAc,
   firstReviewPendingAc,
   firstRefactorPendingAc,
+  greenVerifierForEnv,
 } from "./cycle-record.js";
 import {
   writeSupersededTests,
@@ -112,7 +113,11 @@ async function main(): Promise<number> {
       // app. On failure it leaves the cycle RED + raises an escalation; we exit
       // 0 (the escalation is recorded data, not a command crash) so the driver's
       // next readState routes to a clean raise-to-hil halt.
-      const r = await greenOpenCycle({ ...base, repair: a.repair });
+      // In a build replay (LAKEBASE_TDD_REPLAY_BUILD_DIR set) the per-turn
+      // full-suite honest-GREEN is invalid (a later AC's test is legitimately RED
+      // while only the current AC's code is overlaid), so trust the recorded GREEN
+      // for this turn; the final all-ACs state is verified at the deploy gate (FEIP-7702).
+      const r = await greenOpenCycle({ ...base, repair: a.repair, verify: greenVerifierForEnv() });
       if (r.needsAssess) {
         process.stdout.write(`cycle: GREEN verify failed for ${r.testId} -> Navigator assess (supersession vs regression): ${r.summary}\n`);
       } else if (r.escalated) {
@@ -144,7 +149,8 @@ async function main(): Promise<number> {
         process.stdout.write(`cycle: no AC awaiting refactor for ${a.story}\n`);
         return 0;
       }
-      const r = await refactorAc(tddDir, a.feature, a.story, ac);
+      // Same replay-build trust applies to the refactor re-verify (FEIP-7702).
+      const r = await refactorAc(tddDir, a.feature, a.story, ac, { verify: greenVerifierForEnv() });
       if (r.escalated) {
         process.stdout.write(`cycle: REFACTOR BLOCKED for ${ac} -> raised to HIL: ${r.summary}\n`);
       } else {

--- a/templates/project/common/scripts/run-tests.sh
+++ b/templates/project/common/scripts/run-tests.sh
@@ -57,7 +57,19 @@ elif [ -f "$REPO_ROOT/requirements.txt" ] || [ -f "$REPO_ROOT/pyproject.toml" ];
   # that can't see the venv's fastapi etc., and test collection crashes
   # with ModuleNotFoundError. Pass --extra dev so uv resolves against
   # the dev extras for the test invocation.
-  uv run --extra dev pytest "$@"
+  #
+  # E2E (tests/e2e) is owned by the dedicated Playwright block that enable-e2e
+  # appends below (it runs `playwright install chromium` first, then
+  # `pytest tests/e2e`). The base full run (no positional args, e.g. the deploy
+  # gate's `run-tests.sh`) must NOT collect tests/e2e, or pytest tries to launch
+  # a browser before that install ran and the run dies with "Failed to spawn:
+  # playwright" before the e2e block is reached. An explicit path arg is honored
+  # verbatim (the per-cycle layer runner). See FEIP-7702 follow-up.
+  if [ "$#" -eq 0 ]; then
+    uv run --extra dev pytest --ignore=tests/e2e
+  else
+    uv run --extra dev pytest "$@"
+  fi
 elif [ -f "$REPO_ROOT/package.json" ]; then
   # Node.js / Knex + Jest
   echo "Running Knex migrations..."

--- a/tests/bdd/enable-e2e.test.ts
+++ b/tests/bdd/enable-e2e.test.ts
@@ -315,3 +315,18 @@ describe("pr.yml template: project-root E2E step", () => {
     expect(yml).toMatch(/Phase 2/);
   });
 });
+
+describe("base run-tests.sh: the full run does not collect tests/e2e (FEIP-7702 follow-up)", () => {
+  const script = fs.readFileSync(KIT_RUN_TESTS_SH, "utf8");
+
+  it("the no-arg Python run passes --ignore=tests/e2e so e2e is owned by the appended Playwright block", () => {
+    // The deploy gate runs `./scripts/run-tests.sh` with no args. If the base
+    // pytest collected tests/e2e it would try to launch a browser and die with
+    // "Failed to spawn: playwright" BEFORE the enable-e2e-appended block runs
+    // `playwright install chromium`. So the no-arg run must ignore tests/e2e.
+    expect(script).toMatch(/if \[ "\$#" -eq 0 \]; then/);
+    expect(script).toMatch(/uv run --extra dev pytest --ignore=tests\/e2e/);
+    // An explicit path arg is still honored verbatim (the per-cycle layer runner).
+    expect(script).toMatch(/uv run --extra dev pytest "\$@"/);
+  });
+});

--- a/tests/bdd/sftdd-honest-green.test.ts
+++ b/tests/bdd/sftdd-honest-green.test.ts
@@ -19,6 +19,8 @@ import {
   reviewAc,
   refactorAc,
   firstRefactorPendingAc,
+  replayTrustVerifier,
+  greenVerifierForEnv,
   type GreenVerifier,
 } from "../../scripts/sftdd/cycle-record.js";
 import {
@@ -120,6 +122,36 @@ describe("honest GREEN: greenOpenCycle runs a real verify before stamping green"
     expect(r.escalated).toBeFalsy();
     expect(cycle("AC1").green_at).toBeTruthy();
     expect(readEscalations(tdd).filter((e) => !e.resolved_at).length).toBe(0);
+  });
+});
+
+// FEIP-7702: in replay-build mode the per-turn honest-GREEN full-suite verify is
+// invalid mid-build (a later AC's test is legitimately RED while its code is not
+// yet overlaid), so it must NOT fail the cycle. The replay trusts the recorded
+// GREEN per turn; the final all-ACs state is still verified at the deploy gate.
+describe("replay-build: per-turn green trusts the recorded outcome (FEIP-7702)", () => {
+  it("replayTrustVerifier passes without running a real verify (no deploy)", async () => {
+    const r = await replayTrustVerifier({ projectDir: "/does/not/exist", tddDir: tdd, featureId: F, story: S });
+    expect(r.passed).toBe(true);
+    expect(r.summary).toMatch(/replay-build/i);
+  });
+
+  it("greenOpenCycle with the replay verifier greens an open RED cycle where a real full-suite verify would fail", async () => {
+    beginNextPendingCycle({ tddDir: tdd, featureId: F, story: S });
+    const r = await greenOpenCycle({ tddDir: tdd, featureId: F, story: S, verify: replayTrustVerifier });
+    expect(r.recorded).toBe(true);
+    expect(r.escalated).toBeFalsy();
+    expect(r.needsAssess).toBeFalsy();
+    expect(cycle("AC1").green_at).toBeTruthy();
+    expect(readEscalations(tdd).filter((e) => !e.resolved_at).length).toBe(0);
+  });
+
+  it("greenVerifierForEnv returns the replay verifier ONLY when LAKEBASE_TDD_REPLAY_BUILD_DIR is set", async () => {
+    expect(greenVerifierForEnv({})).toBeUndefined();
+    const v = greenVerifierForEnv({ LAKEBASE_TDD_REPLAY_BUILD_DIR: "/corpus" });
+    expect(v).toBeDefined();
+    const r = await v!({ projectDir: "/x", tddDir: tdd, featureId: F, story: S });
+    expect(r.passed).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

Two fixes for the replay-build fast-forward path, both under FEIP-7702.

### 1. Replay-build trusts the recorded GREEN per turn
Per-cycle honest-GREEN runs the **whole** pytest suite against the running app. In a replay-build fast-forward, an overlaid intermediate-turn working tree carries a not-yet-built AC's test (a legitimate RED snapshot), so the full-suite verify halts the cycle spuriously.

- `replayTrustVerifier` + `greenVerifierForEnv(env)` in `scripts/sftdd/cycle-record.ts`: when `LAKEBASE_TDD_REPLAY_BUILD_DIR` is set, the per-turn green/refactor trusts the recorded GREEN instead of re-deploy + full-suite verify. The final state is still verified at the deploy gate.
- `scripts/sftdd/cycle.cli.ts` green + refactor handlers pass `verify: greenVerifierForEnv()`.
- Non-replay builds are unchanged (real `defaultGreenVerifier`).
- 3 new cases in `tests/bdd/sftdd-honest-green.test.ts`.

Live-validated: `run-to-release-engineer` drove through all 5 cycles with no per-turn halt and reached the Release Engineer + deploy.

### 2. Base run-tests.sh skips tests/e2e
The base no-arg `run-tests.sh` Python path collected `tests/e2e` before the enable-e2e-appended Playwright block could run `playwright install chromium`, so `set -e` killed the deploy gate's full-suite run with `Failed to spawn: playwright`. The base run now ignores `tests/e2e` (owned by the appended e2e block, which installs the browser first); an explicit path arg is still honored verbatim for the per-cycle layer runner.

- `templates/project/common/scripts/run-tests.sh`
- Guard test in `tests/bdd/enable-e2e.test.ts`.

## Test
Full vitest suite green: 2296 passed / 132 skipped.

This pull request and its description were written by Isaac.