### PR TITLE
fix(security): keep Lakebase PAT off the command line + unify shell escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Lakebase-auth PAT no longer passed on the command line.**
+  `ensureLakebaseSecretAuth` stored the minted PAT with
+  `databricks secrets put-secret … --string-value "<pat>"`, which exposed the
+  secret in the process table (`ps`) and any shell trace for the call's
+  lifetime. The PAT is now fed to the CLI on **stdin** (the documented
+  alternative to `--string-value`), so it never appears as a process argument.
+  `exec()` gained an `input` option to support this.
+- **Hardened shell-out escaping across the deploy/UC/secret seams.** Six
+  modules (`secret-auth`, `deploy-credentials`, `deploy-rollback`,
+  `uc-resources`, `databricks-host`, `deploy-app-endpoint`) each defined a local
+  `escapeShellArg` that only escaped `"` — leaving `$`, backticks, and other
+  shell metacharacters active inside the double-quoted interpolations, a
+  correctness bug (and injection surface) for any scope / key / catalog /
+  comment value containing them. All call sites now use the canonical POSIX
+  single-quote escaper `shq()` from `util/exec.ts`; the duplicated local
+  escapers are deleted.
+
 ## [0.3.0-beta.6] - 2026-06-30
 
 EMU / CI robustness, surfaced by a partner project on an Enterprise Managed Users

--- a/scripts/lakebase/databricks-host.ts
+++ b/scripts/lakebase/databricks-host.ts
@@ -13,7 +13,7 @@
 // token cache is invalidated by a CLI upgrade); we tolerate that by
 // trimming to the first `{` before parsing.
 
