### PR TITLE
fix: build honest-GREEN runs the client Vitest suite (FEIP-8051, Finding 26)

### DIFF
--- a/scripts/sftdd/deploy.ts
+++ b/scripts/sftdd/deploy.ts
@@ -352,6 +352,12 @@ function normalizeVerifyRun(raw: boolean | { passed: boolean; output?: string })
     : { passed: raw.passed, output: raw.output ?? "" };
 }
 
+/** True when the project has a React client workspace (client/package.json), whose
+ *  Vitest suite is part of the authoritative full run (Finding 26). */
+function hasClientWorkspace(projectDir: string): boolean {
+  return existsSync(join(projectDir, "client", "package.json"));
+}
+
 function defaultRunVerify(cmd: string, cwd: string, env?: NodeJS.ProcessEnv): VerifyRun {
   try {
     const out = execSync(cmd, { cwd, stdio: "pipe", env: env ?? process.env });
@@ -786,6 +792,7 @@ export async function ensureDeployedAndVerify(args: CycleVerifyArgs): Promise<Cy
     existsSync(join(args.projectDir, "pyproject.toml")) || existsSync(join(args.projectDir, "requirements.txt"));
   let passed: boolean;
   let migrationFailed = false;
+  let clientFailed = false;
   try {
     if (isPython) {
       const mainPassed = (await runVerifyMaybeEphemeral(
@@ -809,7 +816,26 @@ export async function ensureDeployedAndVerify(args: CycleVerifyArgs): Promise<Cy
           )).passed
         : true;
       migrationFailed = mainPassed && !migPassed;
-      passed = mainPassed && migPassed;
+      const backendPassed = mainPassed && migPassed;
+      // Finding 26: the marked pytest passes are BACKEND-ONLY (run-tests.sh's
+      // SFTDD_PYTEST_MARKER early-exit short-circuits before its client Vitest block),
+      // so build honest-GREEN would never run the client suite on a Python + client
+      // scaffold, a false GREEN the deploy feature-verify (unmarked, so it reaches the
+      // client block) later caught. Run the client suite ONCE here (SFTDD_CLIENT_ONLY:
+      // run-tests.sh skips the backend and runs only `cd client && npm test`) so build
+      // GREEN gates on the SAME client tests. No DB, so no ephemeral branch; a failing
+      // client test refuses GREEN. Only when a client/ workspace exists.
+      const clientPassed =
+        backendPassed && hasClientWorkspace(args.projectDir)
+          ? normalizeVerifyRun(
+              runVerify(cfg.verify, args.projectDir, {
+                ...(env ?? process.env),
+                SFTDD_CLIENT_ONLY: "1",
+              }),
+            ).passed
+          : true;
+      clientFailed = backendPassed && !clientPassed;
+      passed = backendPassed && clientPassed;
     } else {
       passed = (await runVerifyMaybeEphemeral(runVerify, cfg.verify, args.projectDir, env, args.lakebaseBranch, nowFn)).passed;
     }
@@ -827,7 +853,9 @@ export async function ensureDeployedAndVerify(args: CycleVerifyArgs): Promise<Cy
   const regexLint = checkE2eRegexClean({ projectDir: args.projectDir });
   const base = migrationFailed
     ? "GREEN verify FAILED on the migration pass (the migration-marked reversibility test failed on its own isolated branch)"
-    : "GREEN verify FAILED against the running app";
+    : clientFailed
+      ? "GREEN verify FAILED on the client pass (the client Vitest suite failed; the backend suite passed)"
+      : "GREEN verify FAILED against the running app";
   const summary = regexLint.clean
     ? base
     : `${base}: e2e-inline-regex-flag , ${summarizeE2eRegexViolations(regexLint.violations)}. ${E2E_REGEX_REMEDIATION}`;

--- a/templates/project/client/src/api/client.ts
+++ b/templates/project/client/src/api/client.ts
@@ -3,20 +3,85 @@
 // (/api, /health) so the same code works behind the Vite dev proxy and against
 // the backend that serves the built client in production.
 
+/** The structured half of an RFC 9457 Problem Details validation refusal. */
+export interface ProblemDetail {
+  /** The field a validation refusal names, when the server returned a structured
+   *  `detail: { field, message }`. This is what lets a form render its
+   *  `field-<field>-error` seam instead of only a generic error. */
+  field?: string;
+  /** Human-readable message: the string `detail`, or the object's `.message`. */
+  message?: string;
+}
+
 export class ApiError extends Error {
   constructor(
     message: string,
-    readonly status: number
+    readonly status: number,
+    /** The field a validation refusal named (from an object-shaped `detail`), if
+     *  any. A form catches ApiError and, when `field` is set, renders the
+     *  `field-<field>-error` seam; otherwise it renders the generic error seam. */
+    readonly field?: string
   ) {
     super(message);
     this.name = "ApiError";
   }
 }
 
+// RFC 9457 Problem Details `detail` may be a STRING ("cart is empty") OR an OBJECT
+// ({ field, message }) for a FIELD-SCOPED validation refusal. A client that only
+// handles the string form DROPS the field + message and throws a generic error, so
+// a form can never surface which field was rejected (its `field-<field>-error` seam
+// never renders). Parse BOTH shapes so the field-level refusal survives to the UI.
+export function _problemDetail(body: unknown): ProblemDetail {
+  if (!body || typeof body !== "object") return {};
+  const detail = (body as { detail?: unknown }).detail;
+  if (typeof detail === "string") return { message: detail };
+  if (detail && typeof detail === "object") {
+    const d = detail as { field?: unknown; message?: unknown };
+    return {
+      field: typeof d.field === "string" ? d.field : undefined,
+      message: typeof d.message === "string" ? d.message : undefined,
+    };
+  }
+  return {};
+}
+
+/** Build an ApiError from a non-ok response, preserving a field-scoped refusal. */
+async function apiErrorFrom(res: Response, fallback: string): Promise<ApiError> {
+  let pd: ProblemDetail = {};
+  try {
+    pd = _problemDetail(await res.json());
+  } catch {
+    // A non-JSON error body: fall back to the generic message + no field.
+  }
+  return new ApiError(pd.message ?? fallback, res.status, pd.field);
+}
+
 export async function getJson<T>(path: string): Promise<T> {
   const res = await fetch(path, { headers: { Accept: "application/json" } });
   if (!res.ok) {
-    throw new ApiError(`GET ${path} failed`, res.status);
+    throw await apiErrorFrom(res, `GET ${path} failed`);
+  }
+  return (await res.json()) as T;
+}
+
+// Mutating request. On a validation refusal the thrown ApiError carries `.field`
+// (when the server returned an object `detail`), so a form's catch can render the
+// field-scoped error seam:
+//
+//   try { await postJson("/api/receipts", form); }
+//   catch (e) {
+//     if (e instanceof ApiError && e.field) setFieldError(e.field, e.message);
+//     else setFormError(e instanceof Error ? e.message : String(e));
+//   }
+export async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw await apiErrorFrom(res, `POST ${path} failed`);
   }
   return (await res.json()) as T;
 }

--- a/templates/project/common/scripts/run-tests.sh
+++ b/templates/project/common/scripts/run-tests.sh
@@ -41,8 +41,15 @@ if [ -n "${VERIFY_DATABASE_URL:-}" ]; then
   export DATABASE_URL="$VERIFY_DATABASE_URL"
 fi
 
-# Detect project language and run pending migrations before tests
-if [ -f "$REPO_ROOT/pom.xml" ]; then
+# Detect project language and run pending migrations before tests.
+# SFTDD_CLIENT_ONLY (Finding 26): the build's honest-GREEN verify runs the backend
+# via the SFTDD_PYTEST_MARKER two-pass, which exits before the client Vitest block
+# below. To gate build GREEN on the SAME client suite the deploy feature-verify runs,
+# the build makes ONE extra invocation with SFTDD_CLIENT_ONLY=1: skip the backend
+# entirely (no migrations, no pytest) and run only the client Vitest block.
+if [ "$#" -eq 0 ] && [ -n "${SFTDD_CLIENT_ONLY:-}" ]; then
+  echo "Client-only pass (SFTDD_CLIENT_ONLY=1): skipping the backend suite; running the client Vitest suite only."
+elif [ -f "$REPO_ROOT/pom.xml" ]; then
   # Java / Maven – export SPRING_DATASOURCE_* for Maven/Spring
   if [ -z "${SPRING_DATASOURCE_URL:-}" ] && [ -n "${DATABASE_URL:-}" ]; then
     SPRING_DATASOURCE_URL="jdbc:$(echo "$DATABASE_URL" | sed 's|^postgresql://[^@]*@|postgresql://|')"

--- a/tests/bdd/run-tests-client-only.test.ts
+++ b/tests/bdd/run-tests-client-only.test.ts
@@ -1,0 +1,83 @@
+// Finding 26 (FEIP-8051): run-tests.sh SFTDD_CLIENT_ONLY runs ONLY the client
+// Vitest block and skips the backend suite, so the build's honest-GREEN verify can
+// gate on the SAME client tests the deploy feature-verify runs (the marked pytest
+// two-pass short-circuits before the client block). Functional: a real bash run
+// against a stub `client` npm test, no uv/pytest/vitest needed.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RUN_TESTS_SRC = path.resolve(
+  __dirname, "..", "..", "templates", "project", "common", "scripts", "run-tests.sh",
+);
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  while (tmpDirs.length) {
+    const d = tmpDirs.pop();
+    if (d) try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* */ }
+  }
+});
+
+/** A Python + client project tree with the real run-tests.sh installed and a stub
+ *  client `npm test` that echoes a marker. No backend tooling (uv/pytest) present,
+ *  so a run that does NOT skip the backend would fail loudly. */
+function scaffold(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "run-tests-client-"));
+  tmpDirs.push(root);
+  fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
+  fs.copyFileSync(RUN_TESTS_SRC, path.join(root, "scripts", "run-tests.sh"));
+  fs.writeFileSync(path.join(root, ".env"), "LAKEBASE_PROJECT_ID=x\n");
+  // A Python backend marker: without SFTDD_CLIENT_ONLY the script would try to run
+  // `uv run alembic upgrade head` (absent here) and fail.
+  fs.writeFileSync(path.join(root, "pyproject.toml"), "[project]\nname = 'x'\n");
+  // Client workspace with a stub test script + a present node_modules so the
+  // script's auto-install branch is skipped.
+  const client = path.join(root, "client");
+  fs.mkdirSync(path.join(client, "node_modules"), { recursive: true });
+  fs.writeFileSync(
+    path.join(client, "package.json"),
+    JSON.stringify({ name: "client", scripts: { test: "echo CLIENT_VITEST_RAN" } }) + "\n",
+  );
+  return root;
+}
+
+function run(root: string, env: NodeJS.ProcessEnv): { ok: boolean; out: string } {
+  try {
+    const out = execFileSync("bash", ["scripts/run-tests.sh"], {
+      cwd: root, encoding: "utf8", env: { ...process.env, ...env },
+    });
+    return { ok: true, out };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string };
+    return { ok: false, out: `${err.stdout ?? ""}${err.stderr ?? ""}` };
+  }
+}
+
+describe("run-tests.sh SFTDD_CLIENT_ONLY (Finding 26)", () => {
+  it("runs only the client suite and skips the backend", () => {
+    const root = scaffold();
+    const { ok, out } = run(root, { SFTDD_CLIENT_ONLY: "1" });
+    expect(ok).toBe(true);
+    expect(out).toMatch(/Client-only pass/);
+    expect(out).toMatch(/CLIENT_VITEST_RAN/);
+    // The backend suite must NOT run (no Alembic migration step).
+    expect(out).not.toMatch(/Running Alembic migrations/);
+  });
+
+  it("propagates a client test failure as a non-zero exit (refuses GREEN)", () => {
+    const root = scaffold();
+    // Make the stub client test fail.
+    fs.writeFileSync(
+      path.join(root, "client", "package.json"),
+      JSON.stringify({ name: "client", scripts: { test: "exit 1" } }) + "\n",
+    );
+    const { ok } = run(root, { SFTDD_CLIENT_ONLY: "1" });
+    expect(ok).toBe(false);
+  });
+});

