### PR TITLE
fix: HITL-first gates + hermetic replay (corpus completeness + no-agent-takeover) [field feedback 2026-07-14]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
-# From databricks-solutions org init
-*conf*.json
+# Runtime per-run config snapshot (rebuilt every drive; never a tracked artifact).
+# NB: this replaces an org-init `*conf*.json` glob that was catastrophically
+# over-broad , it silently dropped every corpus/data json with "conf" in its name
+# (AC files like *-confirmed.json, *-nonconforming-*.json, and client tsconfig.json
+# in recorded code trees), so shipped scenario corpora were missing ACs. Anchor to
+# the actual runtime file by exact basename instead.
+run-config.json
+# Turn-recorder runtime state (per-capture; not a shipped corpus artifact).
+.recorder-state.json
 .DS_Store
 __pycache__
 .idea/

--- a/examples/sftdd-scenarios/stockflow/recorded-artifacts/features/F1-stock-visibility/stories/S1-record-stock/acs/AC2-file-new-stock-confirmed.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-artifacts/features/F1-stock-visibility/stories/S1-record-stock/acs/AC2-file-new-stock-confirmed.json
@@ -1,0 +1,13 @@
+{
+  "id": "AC2-file-new-stock-confirmed",
+  "given": "the record-stock form with a SKU and physical location that have no stock record yet",
+  "when": "the operator enters a quantity and a combined inventory_code and files the record",
+  "then": "the stock is recorded for that (sku, location) with the entered quantity and inventory_code, and a save confirmation is shown",
+  "status": "passing",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC1 only asserts the empty form is displayed; this AC adds the observable outcome that a submitted new record is persisted and confirmed."
+  },
+  "layer": "E2E",
+  "architectural_notes": "E2E: the full write path, SPA form -> JSON boundary (app/routes/) -> service (app/services/) -> repository (app/repositories/) -> stock_records on the paired branch, then a save confirmation echoed client-side. The service owns the create-or-update rule and sets the immutable created_at/actor (R1); the repository is the ONLY layer that touches the ORM/session; the boundary never imports the DB session. Realizes durable persistence of a new (sku, location) record with the entered quantity and inventory_code (PI2 NOT NULL, PI3 quantity >= 0). Verified as a real-branch integration test (R4), never mocked."
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-artifacts/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC1-backfill-conforming-codes.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-artifacts/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC1-backfill-conforming-codes.json
@@ -1,0 +1,9 @@
+{
+  "id": "AC1-backfill-conforming-codes",
+  "given": "existing stock rows whose inventory_code parses by delimiter into a location, batch and serial segment (for example \"A12-B7-S001\")",
+  "when": "the split migration runs against those rows",
+  "then": "each such row gains batch_number equal to the batch segment and serial_number equal to the serial segment taken from the existing code",
+  "status": "passing",
+  "layer": "Infra",
+  "architectural_notes": "Infra: a data-store contract on the shape and contents of stock_records after the Alembic revision runs against the paired branch. The delimiter parse (split inventory_code on '-', segment 2 -> batch_number, segment 3 -> serial_number) is one-off migration logic that lives in the Alembic revision under migrations/versions/, NOT in app/services or app/models, so the running domain never carries backfill code. Owner module: the split Alembic revision; the app/models/ stock model is updated to expose the two new columns. Verified by a real-branch integration test that seeds conforming rows and asserts the backfilled values."
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-artifacts/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC2-nonconforming-left-null.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-artifacts/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC2-nonconforming-left-null.json
@@ -1,0 +1,13 @@
+{
+  "id": "AC2-nonconforming-left-null",
+  "given": "existing stock rows whose inventory_code lacks a batch or serial segment (for example \"X-1\" or a bare \"c\")",
+  "when": "the split migration runs against those rows",
+  "then": "each such row has batch_number and serial_number left NULL rather than guessed or dropped",
+  "status": "passing",
+  "layer": "Infra",
+  "architectural_notes": "Infra: a schema-shape contract realized by declaring batch_number and serial_number as NULLABLE columns (deliberate absence of NOT NULL). Because the columns permit NULL, the Alembic backfill records nonconforming codes as NULL rather than rejecting the row or guessing a value; no CHECK or NOT NULL constraint is added on these two columns. Owner module: the split Alembic revision (column definitions + backfill). Verified by a real-branch test seeding short/nonconforming codes (X-1, bare c) and asserting both columns are left NULL on those rows.",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC1 asserts conforming codes produce populated batch/serial values; this AC adds the distinct outcome that codes without those segments are recorded as NULL, which can be broken (by guessing a value) without breaking AC1's parse of conforming codes."
+  }
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-artifacts/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC5-nonconforming-count-reported.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-artifacts/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC5-nonconforming-count-reported.json
@@ -1,0 +1,13 @@
+{
+  "id": "AC5-nonconforming-count-reported",
+  "given": "a set of existing stock rows of which some inventory_codes do not parse as location-batch-serial",
+  "when": "the integrity probe is run for review before the change is accepted",
+  "then": "it surfaces the count of rows whose codes did not parse into batch and serial",
+  "status": "passing",
+  "layer": "Infra",
+  "architectural_notes": "Infra: a read-only integrity-probe contract on the branch, run for review before the change is accepted. This is a cross-cutting observability/reporting concern, NOT domain logic: a diagnostic query that counts rows whose inventory_code does not parse into location-batch-serial, surfaced to the reviewer. Owner module: an integrity-probe query shipped alongside the split Alembic revision (migration tooling), reading stock_records only. Verified by a real-branch test seeding a known mix of conforming/nonconforming codes and asserting the reported count matches the nonconforming subset.",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC2 asserts nonconforming rows are stored as NULL; this AC adds the distinct reporting outcome that their number is surfaced for review, which can be broken (no count reported, or a wrong count) while the NULL storage outcome still holds."
+  }
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/001-navigator-reflect/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/001-navigator-reflect/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/002-navigator-reflect/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/002-navigator-reflect/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/003-navigator/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/003-navigator/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/004-driver/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/004-driver/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/005-navigator-review/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S1-record-stock/turns/005-navigator-review/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/001-navigator-reflect/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/001-navigator-reflect/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/002-navigator-reflect/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/002-navigator-reflect/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/003-navigator/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/003-navigator/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/004-driver/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/004-driver/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/005-navigator-review/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S2-stock-by-location-home/turns/005-navigator-review/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/006-navigator-reflect/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/006-navigator-reflect/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/007-navigator-reflect/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/007-navigator-reflect/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/008-navigator/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/008-navigator/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/009-driver/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/009-driver/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/010-navigator-review/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F1-stock-visibility/stories/S3-sku-detail/turns/010-navigator-review/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S1-split-schema-migration/turns/001-navigator-reflect/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S1-split-schema-migration/turns/001-navigator-reflect/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S1-split-schema-migration/turns/002-navigator/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S1-split-schema-migration/turns/002-navigator/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S1-split-schema-migration/turns/003-driver/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S1-split-schema-migration/turns/003-driver/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S1-split-schema-migration/turns/004-navigator-review/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S1-split-schema-migration/turns/004-navigator-review/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/005-navigator-reflect/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/005-navigator-reflect/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/006-navigator/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/006-navigator/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/007-driver/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/007-driver/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/008-navigator-review/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/008-navigator-review/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/009-driver-refactor/code/client/tsconfig.json
+++ b/examples/sftdd-scenarios/stockflow/recorded-build/features/F6-split-tracking-code/stories/S2-detail-view-split-fields/turns/009-driver-refactor/code/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "tests/setup.ts"]
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0008-spec-author/files/.sftdd/features/F1-stock-visibility/stories/S1-record-stock/acs/AC2-file-new-stock-confirmed.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0008-spec-author/files/.sftdd/features/F1-stock-visibility/stories/S1-record-stock/acs/AC2-file-new-stock-confirmed.json
@@ -1,0 +1,12 @@
+{
+  "id": "AC2-file-new-stock-confirmed",
+  "given": "the record-stock form with a SKU and physical location that have no stock record yet",
+  "when": "the operator enters a quantity and a combined inventory_code and files the record",
+  "then": "the stock is recorded for that (sku, location) with the entered quantity and inventory_code, and a save confirmation is shown",
+  "status": "draft",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC1 only asserts the empty form is displayed; this AC adds the observable outcome that a submitted new record is persisted and confirmed."
+  },
+  "layer": "E2E"
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0009-architect-reviewer/files/.sftdd/features/F1-stock-visibility/stories/S1-record-stock/acs/AC2-file-new-stock-confirmed.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0009-architect-reviewer/files/.sftdd/features/F1-stock-visibility/stories/S1-record-stock/acs/AC2-file-new-stock-confirmed.json
@@ -1,0 +1,13 @@
+{
+  "id": "AC2-file-new-stock-confirmed",
+  "given": "the record-stock form with a SKU and physical location that have no stock record yet",
+  "when": "the operator enters a quantity and a combined inventory_code and files the record",
+  "then": "the stock is recorded for that (sku, location) with the entered quantity and inventory_code, and a save confirmation is shown",
+  "status": "draft",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC1 only asserts the empty form is displayed; this AC adds the observable outcome that a submitted new record is persisted and confirmed."
+  },
+  "layer": "E2E",
+  "architectural_notes": "E2E: the full write path, SPA form -> JSON boundary (app/routes/) -> service (app/services/) -> repository (app/repositories/) -> stock_records on the paired branch, then a save confirmation echoed client-side. The service owns the create-or-update rule and sets the immutable created_at/actor (R1); the repository is the ONLY layer that touches the ORM/session; the boundary never imports the DB session. Realizes durable persistence of a new (sku, location) record with the entered quantity and inventory_code (PI2 NOT NULL, PI3 quantity >= 0). Verified as a real-branch integration test (R4), never mocked."
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0018-driver/files/.sftdd/features/F1-stock-visibility/stories/S1-record-stock/acs/AC2-file-new-stock-confirmed.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0018-driver/files/.sftdd/features/F1-stock-visibility/stories/S1-record-stock/acs/AC2-file-new-stock-confirmed.json
@@ -1,0 +1,13 @@
+{
+  "id": "AC2-file-new-stock-confirmed",
+  "given": "the record-stock form with a SKU and physical location that have no stock record yet",
+  "when": "the operator enters a quantity and a combined inventory_code and files the record",
+  "then": "the stock is recorded for that (sku, location) with the entered quantity and inventory_code, and a save confirmation is shown",
+  "status": "passing",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC1 only asserts the empty form is displayed; this AC adds the observable outcome that a submitted new record is persisted and confirmed."
+  },
+  "layer": "E2E",
+  "architectural_notes": "E2E: the full write path, SPA form -> JSON boundary (app/routes/) -> service (app/services/) -> repository (app/repositories/) -> stock_records on the paired branch, then a save confirmation echoed client-side. The service owns the create-or-update rule and sets the immutable created_at/actor (R1); the repository is the ONLY layer that touches the ORM/session; the boundary never imports the DB session. Realizes durable persistence of a new (sku, location) record with the entered quantity and inventory_code (PI2 NOT NULL, PI3 quantity >= 0). Verified as a real-branch integration test (R4), never mocked."
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0065-spec-author/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC1-backfill-conforming-codes.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0065-spec-author/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC1-backfill-conforming-codes.json
@@ -1,0 +1,8 @@
+{
+  "id": "AC1-backfill-conforming-codes",
+  "given": "existing stock rows whose inventory_code parses by delimiter into a location, batch and serial segment (for example \"A12-B7-S001\")",
+  "when": "the split migration runs against those rows",
+  "then": "each such row gains batch_number equal to the batch segment and serial_number equal to the serial segment taken from the existing code",
+  "status": "draft",
+  "layer": "Infra"
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0065-spec-author/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC2-nonconforming-left-null.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0065-spec-author/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC2-nonconforming-left-null.json
@@ -1,0 +1,12 @@
+{
+  "id": "AC2-nonconforming-left-null",
+  "given": "existing stock rows whose inventory_code lacks a batch or serial segment (for example \"X-1\" or a bare \"c\")",
+  "when": "the split migration runs against those rows",
+  "then": "each such row has batch_number and serial_number left NULL rather than guessed or dropped",
+  "status": "draft",
+  "layer": "Infra",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC1 asserts conforming codes produce populated batch/serial values; this AC adds the distinct outcome that codes without those segments are recorded as NULL, which can be broken (by guessing a value) without breaking AC1's parse of conforming codes."
+  }
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0065-spec-author/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC5-nonconforming-count-reported.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0065-spec-author/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC5-nonconforming-count-reported.json
@@ -1,0 +1,12 @@
+{
+  "id": "AC5-nonconforming-count-reported",
+  "given": "a set of existing stock rows of which some inventory_codes do not parse as location-batch-serial",
+  "when": "the integrity probe is run for review before the change is accepted",
+  "then": "it surfaces the count of rows whose codes did not parse into batch and serial",
+  "status": "draft",
+  "layer": "Infra",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC2 asserts nonconforming rows are stored as NULL; this AC adds the distinct reporting outcome that their number is surfaced for review, which can be broken (no count reported, or a wrong count) while the NULL storage outcome still holds."
+  }
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0066-architect-reviewer/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC1-backfill-conforming-codes.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0066-architect-reviewer/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC1-backfill-conforming-codes.json
@@ -1,0 +1,9 @@
+{
+  "id": "AC1-backfill-conforming-codes",
+  "given": "existing stock rows whose inventory_code parses by delimiter into a location, batch and serial segment (for example \"A12-B7-S001\")",
+  "when": "the split migration runs against those rows",
+  "then": "each such row gains batch_number equal to the batch segment and serial_number equal to the serial segment taken from the existing code",
+  "status": "draft",
+  "layer": "Infra",
+  "architectural_notes": "Infra: a data-store contract on the shape and contents of stock_records after the Alembic revision runs against the paired branch. The delimiter parse (split inventory_code on '-', segment 2 -> batch_number, segment 3 -> serial_number) is one-off migration logic that lives in the Alembic revision under migrations/versions/, NOT in app/services or app/models, so the running domain never carries backfill code. Owner module: the split Alembic revision; the app/models/ stock model is updated to expose the two new columns. Verified by a real-branch integration test that seeds conforming rows and asserts the backfilled values."
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0066-architect-reviewer/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC2-nonconforming-left-null.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0066-architect-reviewer/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC2-nonconforming-left-null.json
@@ -1,0 +1,13 @@
+{
+  "id": "AC2-nonconforming-left-null",
+  "given": "existing stock rows whose inventory_code lacks a batch or serial segment (for example \"X-1\" or a bare \"c\")",
+  "when": "the split migration runs against those rows",
+  "then": "each such row has batch_number and serial_number left NULL rather than guessed or dropped",
+  "status": "draft",
+  "layer": "Infra",
+  "architectural_notes": "Infra: a schema-shape contract realized by declaring batch_number and serial_number as NULLABLE columns (deliberate absence of NOT NULL). Because the columns permit NULL, the Alembic backfill records nonconforming codes as NULL rather than rejecting the row or guessing a value; no CHECK or NOT NULL constraint is added on these two columns. Owner module: the split Alembic revision (column definitions + backfill). Verified by a real-branch test seeding short/nonconforming codes (X-1, bare c) and asserting both columns are left NULL on those rows.",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC1 asserts conforming codes produce populated batch/serial values; this AC adds the distinct outcome that codes without those segments are recorded as NULL, which can be broken (by guessing a value) without breaking AC1's parse of conforming codes."
+  }
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0066-architect-reviewer/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC5-nonconforming-count-reported.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0066-architect-reviewer/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC5-nonconforming-count-reported.json
@@ -1,0 +1,13 @@
+{
+  "id": "AC5-nonconforming-count-reported",
+  "given": "a set of existing stock rows of which some inventory_codes do not parse as location-batch-serial",
+  "when": "the integrity probe is run for review before the change is accepted",
+  "then": "it surfaces the count of rows whose codes did not parse into batch and serial",
+  "status": "draft",
+  "layer": "Infra",
+  "architectural_notes": "Infra: a read-only integrity-probe contract on the branch, run for review before the change is accepted. This is a cross-cutting observability/reporting concern, NOT domain logic: a diagnostic query that counts rows whose inventory_code does not parse into location-batch-serial, surfaced to the reviewer. Owner module: an integrity-probe query shipped alongside the split Alembic revision (migration tooling), reading stock_records only. Verified by a real-branch test seeding a known mix of conforming/nonconforming codes and asserting the reported count matches the nonconforming subset.",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC2 asserts nonconforming rows are stored as NULL; this AC adds the distinct reporting outcome that their number is surfaced for review, which can be broken (no count reported, or a wrong count) while the NULL storage outcome still holds."
+  }
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0074-driver/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC1-backfill-conforming-codes.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0074-driver/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC1-backfill-conforming-codes.json
@@ -1,0 +1,9 @@
+{
+  "id": "AC1-backfill-conforming-codes",
+  "given": "existing stock rows whose inventory_code parses by delimiter into a location, batch and serial segment (for example \"A12-B7-S001\")",
+  "when": "the split migration runs against those rows",
+  "then": "each such row gains batch_number equal to the batch segment and serial_number equal to the serial segment taken from the existing code",
+  "status": "passing",
+  "layer": "Infra",
+  "architectural_notes": "Infra: a data-store contract on the shape and contents of stock_records after the Alembic revision runs against the paired branch. The delimiter parse (split inventory_code on '-', segment 2 -> batch_number, segment 3 -> serial_number) is one-off migration logic that lives in the Alembic revision under migrations/versions/, NOT in app/services or app/models, so the running domain never carries backfill code. Owner module: the split Alembic revision; the app/models/ stock model is updated to expose the two new columns. Verified by a real-branch integration test that seeds conforming rows and asserts the backfilled values."
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0074-driver/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC2-nonconforming-left-null.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0074-driver/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC2-nonconforming-left-null.json
@@ -1,0 +1,13 @@
+{
+  "id": "AC2-nonconforming-left-null",
+  "given": "existing stock rows whose inventory_code lacks a batch or serial segment (for example \"X-1\" or a bare \"c\")",
+  "when": "the split migration runs against those rows",
+  "then": "each such row has batch_number and serial_number left NULL rather than guessed or dropped",
+  "status": "passing",
+  "layer": "Infra",
+  "architectural_notes": "Infra: a schema-shape contract realized by declaring batch_number and serial_number as NULLABLE columns (deliberate absence of NOT NULL). Because the columns permit NULL, the Alembic backfill records nonconforming codes as NULL rather than rejecting the row or guessing a value; no CHECK or NOT NULL constraint is added on these two columns. Owner module: the split Alembic revision (column definitions + backfill). Verified by a real-branch test seeding short/nonconforming codes (X-1, bare c) and asserting both columns are left NULL on those rows.",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC1 asserts conforming codes produce populated batch/serial values; this AC adds the distinct outcome that codes without those segments are recorded as NULL, which can be broken (by guessing a value) without breaking AC1's parse of conforming codes."
+  }
+}

--- a/examples/sftdd-scenarios/stockflow/turns/0074-driver/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC5-nonconforming-count-reported.json
+++ b/examples/sftdd-scenarios/stockflow/turns/0074-driver/files/.sftdd/features/F6-split-tracking-code/stories/S1-split-schema-migration/acs/AC5-nonconforming-count-reported.json
@@ -1,0 +1,13 @@
+{
+  "id": "AC5-nonconforming-count-reported",
+  "given": "a set of existing stock rows of which some inventory_codes do not parse as location-batch-serial",
+  "when": "the integrity probe is run for review before the change is accepted",
+  "then": "it surfaces the count of rows whose codes did not parse into batch and serial",
+  "status": "passing",
+  "layer": "Infra",
+  "architectural_notes": "Infra: a read-only integrity-probe contract on the branch, run for review before the change is accepted. This is a cross-cutting observability/reporting concern, NOT domain logic: a diagnostic query that counts rows whose inventory_code does not parse into location-batch-serial, surfaced to the reviewer. Owner module: an integrity-probe query shipped alongside the split Alembic revision (migration tooling), reading stock_records only. Verified by a real-branch test seeding a known mix of conforming/nonconforming codes and asserting the reported count matches the nonconforming subset.",
+  "independence": {
+    "distinct_from_prior": true,
+    "rationale": "AC2 asserts nonconforming rows are stored as NULL; this AC adds the distinct reporting outcome that their number is surfaced for review, which can be broken (no count reported, or a wrong count) while the NULL storage outcome still holds."
+  }
+}

--- a/examples/tdd-workflow-smoke/orchestrator/_replay-smoke.sh
+++ b/examples/tdd-workflow-smoke/orchestrator/_replay-smoke.sh
@@ -197,11 +197,17 @@ replay_smoke() {
   # same run on Y , it does NOT bail out of the state machine. The pause is
   # INTERNAL to this one drive process, so recording + the turn timeline span
   # design and build continuously (as if there were no pause).
-  local GATES_FLAG=""
+  # This harness is headless BY CONSTRUCTION (it exports LAKEBASE_SFTDD_HUMAN_PROXY=1
+  # and its callers set LAKEBASE_SFTDD_AUTO_CONTINUE=1), so it ALWAYS runs the
+  # proxy gate policy: the Human Proxy approves each per-story spec gate without a
+  # human, in both the capture and replay directions. This is a deliberate,
+  # explicit opt-in , the project's declared gate policy is now interactive
+  # (HITL-first), and a run-scoped --gates never rewrites it. Before that flip this
+  # relied on proxy being the global default; declaring it here is the correct,
+  # self-describing behavior for an automated run.
+  local GATES_FLAG="--gates proxy"
   if [[ "${REPLAY_DESIGN:-1}" == "1" ]]; then
     export LAKEBASE_SFTDD_REPLAY_DIR="${CORPUS_DIR}"
-  else
-    GATES_FLAG="--gates proxy"
   fi
   if [[ "$REPLAY_BUILD" == "1" ]]; then
     [[ -d "$BUILD_CORPUS_DIR" ]] || { err "build corpus missing: $BUILD_CORPUS_DIR"; return 2; }

--- a/scripts/sftdd/drive.cli.ts
+++ b/scripts/sftdd/drive.cli.ts
@@ -185,6 +185,20 @@ class ClaudeTurnError extends Error {
   }
 }
 
+/** A replay lane (LAKEBASE_SFTDD_REPLAY_DIR / _REPLAY_BUILD_DIR) was told to
+ *  reproduce a turn the corpus has no artifact for. A replay is a RECORDING: it
+ *  must never fall through to a live agent (that would let an agent "take over"
+ *  a run meant to be deterministic, and silently mask a broken/incomplete
+ *  corpus). So a miss is a hard, loud failure that names the missing artifact.
+ *  Almost always the corpus is missing a file (e.g. a `.gitignore` glob dropped
+ *  it) , put the artifact in the right place, do not run the model. */
+class ReplayCorpusMissError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReplayCorpusMissError";
+  }
+}
+
 function spawnClaudeStreaming(args: string[], cwd: string): Promise<TurnUsage | undefined> {
   return new Promise((resolve, reject) => {
     // Capture BOTH stdout (the stream-json events) and stderr (claude's own
@@ -299,7 +313,10 @@ function execRunner(cfg: DriveEffectsConfig): CommandRunner {
         // cycle-record CLIs that stamp RED/GREEN against the overlaid code), so
         // every Navigator<->Driver event is reproduced , only the artifact
         // delivery is mocked. The Kth Navigator/Driver turn maps to the Kth
-        // recorded turn dir. A turn the corpus lacks falls through to the real agent.
+        // recorded turn dir. A replay is a RECORDING: a corpus miss is a HARD
+        // FAILURE (ReplayCorpusMissError), never a fall-through to a live agent ,
+        // an agent taking over would defeat the deterministic reproduction and
+        // silently mask an incomplete corpus.
         const replayBuildDir = sftddEnv("REPLAY_BUILD_DIR");
         const story = cmd.replay?.story;
         if (replayBuildDir && story && (cmd.role === "navigator" || cmd.role === "driver")) {
@@ -312,7 +329,20 @@ function execRunner(cfg: DriveEffectsConfig): CommandRunner {
           // skips reflect turns, so RED maps to the first real recorded build turn).
           if (cmd.replay?.buildMode === "reflect") {
             const rd = sftddEnv("REPLAY_DIR");
-            if (rd) restoreReflectVerdict({ replayDir: rd, sftddDir: cfg.sftddDir, featureId: cfg.featureId, story });
+            // The verdict lives in the DESIGN corpus. When it is present (REPLAY_DIR
+            // set), it MUST restore; a miss is a corpus defect, not a reason to run
+            // the Navigator live. (When REPLAY_DIR is unset the design lane is not
+            // being replayed, so there is no recorded verdict to restore here.)
+            if (rd) {
+              const restored = restoreReflectVerdict({ replayDir: rd, sftddDir: cfg.sftddDir, featureId: cfg.featureId, story });
+              if (!restored) {
+                throw new ReplayCorpusMissError(
+                  `[drive] REPLAY CORPUS MISS: reflect verdict for ${story} is not in the corpus ` +
+                    `(expected features/${cfg.featureId}/stories/${story}/reflect-verdict.json under ${rd}). ` +
+                    `Replay will NOT run the Navigator live , put the recorded verdict in the corpus (check .gitignore is not dropping it).`,
+                );
+              }
+            }
             process.stderr.write(`[drive] replayed reflect (navigator ${story}) from corpus , verdict only (no code, not counted)\n`);
             return;
           }
@@ -332,16 +362,22 @@ function execRunner(cfg: DriveEffectsConfig): CommandRunner {
             );
             return;
           }
-          process.stderr.write(`[drive] build replay miss for ${cmd.role} turn ${turnIndex} (${story}); running the real agent\n`);
+          throw new ReplayCorpusMissError(
+            `[drive] REPLAY CORPUS MISS: build turn ${turnIndex} for ${story} (${cmd.role}) has no recorded turn dir under ` +
+              `${replayBuildDir} (features/${cfg.featureId}/stories/${story}/turns). The live orchestrator dispatched more ` +
+              `build turns than the corpus recorded, or the corpus is incomplete. Replay will NOT run the agent live , ` +
+              `re-record or fix the corpus so it covers every dispatched turn.`,
+          );
         }
-        // Fast-forward replay: when LAKEBASE_SFTDD_REPLAY_DIR is set, a design-lane
         // Fast-forward replay: when LAKEBASE_SFTDD_REPLAY_DIR is set, a design-lane
         // role's turn copies its recorded output from the corpus instead of
         // spawning the model. The orchestrator still VISITS the turn (logs +
         // transitions + runs its deterministic effects); only the LLM generation
         // is replaced. Navigator/Driver are never replayed (not design roles),
-        // so the real TDD begins at the Navigator handoff. A turn the corpus
-        // lacks (e.g. an un-recorded story) falls through to the real agent.
+        // so the real TDD begins at the Navigator handoff. A replay is a RECORDING:
+        // if the deterministic pipeline dispatched a replayable design turn, the
+        // corpus MUST have its artifact , a miss is a HARD FAILURE, never a
+        // fall-through to a live agent (the .gitignore corpus drop this guards).
         const replayDir = sftddEnv("REPLAY_DIR");
         if (replayDir && REPLAYABLE_DESIGN_ROLES.has(cmd.role)) {
           const replayed = replayDesignTurn({
@@ -356,7 +392,12 @@ function execRunner(cfg: DriveEffectsConfig): CommandRunner {
             );
             return;
           }
-          process.stderr.write(`[drive] replay miss for ${cmd.role} (no corpus artifact); running the real agent\n`);
+          const where = `${cmd.role}${cmd.replay?.mode ? `/${cmd.replay.mode}` : ""}${cmd.replay?.story ? ` ${cmd.replay.story}` : ""}`;
+          throw new ReplayCorpusMissError(
+            `[drive] REPLAY CORPUS MISS: no recorded artifact for design turn '${where}' under ${replayDir} ` +
+              `(features/${cfg.featureId}/...). The deterministic pipeline dispatched this turn but the corpus lacks its ` +
+              `output. Replay will NOT run the agent live , put the recorded artifact in the corpus (check .gitignore is not dropping it).`,
+          );
         }
         // stream-json (requires --verbose with --print) lets us capture the turn's
         // token usage from the result event while teeing readable text to the console.
@@ -1094,6 +1135,13 @@ async function main(): Promise<number> {
       }
       process.stderr.write(`[drive] ${err.message}\n        recorded under ${path.basename(cfg.sftddDir)}/escalations/ ; resolve it, then re-run.\n`);
       return 3;
+    }
+    // A replay corpus miss: the recording is incomplete for a turn the pipeline
+    // dispatched. Not an escalation (no live workflow to resume) , it is a corpus/
+    // config defect. Fail loud with the missing-artifact guidance; no agent ran.
+    if (err instanceof ReplayCorpusMissError) {
+      process.stderr.write(`${err.message}\n`);
+      return 2;
     }
     process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     return 1;

--- a/scripts/sftdd/drive.cli.ts
+++ b/scripts/sftdd/drive.cli.ts
@@ -141,8 +141,11 @@ Flags:
                        driver blocks for a human [Y/n], then RESUMES the same run
                        on Y , it never leaves the state machine. n re-asks. Set
                        LAKEBASE_SFTDD_AUTO_CONTINUE=1 to auto-confirm (non-interactive).
-  --gates <mode>       proxy (default, headless: Human Proxy approves) | interactive
-                       (stop AT each HITL gate so the human answers, then re-run)
+  --gates <mode>       interactive (default: stop AT each HITL gate so the human
+                       answers, then re-run) | proxy (headless: Human Proxy
+                       approves; requires LAKEBASE_SFTDD_AUTO_CONTINUE=1 or CI).
+                       Run-scoped: overrides project.gates for THIS run only,
+                       never rewrites sftdd-config.json.
   --no-sizing          Skip the Architect's t-shirt-sizing (planning-poker) step:
                        planning goes propose -> author-requests, no estimate.
                        Sizing is ON by default. Aliases: --no-planning-poker,
@@ -586,7 +589,7 @@ function makeConfirmContinue(): (action: WorkflowAction) => Promise<void> {
   const answerFile = sftddEnv("GATE_ANSWER_FILE")?.trim();
   const isYes = (a: string): boolean => a === "" || a === "y" || a === "yes";
   return (action) =>
-    new Promise((resolve) => {
+    new Promise<void>((resolve, reject) => {
       const label = describeAction(action);
       const prompt = `\n[drive] PAUSED , continue past the ${label} handoff? [Y/n] `;
       if (auto) {
@@ -619,11 +622,18 @@ function makeConfirmContinue(): (action: WorkflowAction) => Promise<void> {
         };
         return ask();
       }
-      // No terminal + no control channel: never crash or hang , continue.
-      process.stderr.write(
-        `${prompt}\n[drive] no interactive terminal and no LAKEBASE_SFTDD_GATE_ANSWER_FILE , auto-continuing past ${label}.\n`,
+      // No auto-confirm, no control channel, no TTY: there is NO human in the
+      // loop, so STOP rather than silently proceed past the handoff (an
+      // agent-driven non-TTY run must not self-approve). A deliberate headless
+      // run sets LAKEBASE_SFTDD_AUTO_CONTINUE=1; a controller writes a gate-answer
+      // file; a human uses a terminal. None present = refuse.
+      reject(
+        new Error(
+          `[drive] PAUSED at the ${label} handoff with no human channel , refusing to continue. ` +
+            `Set LAKEBASE_SFTDD_AUTO_CONTINUE=1 (deliberate headless), provide ` +
+            `LAKEBASE_SFTDD_GATE_ANSWER_FILE, or run in an interactive terminal.`,
+        ),
       );
-      resolve();
     });
 }
 
@@ -748,17 +758,19 @@ async function runSprintMode(args: ParsedArgs): Promise<number> {
   // The claim CLI lives in dist/scripts/lakebase/, a sibling-of-parent of this
   // file's dist dir, so it resolves regardless of PATH (the smoke runs via npx).
   const claimJs = path.join(__dirname, "..", "lakebase", "scm-claim-feature.cli.js");
-  // gates + sizing come from sftdd-config.json (the --gates / --no-sizing flags
-  // wrote through to it before resolution). The file is the single source.
+  // sizing comes from sftdd-config.json; the gate mode is RUN-SCOPED (--gates
+  // override else the project's declared policy), never read back from a
+  // flag-mutated file.
   const settings = resolveSftddSettings({ projectDir });
-  const interactive = settings.project.gates === "interactive";
+  const gates = effectiveGates(args, projectDir);
+  const interactive = gates === "interactive";
   const skipSizing = !settings.plan.sizing;
 
   const effects: SprintEffects = {
     async drivePlanning() {
       const cfg = buildCfg(args, "");
       cfg.runner = execRunner(cfg);
-      snapshotRunConfig(cfg,"plan");
+      snapshotRunConfig(cfg, "plan", gates);
       const planning: DriveEffects = {
         // Sizing is ON by default; --no-sizing (or config plan.sizing:false) opts out.
         readState: async () => deriveSprintPlanningState(sftddDir, sprint, { skipSizing }),
@@ -805,7 +817,7 @@ async function runSprintMode(args: ParsedArgs): Promise<number> {
       // resumed mid-flight feature is untouched.
       resetStaleTerminalPhase(cfg.sftddDir);
       cfg.runner = execRunner(cfg);
-      snapshotRunConfig(cfg,"full");
+      snapshotRunConfig(cfg, "full", gates);
       const r = await runDriver(withTurnRecording(withBuildRecording(buildDriveEffects(cfg), cfg), cfg), {
         stopWhen: gatedStopWhen(undefined, interactive),
       });
@@ -858,18 +870,35 @@ async function runSprintMode(args: ParsedArgs): Promise<number> {
   }
 }
 
+/** The RUN-SCOPED gate mode: a `--gates` flag overrides for THIS run only; absent,
+ *  the project's declared policy in sftdd-config.json wins. The flag never rewrites
+ *  the file (that let one headless run flip an interactive project to proxy), so the
+ *  effective mode is resolved fresh here, not read back from a mutated file. */
+function effectiveGates(args: ParsedArgs, projectDir: string): "interactive" | "proxy" {
+  const flag = args.gates as "interactive" | "proxy" | undefined;
+  return flag ?? resolveSftddSettings({ projectDir }).project.gates;
+}
+
+/** True when the run has an explicit non-interactive signal (CI / auto-continue).
+ *  Headless proxy gating is only legitimate with one of these; otherwise a stray
+ *  LAKEBASE_SFTDD_HUMAN_PROXY leaking into a dev shell would silently bypass HITL. */
+function hasNonInteractiveSignal(): boolean {
+  return sftddEnv("AUTO_CONTINUE") === "1" || /^(1|true)$/i.test(process.env.CI ?? "");
+}
+
 /** P0.1: snapshot the resolved model + option matrix to .tdd/run-config.json (and
  *  the corpus root when recording) at the start of an ACTUAL run (not --dry-run),
  *  so a timing report is self-describing and two runs are A/B-comparable.
  *  Best-effort: writeRunConfig swallows its own IO errors. */
-function snapshotRunConfig(cfg: DriveEffectsConfig, bound: string): void {
+function snapshotRunConfig(cfg: DriveEffectsConfig, bound: string, gates: "interactive" | "proxy"): void {
   writeRunConfig({
     projectDir: cfg.projectDir,
     sftddDir: cfg.sftddDir,
     bound,
-    // gates from sftdd-config.json (the --gates flag wrote through to it), so the
-    // snapshot records what the drive actually used, never a stale flag default.
-    gates: resolveSftddSettings({ projectDir: cfg.projectDir }).project.gates,
+    // Run-scoped effective gate mode (--gates override else project policy),
+    // recorded here so the snapshot is where the run-scoped choice lives , the
+    // flag never persists into sftdd-config.json.
+    gates,
     uiTrack: cfg.uiTrack,
     buildSessionScope: cfg.buildSessionScope,
     reviewEffort: cfg.reviewEffort,
@@ -903,11 +932,26 @@ async function main(): Promise<number> {
   // Write-through the drive's ad-hoc override flags into sftdd-config.json BEFORE
   // any settings resolution, so the file stays the single source of truth (the
   // flag is a WRITER, not a parallel reader; absent flags never mutate the file).
+  // NB: --gates is NOT here , it is run-scoped policy, resolved per run and never
+  // persisted (see effectiveGates / applyProjectOverrides).
   applyProjectOverrides(args.projectDir ?? process.cwd(), {
-    gates: args.gates as "interactive" | "proxy" | undefined,
     deployTarget: args.deployTarget,
     sizing: args.noSizing === true ? false : undefined,
   });
+
+  // HITL enforcement: headless proxy gating is only legitimate with an explicit
+  // non-interactive signal. Refuse `proxy` in an interactive/dev context so a
+  // stray LAKEBASE_SFTDD_HUMAN_PROXY (which the /plan|/sprint|... commands turn
+  // into `--gates proxy`) can't silently bypass the human. CI + the smokes set
+  // LAKEBASE_SFTDD_AUTO_CONTINUE=1 (or CI), so they pass.
+  if (effectiveGates(args, args.projectDir ?? process.cwd()) === "proxy" && !hasNonInteractiveSignal()) {
+    process.stderr.write(
+      `lakebase-sftdd-drive: gate mode 'proxy' (Human Proxy approves headlessly) requires an explicit\n` +
+        `non-interactive signal (LAKEBASE_SFTDD_AUTO_CONTINUE=1 or CI). Refusing to bypass HITL in an\n` +
+        `interactive/dev context. Unset LAKEBASE_SFTDD_HUMAN_PROXY, or pass --gates interactive.\n`,
+    );
+    return 2;
+  }
 
   // Tier-1: `--sprint <name>` with no `--feature` runs the whole-sprint orchestrator.
   if (args.sprint && !args.feature) {
@@ -962,9 +1006,9 @@ async function main(): Promise<number> {
   }
 
   cfg.runner = execRunner(cfg);
-  snapshotRunConfig(cfg,bound ?? "full");
-  // gates from sftdd-config.json (the --gates flag wrote through to it).
-  const interactive = resolveSftddSettings({ projectDir: cfg.projectDir }).project.gates === "interactive";
+  const gates = effectiveGates(args, cfg.projectDir);
+  snapshotRunConfig(cfg, bound ?? "full", gates);
+  const interactive = gates === "interactive";
   try {
     const result = await runDriver(withTurnRecording(withBuildRecording(buildDriveEffects(cfg), cfg), cfg), {
       maxSteps: args.maxSteps,

--- a/scripts/sftdd/sftdd-config.ts
+++ b/scripts/sftdd/sftdd-config.ts
@@ -164,7 +164,10 @@ export function resolveSftddSettings(inputs: ResolveInputs): ResolvedSettings {
 
   const project = {
     uiTrack: file?.project?.uiTrack ?? false,
-    gates: (file?.project?.gates ?? "proxy") as "interactive" | "proxy",
+    // HITL-first: the declared project policy defaults to interactive (a human
+    // approves each gate). Headless (proxy) is a deliberate opt-in, set in the
+    // file or as a RUN-SCOPED --gates override (never persisted by a flag).
+    gates: (file?.project?.gates ?? "interactive") as "interactive" | "proxy",
     deployTarget: file?.project?.deployTarget ?? "local",
     clientFramework: (file?.project?.clientFramework ?? "none") as "react" | "none",
   };
@@ -198,7 +201,7 @@ export function defaultSftddConfig(): SftddConfigFile {
     roles,
     build: { loopGranularity: "story", batchCap: 3, sessionScope: "story" },
     plan: { sizing: true },
-    project: { uiTrack: false, gates: "proxy", deployTarget: "local", clientFramework: "none" },
+    project: { uiTrack: false, gates: "interactive", deployTarget: "local", clientFramework: "none" },
   };
 }
 
@@ -212,21 +215,26 @@ export function writeSftddConfig(projectDir: string, config: SftddConfigFile, op
 }
 
 /**
- * Write-through for the drive's ad-hoc override flags (`--gates`,
- * `--deploy-target`, `--no-sizing`). These are WRITERS, not parallel readers: a
- * flag persists its value into sftdd-config.json so the file stays the single
- * source of truth (resolveSftddSettings then reads it like any other setting).
+ * Write-through for the drive's ad-hoc override flags (`--deploy-target`,
+ * `--no-sizing`). These are WRITERS, not parallel readers: a flag persists its
+ * value into sftdd-config.json so the file stays the single source of truth.
  * No-op when no override is given, so a plain run never mutates the file. Loads
  * the existing config (or the default when none) so unrelated fields are kept.
+ *
+ * `--gates` is intentionally NOT here: it is the HITL POLICY, and a run-scoped
+ * flag must never rewrite the project's declared policy (that let one headless
+ * `--gates proxy` invocation permanently flip an interactive project to proxy).
+ * The drive resolves the effective gate mode as `--gates ?? project.gates` per
+ * run and records it run-scoped in run-config.json; sftdd-config.json stays
+ * authoritative and is only changed by editing the file.
  */
 export function applyProjectOverrides(
   projectDir: string,
-  over: { gates?: "interactive" | "proxy"; deployTarget?: string; sizing?: boolean },
+  over: { deployTarget?: string; sizing?: boolean },
 ): void {
-  if (over.gates === undefined && over.deployTarget === undefined && over.sizing === undefined) return;
+  if (over.deployTarget === undefined && over.sizing === undefined) return;
   const cfg = loadSftddConfig(projectDir) ?? defaultSftddConfig();
   cfg.project = cfg.project ?? {};
-  if (over.gates !== undefined) cfg.project.gates = over.gates;
   if (over.deployTarget !== undefined) cfg.project.deployTarget = over.deployTarget;
   cfg.plan = cfg.plan ?? {};
   if (over.sizing !== undefined) cfg.plan.sizing = over.sizing;

--- a/tests/bdd/scenario-corpus-integrity.test.ts
+++ b/tests/bdd/scenario-corpus-integrity.test.ts
@@ -1,0 +1,78 @@
+// Scenario-corpus referential integrity: every ac_id a test-list references must
+// resolve to a git-TRACKED ac file in the shipped fixture.
+//
+// The defect this guards (field feedback 2026-07-14, Finding 3): a `.gitignore`
+// `*conf*.json` glob silently dropped corpus ac files whose names contain "conf"
+// (AC2-file-new-stock-confirmed, AC5-nonconforming-count-reported, ...). The files
+// existed on disk in a dev clone (so an on-disk check passed) but were never
+// committed, so shipped scenarios had test-lists referencing ac files that a
+// consumer never received , a dangling reference that stayed green. So this asks
+// git (tracked set), not the filesystem, and scopes to scenarios whose
+// scenario.json is itself tracked (the real shipped corpora, not stray local dirs).
+
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+const REPO_ROOT = join(__dirname, "..", "..");
+const SCENARIOS = "examples/sftdd-scenarios";
+
+function tracked(paths: string): Set<string> {
+  const out = execFileSync("git", ["ls-files", paths], { cwd: REPO_ROOT, encoding: "utf8" });
+  return new Set(out.split("\n").map((l) => l.trim()).filter(Boolean));
+}
+
+/** Tracked scenario roots (a scenario.json that git actually ships). */
+function trackedScenarioRoots(): string[] {
+  return [...tracked(SCENARIOS)]
+    .filter((p) => p.endsWith("/scenario.json"))
+    .map((p) => dirname(p));
+}
+
+describe("scenario corpus: every test-list ac_id resolves to a shipped (tracked) ac file", () => {
+  const roots = trackedScenarioRoots();
+
+  it("has at least one shipped scenario to check", () => {
+    expect(roots.length).toBeGreaterThan(0);
+  });
+
+  for (const root of roots) {
+    it(`${root}: no dangling ac_id references`, () => {
+      const files = tracked(root);
+      const testLists = [...files].filter((f) => /\/test-list.*\.json$/.test(f));
+      const acFiles = [...files].filter((f) => /\/acs\/.+\.json$/.test(f));
+
+      const dangling: string[] = [];
+      for (const tl of testLists) {
+        // A test-list lives under `.../recorded-artifacts/features/<feature>/...`.
+        // Resolve its ac files in the SAME recorded-artifacts tree for the SAME
+        // feature , NOT in per-turn `.sftdd` snapshots elsewhere in the corpus, or
+        // a snapshot copy would mask a missing recorded-artifacts ac.
+        const m = tl.match(/^(.*\/recorded-artifacts)\/features\/([^/]+)\//);
+        if (!m) continue;
+        const [, artifactsRoot, feature] = m;
+        const acPrefix = `${artifactsRoot}/features/${feature}/`;
+        let doc: { items?: Array<{ ac_id?: string }> };
+        try {
+          doc = JSON.parse(readFileSync(join(REPO_ROOT, tl), "utf8"));
+        } catch {
+          continue;
+        }
+        for (const item of doc.items ?? []) {
+          const ac = item?.ac_id;
+          if (!ac) continue;
+          const hit = acFiles.some((f) => f.startsWith(acPrefix) && f.endsWith(`/acs/${ac}.json`));
+          if (!hit) dangling.push(`${tl} -> ${ac}`);
+        }
+      }
+
+      expect(
+        [...new Set(dangling)],
+        `test-list ac_id(s) with no tracked ac file (shipped corpus is missing them; ` +
+          `check .gitignore is not dropping data files, then git add the ac json):\n` +
+          [...new Set(dangling)].map((d) => `  ${d}`).join("\n"),
+      ).toEqual([]);
+    });
+  }
+});

--- a/tests/bdd/scenario-corpus-integrity.test.ts
+++ b/tests/bdd/scenario-corpus-integrity.test.ts
@@ -76,3 +76,83 @@ describe("scenario corpus: every test-list ac_id resolves to a shipped (tracked)
     });
   }
 });
+
+// Full replay-artifact completeness. The runtime hard-fail (drive.cli.ts
+// ReplayCorpusMissError) refuses to run an agent when a replay lane is told to
+// reproduce a turn the corpus lacks. This test is that same contract, moved
+// EARLIER: it fails hermetically in CI (naming the missing file) the moment a
+// shipped scenario is missing an artifact the driver would restore, so a drop
+// never survives to surface as a live-replay hard-fail. It keys off what the
+// corpus actually SHIPS (tracked story.json / feature dir), so it cannot
+// false-fail on an optional feature , if you ship a story, you must ship every
+// artifact its replay needs.
+describe("scenario corpus: every replay artifact the driver restores is tracked (no silent drop)", () => {
+  const roots = trackedScenarioRoots();
+
+  for (const root of roots) {
+    it(`${root}: design + reflect + build artifacts are all shipped`, () => {
+      const files = tracked(root);
+      const aroot = `${root}/recorded-artifacts`;
+      const broot = `${root}/recorded-build`;
+      const has = (p: string) => files.has(p);
+      const hasUnder = (prefix: string) => [...files].some((f) => f.startsWith(prefix));
+
+      // scenario.json drives feature-level replay knobs (uiTrack -> design-guide;
+      // buildReplay -> recorded-build turns). Absent knobs take the replay defaults.
+      let manifest: { uiTrack?: boolean; features?: Array<{ id?: string; buildReplay?: boolean }> } = {};
+      try {
+        manifest = JSON.parse(readFileSync(join(REPO_ROOT, root, "scenario.json"), "utf8"));
+      } catch {
+        /* keep defaults */
+      }
+      const buildReplayFor = (feature: string): boolean =>
+        manifest.features?.find((f) => f.id === feature)?.buildReplay !== false;
+
+      // Enumerate the SHIPPED stories from tracked story.json, grouped by feature.
+      const storyByFeature = new Map<string, Set<string>>();
+      for (const f of files) {
+        const m = f.match(new RegExp(`^${aroot}/features/([^/]+)/stories/([^/]+)/story\\.json$`));
+        if (!m) continue;
+        const [, feature, story] = m;
+        (storyByFeature.get(feature) ?? storyByFeature.set(feature, new Set()).get(feature)!).add(story);
+      }
+
+      const missing: string[] = [];
+      const need = (p: string) => {
+        if (!has(p)) missing.push(p);
+      };
+      const needAny = (prefix: string, label: string) => {
+        if (!hasUnder(prefix)) missing.push(`${label} (>=1 file under ${prefix})`);
+      };
+
+      // A uiTrack scenario replays the UX designer turn from design/design-guide.json.
+      if (manifest.uiTrack) need(`${aroot}/design/design-guide.json`);
+
+      for (const [feature, stories] of storyByFeature) {
+        // Feature-level design turns: Spec Author breakdown (feature-spec.json),
+        // Architect (architecture.json), Test Strategist (test-list.json).
+        need(`${aroot}/features/${feature}/feature-spec.json`);
+        need(`${aroot}/features/${feature}/architecture.json`);
+        need(`${aroot}/features/${feature}/test-list.json`);
+        for (const story of stories) {
+          const sdir = `${aroot}/features/${feature}/stories/${story}`;
+          // Per-story: the Spec Author acs (>=1) and the reflect gate verdict.
+          needAny(`${sdir}/acs/`, `${feature}/${story} acs`);
+          need(`${sdir}/reflect-verdict.json`);
+          // Build lane (unless buildReplay:false): the recorded per-turn code tree.
+          if (buildReplayFor(feature)) {
+            needAny(`${broot}/features/${feature}/stories/${story}/turns/`, `${feature}/${story} recorded-build turns`);
+          }
+        }
+      }
+
+      expect(storyByFeature.size, `no shipped stories found under ${aroot} (is the corpus tracked?)`).toBeGreaterThan(0);
+      expect(
+        missing,
+        `shipped scenario '${root}' is missing replay artifact(s) the driver restores. A live replay would ` +
+          `hard-fail (ReplayCorpusMissError) on these. Check .gitignore is not dropping them, then git add:\n` +
+          missing.map((m) => `  ${m}`).join("\n"),
+      ).toEqual([]);
+    });
+  }
+});

--- a/tests/bdd/sftdd-config.test.ts
+++ b/tests/bdd/sftdd-config.test.ts
@@ -209,16 +209,14 @@ describe("resolveSftddSettings: the file is the single source (env does NOT over
   });
 });
 
-describe("applyProjectOverrides: the drive's override flags write THROUGH to the file", () => {
-  it("persists gates / deployTarget / sizing into the config, then the resolver reads them", () => {
-    applyProjectOverrides(proj, { gates: "interactive", deployTarget: "cloud", sizing: false });
+describe("applyProjectOverrides: deployTarget / sizing write THROUGH; gates never does", () => {
+  it("persists deployTarget / sizing into the config, then the resolver reads them", () => {
+    applyProjectOverrides(proj, { deployTarget: "cloud", sizing: false });
     // the file is the single source: resolution reflects the written-through values.
     const s = resolveSftddSettings({ projectDir: proj });
-    expect(s.project.gates).toBe("interactive");
     expect(s.project.deployTarget).toBe("cloud");
     expect(s.plan.sizing).toBe(false);
-    // and it materialized the persisted single source on disk.
-    expect(loadSftddConfig(proj)?.project?.gates).toBe("interactive");
+    expect(loadSftddConfig(proj)?.project?.deployTarget).toBe("cloud");
   });
 
   it("is a no-op when no override is given (a plain run never mutates the file)", () => {
@@ -228,11 +226,29 @@ describe("applyProjectOverrides: the drive's override flags write THROUGH to the
 
   it("preserves unrelated fields when writing through onto an existing config", () => {
     writeConfig({ version: 1, roles: { navigator: { model: "opus" } }, project: { uiTrack: true } });
-    applyProjectOverrides(proj, { gates: "interactive" });
+    applyProjectOverrides(proj, { deployTarget: "cloud" });
     const loaded = loadSftddConfig(proj);
-    expect(loaded?.project?.gates).toBe("interactive"); // written through
+    expect(loaded?.project?.deployTarget).toBe("cloud"); // written through
     expect(loaded?.project?.uiTrack).toBe(true); // preserved
     expect(loaded?.roles?.navigator?.model).toBe("opus"); // preserved
+  });
+
+  it("NEVER writes gates: the HITL policy is run-scoped, so a flag can't flip persisted policy", () => {
+    // A project that declares interactive must stay interactive on disk no matter
+    // how a headless run is invoked (the --gates flag lives in run-config, not here).
+    writeConfig({ version: 1, roles: {}, project: { gates: "interactive" } });
+    // applyProjectOverrides has no `gates` channel at all; a deployTarget write
+    // must leave project.gates untouched.
+    applyProjectOverrides(proj, { deployTarget: "cloud" });
+    expect(loadSftddConfig(proj)?.project?.gates).toBe("interactive");
+  });
+});
+
+describe("gates: HITL-first default", () => {
+  it("defaults project.gates to interactive when unset (headless is opt-in)", () => {
+    writeConfig({ version: 1, roles: {} });
+    expect(resolveSftddSettings({ projectDir: proj }).project.gates).toBe("interactive");
+    expect(defaultSftddConfig().project?.gates).toBe("interactive");
   });
 });
 

--- a/tests/bdd/sftdd-replay-artifacts.test.ts
+++ b/tests/bdd/sftdd-replay-artifacts.test.ts
@@ -6,7 +6,9 @@
 // the Architect on architectural_notes + architecture.json + the canon, NOT on
 // `layer`, so the Spec Author must not strip it (a cleanly-mapping story gets its
 // notes PROJECTED with no Architect turn to restore a stripped layer). A story the
-// corpus lacks returns false (-> real agent).
+// corpus lacks returns false: the caller (drive.cli.ts) treats a replay corpus miss
+// as a HARD FAILURE (ReplayCorpusMissError) , a replay is a recording and must never
+// fall through to a live agent.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "fs";
@@ -79,7 +81,7 @@ describe("replayDesignTurn: each stage's output is replayed per-turn", () => {
     expect(existsSync(join(tdd, "design", "design-guide.json"))).toBe(true);
   });
 
-  it("a story the corpus does not cover returns false (driver falls back to the real agent)", () => {
+  it("a story the corpus does not cover returns false (a corpus miss; the driver hard-fails, never runs a live agent)", () => {
     expect(replayDesignTurn({ turn: { role: "spec-author", story: "S2-not-recorded" }, replayDir: corpus, sftddDir: tdd, featureId: F })).toBe(false);
   });
 });
@@ -96,7 +98,7 @@ describe("restoreReflectVerdict: the reflect turn's .sftdd verdict (filtered by 
     expect(JSON.parse(readFileSync(dst, "utf8")).passed).toBe(true);
   });
 
-  it("returns false when the corpus has no verdict (no-op, caller runs the real reflect)", () => {
+  it("returns false when the corpus has no verdict (a corpus miss; the driver hard-fails, never runs the reflect live)", () => {
     expect(restoreReflectVerdict({ replayDir: corpus, sftddDir: tdd, featureId: F, story: S })).toBe(false);
   });
 });

--- a/tests/bdd/sftdd-replay-build.test.ts
+++ b/tests/bdd/sftdd-replay-build.test.ts
@@ -78,7 +78,7 @@ describe("replayBuildTurn (per-turn build replay)", () => {
     expect(existsSync(join(proj, "app", "main.py"))).toBe(true);
   });
 
-  it("returns false past the last recorded turn (falls back to the live agent)", () => {
+  it("returns false past the last recorded turn (a corpus miss; the driver hard-fails, never runs a live agent)", () => {
     expect(replayBuildTurn({ replayBuildDir: corpus, projectDir: proj, sftddDir: tdd, featureId: F, story: S, turnIndex: 3 })).toBe(false);
   });
 


### PR DESCRIPTION
Addresses the three findings in the 2026-07-14 field-feedback report against v0.3.0-beta.14, plus a fundamental replay-integrity fix.

## Findings addressed

**F3 , `.gitignore` silently dropped scenario corpus data (`5249b2c`)**
An org-init `*conf*.json` glob matched corpus files whose names contain "conf" (`*-confirmed.json`, `*-nonconforming-*.json`, client `tsconfig.json`), so shipped scenarios referenced AC files a consumer never received. Anchored the ignore to the actual runtime file (`run-config.json`) by exact basename, recovered the dropped data, and added a referential-integrity guard.

**F2 , HITL-first gate policy (`0ca6362`)**
The declared project gate policy now defaults to `interactive` (a human approves each gate). `proxy` (headless) is a deliberate opt-in. A run-scoped `--gates` override no longer persists into `sftdd-config.json` (a single headless `--gates proxy` could permanently flip an interactive project). The drive resolves the effective mode per run as `--gates ?? project.gates` and records it run-scoped; `proxy` without a non-interactive signal (AUTO_CONTINUE / CI) refuses rather than silently auto-continuing.

**Replay must never fall through to a live agent (`efdb72e`)**
Core fix. A replay is a recording. When a replay lane was told to reproduce a turn the corpus lacked, the driver used to print a note and spawn the real agent, letting an agent "take over" a deterministic run and silently masking an incomplete corpus (this is how the F3 drop surfaced: a missing AC made the Navigator run live). All three fall-throughs (design turn, build turn, reflect verdict) now throw `ReplayCorpusMissError`, failing loud (exit 2) and naming the missing artifact. No agent is ever spawned in a replay lane.

**Corpus completeness guard (`6405df8`)**
Broadened the integrity guard from "every test-list `ac_id` resolves to a tracked ac" to the full artifact set the driver restores (design + per-story reflect-verdict + acs + recorded-build turns). It is the runtime `ReplayCorpusMissError` contract moved earlier: a dropped artifact fails hermetically in CI, naming the exact file, instead of surfacing as a live-replay hard-fail. Audit confirmed the `stockflow` reference corpus is already complete.

## Verification
- Typecheck clean; full hermetic suite 2673 passed, 0 failures.
- Completeness guard verified to fail (naming the file) when an artifact is de-indexed.
- Live `replay-scenario.sh --scenario stockflow` re-validation in progress.

This pull request and its description were written by Isaac.