-import { exec } from "../util/exec.js";
+import { exec, shq } from "../util/exec.js";
 import { KIT_TIMEOUTS } from "./kit-config.js";
 
 export interface ResolveDatabricksHostArgs {
@@ -34,7 +34,7 @@ export async function resolveDatabricksHost(
 ): Promise<string | undefined> {
   const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
   const out = await exec(
-    `databricks auth describe --profile "${escapeShellArg(args.profile)}" -o json`,
+    `databricks auth describe --profile ${shq(args.profile)} -o json`,
     { timeout: timeoutMs }
   );
   return parseHostFromAuthDescribe(out);
@@ -60,6 +60,3 @@ export function parseHostFromAuthDescribe(out: string): string | undefined {
   }
 }
 
-function escapeShellArg(s: string): string {
-  return s.replace(/"/g, '\\"');
-}

--- a/scripts/lakebase/deploy-app-endpoint.ts
+++ b/scripts/lakebase/deploy-app-endpoint.ts
@@ -21,7 +21,7 @@
 // separately (slice 5).
 
 import { spawn } from "node:child_process";
-import { exec } from "../util/exec.js";
+import { exec, shq } from "../util/exec.js";
 import { KIT_TIMEOUTS } from "./kit-config.js";
 import { uploadDirectory, UploadDirectoryResult } from "./deploy-workspace-upload.js";
 
@@ -147,7 +147,7 @@ export async function getAppEndpoint(args: GetAppEndpointArgs): Promise<GetAppEn
   const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
   try {
     const stdout = await exec(
-      `databricks apps get "${escapeShellArg(args.appName)}" --profile "${escapeShellArg(args.profile)}" -o json`,
+      `databricks apps get ${shq(args.appName)} --profile ${shq(args.profile)} -o json`,
       { timeout: timeoutMs }
     );
     const info = JSON.parse(stdout) as Record<string, unknown>;
@@ -195,7 +195,7 @@ export async function deleteAppEndpoint(args: DeleteAppEndpointArgs): Promise<De
 
   try {
     await exec(
-      `databricks apps delete "${escapeShellArg(args.appName)}" --profile "${escapeShellArg(args.profile)}"`,
+      `databricks apps delete ${shq(args.appName)} --profile ${shq(args.profile)}`,
       { timeout: timeoutMs }
     );
     appDeleted = true;
@@ -217,7 +217,7 @@ export async function deleteAppEndpoint(args: DeleteAppEndpointArgs): Promise<De
   if (args.workspacePath) {
     try {
       await exec(
-        `databricks workspace delete "${escapeShellArg(args.workspacePath)}" --recursive --profile "${escapeShellArg(args.profile)}"`,
+        `databricks workspace delete ${shq(args.workspacePath)} --recursive --profile ${shq(args.profile)}`,
         { timeout: timeoutMs }
       );
       workspaceDeleted = true;
@@ -261,7 +261,7 @@ export async function ensureAppEndpoint(args: EnsureAppEndpointArgs): Promise<En
   let created = false;
   if (!lookup.exists) {
     await exec(
-      `databricks apps create "${escapeShellArg(args.appName)}" --description "${escapeShellArg(description)}" --profile "${escapeShellArg(args.profile)}"`,
+      `databricks apps create ${shq(args.appName)} --description ${shq(description)} --profile ${shq(args.profile)}`,
       { timeout: createTimeoutMs }
     );
     created = true;
@@ -325,10 +325,10 @@ export async function ensureAppEndpoint(args: EnsureAppEndpointArgs): Promise<En
 export async function getCiAppEndpoint(args: GetCiAppEndpointArgs): Promise<GetCiAppEndpointResult> {
   const appName = args.appName ?? deriveCiAppName(args.instance, args.branch);
   const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
-  const profileFlag = args.profile ? ` --profile "${escapeShellArg(args.profile)}"` : "";
+  const profileFlag = args.profile ? ` --profile ${shq(args.profile)}` : "";
   try {
     const stdout = await exec(
-      `databricks apps get "${escapeShellArg(appName)}"${profileFlag} -o json`,
+      `databricks apps get ${shq(appName)}${profileFlag} -o json`,
       { timeout: timeoutMs }
     );
     const info = JSON.parse(stdout) as Record<string, unknown>;
@@ -425,6 +425,3 @@ function runDeploy(args: {
   });
 }
 
-function escapeShellArg(s: string): string {
-  return s.replace(/"/g, '\\"');
-}

--- a/scripts/lakebase/deploy-credentials.ts
+++ b/scripts/lakebase/deploy-credentials.ts
@@ -13,7 +13,7 @@
 // DeployTarget + profile + appName, it resolves the SP, grants the
 // permission(s), returns a structured result.
 
-import { exec } from "../util/exec.js";
+import { exec, shq } from "../util/exec.js";
 import { KIT_TIMEOUTS } from "./kit-config.js";
 import { DeployTarget } from "./deploy-targets.js";
 import { getAppEndpoint } from "./deploy-app-endpoint.js";
@@ -111,7 +111,7 @@ export async function grantLakebasePermission(
     ],
   });
   await exec(
-    `databricks api patch "/api/2.0/permissions/database-projects/${escapeShellArg(args.projectName)}" --profile "${escapeShellArg(args.profile)}" --json '${escapeSingleQuoted(payload)}'`,
+    `databricks api patch /api/2.0/permissions/database-projects/${shq(args.projectName)} --profile ${shq(args.profile)} --json ${shq(payload)}`,
     { timeout: timeoutMs }
   );
   return { granted: true };
@@ -178,15 +178,3 @@ export async function propagateCredentials(
   };
 }
 
-// ─── helpers ────────────────────────────────────────────────────
-
-function escapeShellArg(s: string): string {
-  return s.replace(/"/g, '\\"');
-}
-
-function escapeSingleQuoted(s: string): string {
-  // Within single-quoted shell strings, the only escape needed is to
-  // close + reopen for embedded apostrophes. The JSON payload itself
-  // contains no apostrophes, but harden anyway for future-proofing.
-  return s.replace(/'/g, `'\\''`);
-}

--- a/scripts/lakebase/deploy-rollback.ts
+++ b/scripts/lakebase/deploy-rollback.ts
@@ -22,7 +22,7 @@
 // structured result shape as `ensureAppEndpoint`.
 
 import { spawn } from "node:child_process";
-import { exec } from "../util/exec.js";
+import { exec, shq } from "../util/exec.js";
 import { KIT_TIMEOUTS } from "./kit-config.js";
 
 export interface RollbackDeployArgs {
@@ -71,7 +71,7 @@ export async function listAppDeployments(args: {
 }): Promise<DeploymentInfo[]> {
   const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
   const stdout = await exec(
-    `databricks apps list-deployments "${escapeShellArg(args.appName)}" --profile "${escapeShellArg(args.profile)}" -o json`,
+    `databricks apps list-deployments ${shq(args.appName)} --profile ${shq(args.profile)} -o json`,
     { timeout: timeoutMs }
   );
   const parsed = JSON.parse(stdout) as unknown;
@@ -218,6 +218,3 @@ function runRollbackDeploy(args: {
   });
 }
 
-function escapeShellArg(s: string): string {
-  return s.replace(/"/g, '\\"');
-}

--- a/scripts/lakebase/secret-auth.ts
+++ b/scripts/lakebase/secret-auth.ts
@@ -10,7 +10,7 @@
 // Lifted from the lakebase-scm-extension's bespoke
 // DeployService.ensureLakebaseSecretAuth.
 
-import { exec } from "../util/exec.js";
+import { exec, shq } from "../util/exec.js";
 import { KIT_TIMEOUTS } from "./kit-config.js";
 
 const NINETY_DAYS_SECONDS = 90 * 24 * 60 * 60;
@@ -79,7 +79,7 @@ export async function ensureLakebaseSecretAuth(
   let scopeCreated = false;
   try {
     await exec(
-      `databricks secrets create-scope "${escapeShellArg(scopeName)}" --profile "${escapeShellArg(profile)}"`,
+      `databricks secrets create-scope ${shq(scopeName)} --profile ${shq(profile)}`,
       { timeout: timeoutMs }
     );
     scopeCreated = true;
@@ -90,7 +90,7 @@ export async function ensureLakebaseSecretAuth(
 
   // 2. Mint PAT
   const tokenJson = await exec(
-    `databricks tokens create --comment "${escapeShellArg(tokenComment)}" --lifetime-seconds ${tokenLifetimeSeconds} -o json --profile "${escapeShellArg(profile)}"`,
+    `databricks tokens create --comment ${shq(tokenComment)} --lifetime-seconds ${tokenLifetimeSeconds} -o json --profile ${shq(profile)}`,
     { timeout: timeoutMs }
   );
   const tokenStart = tokenJson.indexOf("{");
@@ -103,10 +103,12 @@ export async function ensureLakebaseSecretAuth(
     throw new Error("databricks tokens create returned no token_value");
   }
 
-  // 3. Store the PAT
+  // 3. Store the PAT. Feed it on stdin (the CLI reads the value from stdin
+  // when --string-value is omitted) so the secret never appears on the
+  // command line / in the process table.
   await exec(
-    `databricks secrets put-secret "${escapeShellArg(scopeName)}" "${escapeShellArg(keyName)}" --string-value "${escapeShellArg(pat)}" --profile "${escapeShellArg(profile)}"`,
-    { timeout: timeoutMs }
+    `databricks secrets put-secret ${shq(scopeName)} ${shq(keyName)} --profile ${shq(profile)}`,
+    { timeout: timeoutMs, input: pat }
   );
 
   // 4. ACL (best-effort)
@@ -114,7 +116,7 @@ export async function ensureLakebaseSecretAuth(
   if (servicePrincipalClientId) {
     try {
       await exec(
-        `databricks secrets put-acl "${escapeShellArg(scopeName)}" "${escapeShellArg(servicePrincipalClientId)}" READ --profile "${escapeShellArg(profile)}"`,
+        `databricks secrets put-acl ${shq(scopeName)} ${shq(servicePrincipalClientId)} READ --profile ${shq(profile)}`,
         { timeout: timeoutMs }
       );
       aclGranted = true;
@@ -134,8 +136,4 @@ export async function ensureLakebaseSecretAuth(
 
 function isAlreadyExistsError(msg: string): boolean {
   return /already exists|SCOPE_ALREADY_EXISTS|RESOURCE_ALREADY_EXISTS/i.test(msg);
-}
-
-function escapeShellArg(s: string): string {
-  return s.replace(/"/g, '\\"');
 }

--- a/scripts/lakebase/uc-resources.ts
+++ b/scripts/lakebase/uc-resources.ts
@@ -10,7 +10,7 @@
 // are idempotent (existence check + conditional create), and the
 // permission grant matches the platform's standard CHANGES shape.
 
-import { exec } from "../util/exec.js";
+import { exec, shq } from "../util/exec.js";
 import { KIT_TIMEOUTS } from "./kit-config.js";
 
 const DEFAULT_CREATE_COMMENT = "Created by lakebase-app-dev-kit";
@@ -30,7 +30,7 @@ export async function catalogExists(args: CatalogExistsArgs): Promise<boolean> {
   const timeoutMs = args.timeoutMs ?? KIT_TIMEOUTS.cliDefault;
   try {
     await exec(
-      `databricks api get /api/2.1/unity-catalog/catalogs/${escapeShellArg(args.catalog)} --profile "${escapeShellArg(args.profile)}"`,
+      `databricks api get /api/2.1/unity-catalog/catalogs/${shq(args.catalog)} --profile ${shq(args.profile)}`,
       { timeout: timeoutMs }
     );
     return true;
@@ -68,7 +68,7 @@ export async function tryCreateCatalog(args: TryCreateCatalogArgs): Promise<TryC
   const payload = JSON.stringify({ name: args.catalog, comment });
   try {
     await exec(
-      `databricks api post /api/2.1/unity-catalog/catalogs --profile "${escapeShellArg(args.profile)}" --json '${escapeSingleQuoted(payload)}'`,
+      `databricks api post /api/2.1/unity-catalog/catalogs --profile ${shq(args.profile)} --json ${shq(payload)}`,
       { timeout: timeoutMs }
     );
     return { created: true };
@@ -116,7 +116,7 @@ export async function ensureSchemaAndVolume(
   if (!exists) {
     const payload = JSON.stringify({ name: schema, catalog_name: catalog, comment });
     await exec(
-      `databricks api post /api/2.1/unity-catalog/schemas --profile "${escapeShellArg(profile)}" --json '${escapeSingleQuoted(payload)}'`,
+      `databricks api post /api/2.1/unity-catalog/schemas --profile ${shq(profile)} --json ${shq(payload)}`,
       { timeout: timeoutMs }
     );
     schemaCreated = true;
@@ -138,7 +138,7 @@ export async function ensureSchemaAndVolume(
       comment,
     });
     await exec(
-      `databricks api post /api/2.1/unity-catalog/volumes --profile "${escapeShellArg(profile)}" --json '${escapeSingleQuoted(payload)}'`,
+      `databricks api post /api/2.1/unity-catalog/volumes --profile ${shq(profile)} --json ${shq(payload)}`,
       { timeout: timeoutMs }
     );
     volumeCreated = true;
@@ -199,7 +199,7 @@ export async function grantUcCatalogPermission(
     ],
   });
   await exec(
-    `databricks api patch /api/2.1/unity-catalog/permissions/catalog/${escapeShellArg(args.catalog)} --profile "${escapeShellArg(args.profile)}" --json '${escapeSingleQuoted(payload)}'`,
+    `databricks api patch /api/2.1/unity-catalog/permissions/catalog/${shq(args.catalog)} --profile ${shq(args.profile)} --json ${shq(payload)}`,
     { timeout: timeoutMs }
   );
   return { granted: true };
@@ -218,7 +218,7 @@ export function catalogExplorerUrl(workspaceHost: string): string {
 
 async function ucResourceExists(apiPath: string, profile: string, timeoutMs: number): Promise<boolean> {
   try {
-    await exec(`databricks api get ${apiPath} --profile "${escapeShellArg(profile)}"`, { timeout: timeoutMs });
+    await exec(`databricks api get ${apiPath} --profile ${shq(profile)}`, { timeout: timeoutMs });
     return true;
   } catch (err) {
     if (isUcMissingError((err as Error).message)) return false;
@@ -228,12 +228,4 @@ async function ucResourceExists(apiPath: string, profile: string, timeoutMs: num
 
 function isUcMissingError(msg: string): boolean {
   return /RESOURCE_DOES_NOT_EXIST|does not exist|status:? 404\b|NOT_FOUND/i.test(msg);
-}
-
-function escapeShellArg(s: string): string {
-  return s.replace(/"/g, '\\"');
-}
-
-function escapeSingleQuoted(s: string): string {
-  return s.replace(/'/g, `'\\''`);
 }

--- a/scripts/util/exec.ts
+++ b/scripts/util/exec.ts
@@ -9,6 +9,13 @@ export interface ExecOptions {
   env?: Record<string, string>;
   /** Milliseconds before SIGTERM. Default: 60_000. */
   timeout?: number;
+  /**
+   * Written to the child's stdin, then stdin is closed. Use this to feed a
+   * secret to a CLI that reads it from stdin (e.g. `databricks secrets
+   * put-secret` with no `--string-value`) so the value never appears in the
+   * command line / process table. Omit for commands that take no input.
+   */
+  input?: string;
 }
 
 /**
@@ -49,7 +56,7 @@ export function exec(command: string, opts: ExecOptions = {}): Promise<string> {
     if (opts.env) {
       options.env = { ...process.env, ...opts.env };
     }
-    cp.exec(command, options, (err, stdout, stderr) => {
+    const child = cp.exec(command, options, (err, stdout, stderr) => {
       if (err) {
         const msg = String(stderr || err.message);
         reject(new Error(`${command}: ${msg}`));
@@ -57,5 +64,10 @@ export function exec(command: string, opts: ExecOptions = {}): Promise<string> {
       }
       resolve(String(stdout).trim());
     });
+    if (opts.input !== undefined) {
+      // Feed the value on stdin, then close it, so a secret never rides on
+      // the command line (where `ps` / shell traces would expose it).
+      child.stdin?.end(opts.input);
+    }
   });
 }

--- a/tests/bdd/exec.test.ts
+++ b/tests/bdd/exec.test.ts
@@ -22,4 +22,18 @@ describe("exec", () => {
     });
     expect(out).toBe("xyzzy");
   });
+
+  it("feeds `input` to the child on stdin", async () => {
+    // `cat` echoes back exactly what it reads from stdin, proving the value
+    // reached the child without appearing anywhere on the command line.
+    const out = await exec("cat", { input: "secret-on-stdin" });
+    expect(out).toBe("secret-on-stdin");
+  });
+
+  it("closes stdin so a stdin-reading command terminates", async () => {
+    // Without end()ing stdin, `cat` would block until timeout. A prompt
+    // return proves the stream was closed.
+    const out = await exec("cat", { input: "" });
+    expect(out).toBe("");
+  });
 });


### PR DESCRIPTION
## What

Two hardening fixes to the deploy / UC / secret shell-out seams.

### 1. 🔴 Lakebase PAT no longer passed on the command line
`ensureLakebaseSecretAuth` stored the minted PAT with:

```
databricks secrets put-secret <scope> <key> --string-value "<pat>" …
```

`--string-value` puts the secret in the process table (`ps auxww`) and any shell trace for the call's lifetime — visible to any other process/user on the host. This is the one file that mints and stores a long-lived token, so it's the highest-value seam to fix.

The Databricks CLI documents **stdin** as the alternative to `--string-value` ("Pass the secret via standard input"). The PAT is now fed on stdin, so it never appears as a process argument. `exec()` gains an `input` option that writes to the child's stdin and closes it.

> Note: `get-connection.ts` already uses `execFileSync` (no shell) *specifically* to keep short-lived credentials out of `ps` — this brings the PAT path up to the same bar.

### 2. 🟠 Unified shell escaping on the canonical `shq()`
Six modules — `secret-auth`, `deploy-credentials`, `deploy-rollback`, `uc-resources`, `databricks-host`, `deploy-app-endpoint` — each defined a local `escapeShellArg` that only escaped `"`. Inside the double-quoted interpolations they were used in, that left `$`, backticks, and other metacharacters **shell-active** — a correctness bug (and injection surface) for any scope / key / catalog / comment value containing them.

All call sites now use the canonical POSIX single-quote escaper **`shq()`** from `util/exec.ts` (already used throughout `scripts/git/*` and covered by `git-utils.test.ts`). The six duplicated local escapers are deleted.

## Why

Both are latent security/correctness gaps on the credential + deploy paths — exactly the surfaces that run against customer/partner workspaces. Behavior is unchanged for well-formed inputs; the fixes close the `ps` exposure and the metacharacter gap.

## Testing

- **Tier 1 (hermetic, `npm test`):** ✅ 2410 passed, 0 failed. Added `exec()` stdin coverage (`tests/bdd/exec.test.ts`); `shq` correctness is already covered in `git-utils.test.ts`.
- **`npm run typecheck`:** ✅ clean.
- **Tier 3 (live):** ⚠️ **not run** — no billable Lakebase workspace wired for the integration suite in this environment. The changed CLI invocations are argument-quoting/stdin only (no endpoint/flag semantics changed); the `put-secret` stdin path is the CLI's documented equivalent of `--string-value`. Flagging per CONTRIBUTING so a reviewer with workspace access can green Tier 3.

## Notes

- Follows the repo convention that feature PRs don't include rebuilt `dist/` (shipped separately in `build:`/`release:` commits).
- Independent of #166 (adapter baseline) — branches off `main`, no overlapping files.