--- a/tests/bdd/scaffold-client.test.ts
+++ b/tests/bdd/scaffold-client.test.ts
@@ -62,6 +62,20 @@ describe("deployClientProject", () => {
     }
   });
 
+  it("api/client.ts teaches the Problem Details field-error pattern (Finding 26)", () => {
+    const target = mkTarget();
+    deployClientProject(target, "demoapp", { templatesDir: TEMPLATES });
+    const client = read(target, "client/src/api/client.ts");
+    // Parses BOTH a string `detail` and an object `{ field, message }` detail, so a
+    // field-scoped validation refusal survives to the UI instead of being dropped.
+    expect(client).toMatch(/_problemDetail/);
+    expect(client).toMatch(/typeof detail === "string"/);
+    expect(client).toMatch(/field/);
+    // A mutation helper + ApiError.field so a form can render field-<field>-error.
+    expect(client).toMatch(/export async function postJson/);
+    expect(client).toMatch(/field-<field>-error/);
+  });
+
   it("substitutes {{PROJECT_NAME}} and leaves no unresolved placeholder", () => {
     const target = mkTarget();
     deployClientProject(target, "warehouse-ui", { templatesDir: TEMPLATES });

--- a/tests/bdd/sftdd-deploy.test.ts
+++ b/tests/bdd/sftdd-deploy.test.ts
@@ -654,3 +654,84 @@ describe("ensureDeployedAndVerify: migration-isolation two-pass (Python)", () =>
     expect(markers).toEqual(["<unset>"]);
   });
 });
