### PR TITLE
feat(adapters): implement baseline on Flyway + Alembic adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`baseline` on the Flyway and Alembic adapters.** Both adapters now implement
+  the optional `baseline` capability from the ADR-0005 schema-migration-adapter
+  contract; previously it was declared on the interface but omitted by every
+  built-in adapter. `FlywayAdapter.baseline` wraps `flyway baseline` (new
+  `baselineFlyway` runner); `AlembicAdapter.baseline` wraps `alembic stamp` (new
+  `stampAlembic` runner) — Alembic's equivalent operation, with the contract's
+  `version` field carrying the target revision. Both stamp an existing,
+  already-populated schema at a version so pre-baseline migrations are treated as
+  applied and never re-run — the adoption path for a database whose schema
+  predates the migration tool. Additive and backward-compatible: callers that
+  property-check `adapter.baseline` before invoking are unaffected.
+
 ## [0.3.0-beta.6] - 2026-06-30
 
 EMU / CI robustness, surfaced by a partner project on an Enterprise Managed Users

--- a/scripts/lakebase/adapters/alembic-adapter.ts
+++ b/scripts/lakebase/adapters/alembic-adapter.ts
@@ -7,9 +7,9 @@
 // reimplementation.
 //
 // Alembic supports rollback natively (downgrade), so this adapter