+
+// Finding 26 (FEIP-8051): the build honest-GREEN verify uses the marked pytest
+// two-pass, which run-tests.sh short-circuits BEFORE its client Vitest block, so a
+// Python + client scaffold never ran the client suite under build GREEN (only the
+// deploy feature-verify, which runs unmarked, caught it). ensureDeployedAndVerify
+// must run the client suite ONCE (SFTDD_CLIENT_ONLY) and refuse GREEN if it fails.
+describe("ensureDeployedAndVerify: client Vitest pass on Python + client (Finding 26)", () => {
+  function fastClock() {
+    let t = 0;
+    return () => new Date((t += 200));
+  }
+  function stagePythonClient(d: string): void {
+    writeFileSync(join(d, "pyproject.toml"), "[project]\nname = 'x'\n");
+    mkdirSync(join(d, "client"), { recursive: true });
+    writeFileSync(join(d, "client", "package.json"), "{}\n");
+  }
+
+  it("runs a client-only pass after the two marked backend passes, and gates GREEN on it", async () => {
+    stagePythonClient(dir);
+    const calls: Array<{ marker: string; clientOnly: string }> = [];
+    const res = await ensureDeployedAndVerify({
+      projectDir: dir,
+      targetName: "localv",
+      startProcess: () => 4242,
+      reachable: async () => true,
+      runVerify: (_cmd, _cwd, env) => {
+        calls.push({
+          marker: env?.SFTDD_PYTEST_MARKER ?? "<unset>",
+          clientOnly: env?.SFTDD_CLIENT_ONLY ?? "<unset>",
+        });
+        return true;
+      },
+      stop: () => {},
+      sleep: async () => {},
+      now: fastClock(),
+    });
+    expect(res.passed).toBe(true);
+    // two backend marker passes, then exactly one client-only pass (no marker).
+    expect(calls.map((c) => c.marker)).toEqual(["not migration", "migration", "<unset>"]);
+    expect(calls.filter((c) => c.clientOnly === "1")).toHaveLength(1);
+    // the client pass carries NO pytest marker (it is not a backend pass).
+    expect(calls.find((c) => c.clientOnly === "1")!.marker).toBe("<unset>");
+  });
+
+  it("refuses GREEN when the client suite FAILS even though the backend passed", async () => {
+    stagePythonClient(dir);
+    const res = await ensureDeployedAndVerify({
+      projectDir: dir,
+      targetName: "localv",
+      startProcess: () => 4242,
+      reachable: async () => true,
+      // Backend (marked) passes; the client-only pass fails , the exact Finding 26 state.
+      runVerify: (_cmd, _cwd, env) => env?.SFTDD_CLIENT_ONLY !== "1",
+      stop: () => {},
+      sleep: async () => {},
+      now: fastClock(),
+    });
+    expect(res.passed).toBe(false);
+    expect(res.summary).toMatch(/client/i);
+  });
+
+  it("does NOT run a client pass when there is no client/ workspace (back-compat)", async () => {
+    writeFileSync(join(dir, "pyproject.toml"), "[project]\nname = 'x'\n"); // no client/
+    const clientOnlySeen: string[] = [];
+    const res = await ensureDeployedAndVerify({
+      projectDir: dir,
+      targetName: "localv",
+      startProcess: () => 4242,
+      reachable: async () => true,
+      runVerify: (_cmd, _cwd, env) => {
+        if (env?.SFTDD_CLIENT_ONLY) clientOnlySeen.push(env.SFTDD_CLIENT_ONLY);
+        return true;
+      },
+      stop: () => {},
+      sleep: async () => {},
+      now: fastClock(),
+    });
+    expect(res.passed).toBe(true);
+    expect(clientOnlySeen).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes Finding 26 (High): the build lane reported honest-GREEN while the client (Vitest) suite failed deterministically; only the deploy feature-verify caught it, violating the core TDD guarantee (GREEN only if tests pass).

## Root cause
The build honest-GREEN runs the Python backend via the `SFTDD_PYTEST_MARKER` two-pass, and `run-tests.sh`'s marked branch `exit`s BEFORE its client Vitest block. The deploy feature-verify runs `run-tests.sh` UNMARKED, reaches the client block, and fails, exposing the drift. Python + client scaffolds only (non-Python already runs the client block in its single unmarked pass).

## Fix
The marked pytest passes stay backend-only (no double-run, migration isolation intact), and the client suite runs exactly once:
- `run-tests.sh` gains `SFTDD_CLIENT_ONLY=1`: skip the backend entirely and run only the client Vitest block.
- `ensureDeployedAndVerify` (deploy.ts) runs one client-only pass after the two marked backend passes (when a `client/` workspace exists), gates GREEN on its captured exit code, and names a client failure distinctly. Build honest-GREEN now gates on the SAME client tests the deploy gate runs.

## Teaching gap (secondary)
The scaffold's `client/src/api/client.ts` now teaches the RFC 9457 Problem Details pattern: `_problemDetail` parses `detail` as a STRING or an object `{ field, message }`, `ApiError` carries `.field`, and a new `postJson` helper throws it, so a form can render its `field-<field>-error` seam instead of dropping the refusal (the exact S2 gap in the report).

## Validation
Hermetic + functional: deploy.ts client-pass gating via injected `runVerify`; a real `bash` run of `run-tests.sh SFTDD_CLIENT_ONLY` against a stub client `npm test`; a scaffold-content assertion for the Problem Details reference. Full suite (2844) + typecheck green.