-// implements the optional rollback method. baseline is deferred to a
-// follow-up slice; Alembic's `stamp` command is the equivalent, but
-// wiring it through cleanly requires runner changes.
+// implements the optional rollback method. baseline is implemented via
+// Alembic's `stamp` command (sets alembic_version without running
+// migration bodies) — the cross-tool equivalent of Flyway baseline.
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -21,6 +21,7 @@ import {
   listAlembicHeads,
   mergeAlembicHeads,
   rollbackAlembic,
+  stampAlembic,
   statusAlembic,
 } from "../schema-migrate-runners/alembic.js";
 import {
@@ -34,6 +35,8 @@ import {
   registerSchemaMigrationAdapter,
   type ApplyArgs,
   type ApplyResult,
+  type BaselineArgs,
+  type BaselineResult,
   type CollapseHeadsArgs,
   type CollapseHeadsResult,
   type ListArgs,
@@ -191,8 +194,30 @@ export const AlembicAdapter: SchemaMigrationAdapter = {
     return { files: listAlembicFiles(args.projectDir) };
   },
 
-  // baseline intentionally absent in slice 3. Alembic exposes `stamp`
-  // as the equivalent operation; deferred to a follow-up.
+  async baseline(args: BaselineArgs): Promise<BaselineResult> {
+    // Alembic has no `baseline` command; `stamp` is the equivalent — it sets
+    // alembic_version to the target revision without running migration bodies.
+    // The cross-tool contract's `version` field carries the revision id here.
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await stampAlembic({
+        projectDir: args.projectDir,
+        dsn,
+        revision: args.version,
+      });
+      return {
+        status: "ok",
+        baseline_version: legacy.stampedRevision,
+        tool_specific: { tool: legacy.tool },
+      };
+    } catch (err) {
+      return {
+        status: "error",
+        baseline_version: null,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
 
   async newMigration(args: NewMigrationArgs): Promise<NewMigrationResult> {
     try {

--- a/scripts/lakebase/adapters/flyway-adapter.ts
+++ b/scripts/lakebase/adapters/flyway-adapter.ts
@@ -8,7 +8,9 @@
 //
 // Note: Flyway Community Edition does NOT support rollback. The adapter
 // omits the `rollback` method per the ADR-0005 optional-capability
-// protocol; callers MUST property-check before invoking.
+// protocol; callers MUST property-check before invoking. `baseline` IS
+// supported (stamps an existing schema at a version so pre-baseline
+// migrations are treated as applied).
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -16,6 +18,7 @@ import * as path from "node:path";
 import { getConnection } from "../get-connection.js";
 import {
   applyFlyway,
+  baselineFlyway,
   statusFlyway,
 } from "../schema-migrate-runners/flyway.js";
 import {
@@ -29,6 +32,8 @@ import {
   registerSchemaMigrationAdapter,
   type ApplyArgs,
   type ApplyResult,
+  type BaselineArgs,
+  type BaselineResult,
   type ListArgs,
   type ListResult,
   type NewMigrationArgs,
@@ -143,10 +148,28 @@ export const FlywayAdapter: SchemaMigrationAdapter = {
     return { files: listFlywayFiles(args.projectDir) };
   },
 
-  // baseline intentionally absent. Flyway DOES support baseline at the
-  // tool level, but exposing it cleanly requires plumbing flags into the
-  // existing runner. Deferred to a follow-up slice; the adapter's
-  // optional-protocol shape makes this additive.
+  async baseline(args: BaselineArgs): Promise<BaselineResult> {
+    const dsn = await buildDsn(args);
+    try {
+      const legacy = await baselineFlyway({
+        projectDir: args.projectDir,
+        dsn,
+        version: args.version,
+        description: args.description,
+      });
+      return {
+        status: "ok",
+        baseline_version: legacy.baselineVersion,
+        tool_specific: { tool: legacy.tool },
+      };
+    } catch (err) {
+      return {
+        status: "error",
+        baseline_version: null,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
 
   async newMigration(args: NewMigrationArgs): Promise<NewMigrationResult> {
     // Flyway has no `generate` command: migrations are hand-written SQL whose

--- a/scripts/lakebase/schema-migrate-runners/alembic.ts
+++ b/scripts/lakebase/schema-migrate-runners/alembic.ts
@@ -169,6 +169,25 @@ export async function mergeAlembicHeads(projectDir: string, message: string): Pr
   return m[1].trim();
 }
 
+export interface StampAlembicResult {
+  /** The revision the alembic_version table was stamped at. */
+  stampedRevision: string;
+  tool: "alembic";
+}
+
+/**
+ * `alembic stamp <rev>` sets the DB's alembic_version to <rev> WITHOUT running
+ * any migration bodies. This is Alembic's equivalent of Flyway's baseline: it
+ * marks a database whose schema already matches <rev> as being at that revision,
+ * so revisions at or below it are treated as applied and never re-run.
+ */
+export async function stampAlembic(
+  ctx: RunnerCtx & { revision: string }
+): Promise<StampAlembicResult> {
+  await runAlembic(ctx, ["stamp", ctx.revision]);
+  return { stampedRevision: ctx.revision, tool: "alembic" };
+}
+
 /** Return the currently-applied head revision, or undefined when the DB has no Alembic state. */
 async function getCurrentRevision(ctx: RunnerCtx): Promise<string | undefined> {
   const { stdout } = await runAlembic(ctx, ["current"]);

--- a/scripts/lakebase/schema-migrate-runners/flyway.ts
+++ b/scripts/lakebase/schema-migrate-runners/flyway.ts
@@ -188,6 +188,31 @@ export async function applyFlyway(ctx: FlywayCtx): Promise<ApplySchemaMigrations
   };
 }
 
+export interface BaselineFlywayResult {
+  /** The version the schema history table was baselined at. */
+  baselineVersion: string;
+  tool: "flyway";
+}
+
+export async function baselineFlyway(
+  ctx: FlywayCtx & { version: string; description?: string }
+): Promise<BaselineFlywayResult> {
+  // `flyway baseline` stamps an existing (already-populated) schema at a
+  // version so pre-baseline migrations are treated as applied and never
+  // re-run. This is the adoption path for a database whose schema predates
+  // Flyway: baseline at the current version, then future V<n> migrations
+  // above it apply normally.
+  //
+  // Distinct from applyFlyway's `-baselineOnMigrate`/`-baselineVersion=0`
+  // pairing, which anchors the AUTO-baseline at 0 so every user migration
+  // stays pending. Here the caller picks the explicit baseline version.
+  const args = [`-baselineVersion=${ctx.version}`];
+  if (ctx.description) args.push(`-baselineDescription=${ctx.description}`);
+  args.push("baseline");
+  await runFlyway(ctx, args);
+  return { baselineVersion: ctx.version, tool: "flyway" };
+}
+
 export async function rollbackFlyway(
   _ctx: FlywayCtx & { target: string }
 ): Promise<RollbackSchemaMigrationResult> {

--- a/tests/bdd/alembic-adapter.test.ts
+++ b/tests/bdd/alembic-adapter.test.ts
@@ -44,14 +44,15 @@ describe("AlembicAdapter: static surface", () => {
     expect(typeof AlembicAdapter.rollback).toBe("function");
   });
 
-  it("omits baseline in slice 3 (Alembic stamp deferred)", () => {
-    expect(typeof AlembicAdapter.baseline).toBe("undefined");
+  it("implements baseline (via Alembic stamp)", () => {
+    expect(typeof AlembicAdapter.baseline).toBe("function");
   });
 
-  it("apply + status + list are all functions", () => {
+  it("apply + status + list + baseline are all functions", () => {
     expect(typeof AlembicAdapter.apply).toBe("function");
     expect(typeof AlembicAdapter.status).toBe("function");
     expect(typeof AlembicAdapter.list).toBe("function");
+    expect(typeof AlembicAdapter.baseline).toBe("function");
   });
 });
 

--- a/tests/bdd/flyway-adapter.test.ts
+++ b/tests/bdd/flyway-adapter.test.ts
@@ -42,14 +42,15 @@ describe("FlywayAdapter: static surface", () => {
     expect(typeof FlywayAdapter.rollback).toBe("undefined");
   });
 
-  it("omits baseline in slice 2 (deferred to a follow-up)", () => {
-    expect(typeof FlywayAdapter.baseline).toBe("undefined");
+  it("implements baseline (Flyway supports it at the tool level)", () => {
+    expect(typeof FlywayAdapter.baseline).toBe("function");
   });
 
-  it("apply + status + list are all functions", () => {
+  it("apply + status + list + baseline are all functions", () => {
     expect(typeof FlywayAdapter.apply).toBe("function");
     expect(typeof FlywayAdapter.status).toBe("function");
     expect(typeof FlywayAdapter.list).toBe("function");
+    expect(typeof FlywayAdapter.baseline).toBe("function");
   });
 });
 


### PR DESCRIPTION
## What

Implements the optional `baseline()` capability on the Flyway and Alembic adapters. The `SchemaMigrationAdapter` contract (ADR-0005) has always declared `baseline?()`, but every built-in adapter omitted it (flagged as a deferred follow-up slice in both adapter files).

- **`FlywayAdapter.baseline`** → new `baselineFlyway` runner (`flyway baseline -baselineVersion=<v> [-baselineDescription=<d>]`).
- **`AlembicAdapter.baseline`** → new `stampAlembic` runner (`alembic stamp <rev>`), Alembic's equivalent operation. The contract's `version` field carries the target revision.

Both stamp an already-populated schema at a version so pre-baseline migrations are treated as applied and never re-run — the adoption path for a database whose schema predates the migration tool.

## Why

Closes the two `// baseline intentionally absent … deferred to a follow-up` TODOs. Additive and backward-compatible: callers property-check `adapter.baseline` before invoking, so anything treating it as absent is unaffected. `apply`/`status`/`rollback` runner behavior is unchanged.

## Testing

- **Tier 1 (hermetic, `npm test`):** ✅ 2408 passed, 0 failed. Updated the Flyway + Alembic adapter contract tests (static surface now asserts `baseline` is present).
- **`npm run typecheck`:** ✅ clean.
- **Tier 3 (live):** ⚠️ **not run** — I don't have a billable Lakebase workspace wired for the integration suite in this environment. Live `baseline`/`stamp` behavior is not exercised by an automated run here; the change mirrors the existing `apply`/`status` runner+adapter pattern (same DSN seam, same error shape). Flagging per CONTRIBUTING so a reviewer with workspace access can green Tier 3, or advise if you'd like a live-integration assertion added for `baseline`.

## Notes

- Follows the repo convention that feature PRs don't include rebuilt `dist/` (shipped separately in `build:`/`release:` commits).
- No CLI subcommand added — that's slice 4 per ADR-0005. This PR is the adapter+runner capability only.
