### PR TITLE
fix(sftdd): re-driven story resets build state so it re-runs RED/GREEN (FEIP-8052)

### DIFF
--- a/scripts/sftdd/escalation.ts
+++ b/scripts/sftdd/escalation.ts
@@ -128,6 +128,32 @@ export function readEscalations(sftddDir: string): Escalation[] {
   return out;
 }
 
+/** Resolve (stamp `resolved_at` on) every unresolved explicit FILE escalation
+ *  for a story , the deploy-verify / driver-green halts that pin a story to the
+ *  HIL. This is the escalation-file half of a clean rebuild (Finding 27): a
+ *  status/cycle reset alone leaves the halting escalation on disk, so the drive
+ *  still pre-empts to raise-to-hil. The SMELL-derived half (blocking smells in
+ *  smells.json) is cleared separately by the smell resolvers , the dual-source
+ *  rule. Returns the ids it resolved (empty when none matched). A story-scoped
+ *  match: an escalation with no story_id is feature-wide and left untouched. */
+export function resolveEscalationsForStory(
+  sftddDir: string,
+  featureId: string,
+  story: string,
+  at: string = new Date().toISOString(),
+): string[] {
+  const dir = escalationsDir(sftddDir);
+  const resolved: string[] = [];
+  for (const e of readEscalations(sftddDir)) {
+    if (e.resolved_at) continue;
+    if (e.story_id !== story) continue;
+    if (e.feature_id !== undefined && e.feature_id !== featureId) continue;
+    fs.writeFileSync(escalationFile(sftddDir, e.id), JSON.stringify({ ...e, resolved_at: at }, null, 2) + "\n", "utf8");
+    resolved.push(e.id);
+  }
+  return resolved;
+}
+
 /** Escalations derived from unresolved BLOCKING bad-smells in `.tdd/smells.json`.
  *  The Navigator flags a smell (e.g. test-list-drift on a contradictory test);
  *  if it is in BLOCKING_SMELLS and unresolved, it becomes an HIL escalation

--- a/scripts/sftdd/experiment-args.ts
+++ b/scripts/sftdd/experiment-args.ts
@@ -20,6 +20,9 @@ export interface ExperimentArgs {
   reason?: string;
   at?: string;
   revise?: boolean;
+  /** cut: re-fork a pre-existing paired branch of the same name (drop-then-fork),
+   *  for a clean re-cut after a discarded experiment (Finding 27). */
+  resetStaleBranch?: boolean;
   projectDir?: string;
   sftddDir?: string;
 }
@@ -42,6 +45,7 @@ export function parseExperimentArgs(argv: string[]): ExperimentArgs {
     else if (a === "--reason") out.reason = argv[++i];
     else if (a === "--at") out.at = argv[++i];
     else if (a === "--revise") out.revise = true;
+    else if (a === "--reset-stale-branch") out.resetStaleBranch = true;
     else if (a === "--project-dir") out.projectDir = argv[++i];
     else if (a === "--tdd-dir") out.sftddDir = argv[++i];
   }

--- a/scripts/sftdd/experiment.ts
+++ b/scripts/sftdd/experiment.ts
@@ -131,6 +131,19 @@ export interface CutExperimentArgs extends BranchLookupOpts {
   parentBranch?: string;
   ttl?: string;
   notes?: string;
+  /** A RE-cut after a discarded experiment: drop any pre-existing paired branch of
+   *  this name BEFORE forking, so the rebuild forks clean off feature HEAD instead
+   *  of reusing the branch that still carries the discarded build's schema
+   *  (Finding 27). Mirrors the ci-pr --reset-stale-branch precedent. Best-effort:
+   *  a missing branch is a no-op; the drop never blocks the fork. */
+  resetStaleBranch?: boolean;
+}
+
+/** Injectable paired-branch substrate, so the drop-then-fork ordering is testable
+ *  hermetically. Defaults to the real Lakebase-backed ops. */
+export interface CutExperimentDeps {
+  createPairedBranch?: typeof createPairedBranch;
+  deletePairedBranch?: typeof deletePairedBranch;
 }
 
 export interface ExperimentRecord {
@@ -142,14 +155,28 @@ export interface ExperimentRecord {
   dir: string;
 }
 
-export async function cutExperiment(args: CutExperimentArgs): Promise<ExperimentRecord> {
-  const { sftddDir, projectDir, featureId, storyId, experimentSlug, branch, parentBranch, ttl, notes, ...lookup } = args;
+export async function cutExperiment(args: CutExperimentArgs, deps: CutExperimentDeps = {}): Promise<ExperimentRecord> {
+  const { sftddDir, projectDir, featureId, storyId, experimentSlug, branch, parentBranch, ttl, notes, resetStaleBranch, ...lookup } = args;
+  const create = deps.createPairedBranch ?? createPairedBranch;
+  const dropBranch = deps.deletePairedBranch ?? deletePairedBranch;
+  // Re-cut re-fork (Finding 27): a discarded experiment's paired branch of this
+  // same deterministic name still carries its schema, so reusing it makes the
+  // rebuild's migrations collide. Drop it first so the fork below is clean. The
+  // git branch is torn down too (PAIRED). Best-effort: a missing branch or a
+  // teardown hiccup must not block the fresh fork, which is the whole point.
+  if (resetStaleBranch) {
+    try {
+      await dropBranch({ instance: lookup.instance, branch, cwd: projectDir });
+    } catch {
+      /* no stale branch to drop / teardown raced: proceed to fork clean */
+    }
+  }
   // PAIRED cut through the substrate: Lakebase branch + git branch + .env sync,
   // atomically. The experiment is a child of the feature branch (parentBranch),
   // so it forks Lakebase from the feature branch and git-branches off the
   // currently-checked-out feature branch. ttl when given (ephemeral spike),
   // else noExpiry (matches createFeaturePairedBranch's tier semantics).
-  const paired = await createPairedBranch({
+  const paired = await create({
     instance: lookup.instance,
     branch,
     parentBranch,

--- a/scripts/sftdd/orchestrator-derive.ts
+++ b/scripts/sftdd/orchestrator-derive.ts
@@ -162,6 +162,7 @@ function storyView(
       // An experiment that was discarded is no longer cut (a fresh one is cut
       // on revise); merged/active both count as cut.
       experimentCut: e.experiment != null && e.experiment.status !== "discarded",
+      experimentDiscarded: e.experiment != null && e.experiment.status === "discarded",
       testsWritten: probe.testsWritten(id),
       codeWritten: probe.codeWritten(id),
       loop,

--- a/scripts/sftdd/orchestrator-drive.ts
+++ b/scripts/sftdd/orchestrator-drive.ts
@@ -174,6 +174,12 @@ export function nextDesignAction(state: DesignDriveState): DriveAction {
 export interface StoryBuild {
   /** The paired experiment branch was cut. */
   experimentCut: boolean;
+  /** A PRIOR experiment for this story was discarded (revise / rebuild-story), so
+   *  the upcoming cut is a RE-cut. The paired Lakebase branch of the same
+   *  deterministic name may still carry the discarded build's schema, so the
+   *  re-cut must re-fork it clean (--reset-stale-branch), mirroring the ci-pr
+   *  --reset-stale-branch precedent (Finding 27). */
+  experimentDiscarded?: boolean;
   /** The Navigator wrote the (failing) tests for the story. */
   testsWritten: boolean;
   /** The Driver made the tests pass. */
@@ -327,7 +333,7 @@ export type WorkflowAction =
   | { kind: "approve-plan-gate" }
   | { kind: "planning-complete" }
   | { kind: "dispatch"; story: string }
-  | { kind: "cut-experiment"; story: string }
+  | { kind: "cut-experiment"; story: string; resetStaleBranch?: boolean }
   | {
       kind: "invoke-role";
       role: "navigator" | "driver";
@@ -366,7 +372,12 @@ export type WorkflowAction =
 
 /** The next build-lane action for the story the lane is on. */
 function nextBuildAction(story: string, b: StoryBuild): WorkflowAction {
-  if (!b.experimentCut) return { kind: "cut-experiment", story };
+  if (!b.experimentCut) {
+    // A re-cut after a discarded experiment re-forks the polluted paired branch.
+    return b.experimentDiscarded
+      ? { kind: "cut-experiment", story, resetStaleBranch: true }
+      : { kind: "cut-experiment", story };
+  }
   // Per-AC RED -> GREEN -> REVIEW -> REFACTOR: each AC completes its full cycle
   // before the next AC's first test is written. The per-story BUILD list is
   // grouped by AC (scopeToStory), so once an AC's tests are all green its REVIEW

--- a/scripts/sftdd/orchestrator-effects.ts
+++ b/scripts/sftdd/orchestrator-effects.ts
@@ -1250,6 +1250,9 @@ export function commandsForAction(action: WorkflowAction, cfg: DriveEffectsConfi
             cfg.projectDir,
             "--tdd-dir",
             cfg.sftddDir,
+            // A re-cut after a discarded experiment re-forks the stale paired branch
+            // clean (Finding 27); a first cut omits it (nothing to reset).
+            ...(action.resetStaleBranch ? ["--reset-stale-branch"] : []),
           ],
         },
       ];

--- a/scripts/sftdd/revise.ts
+++ b/scripts/sftdd/revise.ts
@@ -28,9 +28,17 @@ import {
   storyAcIds,
   resolveSftddDir,
 } from "./sftdd-paths.js";
-import { readPipeline, writePipeline, reviseStory } from "./story-pipeline.js";
-import { markSmellResolved, composeReviseBrief, readSmellsLog, specLevelSmell } from "./smells.js";
+import { readPipeline, writePipeline, reviseStory, setStoryStatus } from "./story-pipeline.js";
+import {
+  markSmellResolved,
+  composeReviseBrief,
+  readSmellsLog,
+  specLevelSmell,
+  resolveAllOpenSmellsForStory,
+} from "./smells.js";
 import { clearReflectVerdict } from "./reflection.js";
+import { resetStoryBuildState } from "./cycle-record.js";
+import { resolveEscalationsForStory } from "./escalation.js";
 
 /** Default author identity recorded on a headless self-heal. A real interactive
  *  decision passes the human's identity through `approver`. */
@@ -172,6 +180,15 @@ export function applyReviseSelfHeal(args: ReviseSelfHealArgs): ReviseSelfHealRes
   reviseStory(pipeline, args.story, { approver, at, reason: args.reason });
   writePipeline(sftddDir, pipeline);
 
+  // 2a. Reset the story's BUILD state (Finding 27). reviseStory only flips the
+  // pipeline status; the build lane derives "pending" from the cycle records on
+  // disk, so a status-only revise leaves every stale green_at behind. Once the
+  // design lane regenerates a same-id test-list those cycles re-match and the
+  // story reads allGreen, so the drive skips RED/GREEN straight back to deploy and
+  // re-fails on the same stale build. Clearing the cycles makes it genuinely
+  // re-drive , the SAME reset the `experiment discard --revise` door already does.
+  resetStoryBuildState(sftddDir, args.featureId, args.story);
+
   // 2b. Force the owning author to actually RE-AUTHOR: stale its artifact so the
   // design lane re-invokes it, and deliver the verdict as a smell-aware hand-back
   // brief (composeReviseBrief FORCES missing coverage for a reflect defect, keeps
@@ -271,7 +288,92 @@ export function reviseStoryWithSelfHeal(
     reason: opts.reason,
   });
   writePipeline(sftddDir, pipeline);
+  // Finding 27: even the plain reset must clear the stale build cycles, or the
+  // (still-present) test-list reads allGreen off them and the build lane skips.
+  resetStoryBuildState(sftddDir, featureId, story);
   return { mode: "plain", story };
+}
+
+export interface RebuildStoryResult {
+  /** Cycle artifacts were removed (the story's build was cleared). */
+  cyclesCleared: boolean;
+  /** How many per-story test-list items were flipped back to `pending`. */
+  testItemsReset: number;
+  /** Explicit HIL escalation files resolved (deploy-verify / driver-green halts). */
+  escalationsCleared: string[];
+  /** Blocking smells resolved for the story. */
+  smellsCleared: string[];
+  /** The prior experiment was marked discarded so the drive re-forks it clean. */
+  experimentReset: boolean;
+}
+
+/**
+ * `pipeline rebuild-story`: the explicit, sanctioned "re-drive this story from a
+ * clean slate" operator op (Finding 27), so recovering a story after a caught
+ * false-GREEN (or any build-lane defect) never requires hand-deleting kit-internal
+ * state (`rm -rf .sftdd/cycles/...`). It clears EVERY on-disk source that would
+ * otherwise make the re-drive skip the build or immediately re-halt:
+ *   1. the build cycle records + test-list statuses (resetStoryBuildState), so the
+ *      story reads pending again and the lane re-runs RED/GREEN;
+ *   2. the story's explicit HIL escalation files AND its blocking smells , the two
+ *      escalation sources, either of which alone would pin it back to raise-to-hil;
+ *   3. the prior experiment record (-> discarded), so the drive re-cuts a FRESH
+ *      experiment branch (with --reset-stale-branch) instead of reusing the
+ *      polluted one.
+ * It then puts the story back on the single build lane (status building + active).
+ * Single-lane invariant: refuses (throws) when the lane is busy with a DIFFERENT
+ * story. Throws when the story is not in the pipeline.
+ */
+export function rebuildStory(
+  sftddDir: string,
+  featureId: string,
+  story: string,
+  opts?: { approver?: string; at?: string },
+): RebuildStoryResult {
+  const at = opts?.at ?? new Date().toISOString();
+  const pipeline = readPipeline(sftddDir, featureId);
+  const entry = pipeline.stories[story];
+  if (!entry) throw new Error(`rebuild-story: story ${story} is not in the pipeline for ${featureId}`);
+  if (pipeline.build_active !== null && pipeline.build_active !== story) {
+    throw new Error(
+      `rebuild-story: the build lane is busy on ${pipeline.build_active}; ` +
+        `complete, revise, or discard it before rebuilding ${story}.`,
+    );
+  }
+
+  const build = resetStoryBuildState(sftddDir, featureId, story);
+  const escalationsCleared = resolveEscalationsForStory(sftddDir, featureId, story, at);
+  const smellsCleared = resolveAllOpenSmellsForStory(
+    sftddDir,
+    story,
+    `cleared for rebuild-story by ${opts?.approver ?? "operator"}`,
+  );
+
+  // Re-fork the experiment on the next cut: a discarded experiment record makes
+  // the drive re-cut (experimentCut reads false) and pass --reset-stale-branch, so
+  // the rebuild forks a clean paired branch off feature HEAD rather than reusing
+  // the branch that carries the discarded build's schema.
+  let experimentReset = false;
+  if (entry.experiment && entry.experiment.status !== "discarded") {
+    entry.experiment.status = "discarded";
+    entry.experiment.closed_at = at;
+    experimentReset = true;
+  }
+
+  // Put the story back on the single build lane from the clean slate.
+  setStoryStatus(pipeline, story, "building");
+  pipeline.build_active = story;
+  const idx = pipeline.build_queue.indexOf(story);
+  if (idx !== -1) pipeline.build_queue.splice(idx, 1);
+  writePipeline(sftddDir, pipeline);
+
+  return {
+    cyclesCleared: build.cyclesCleared,
+    testItemsReset: build.testItemsReset,
+    escalationsCleared,
+    smellsCleared,
+    experimentReset,
+  };
 }
 
 /** On `discard`, a story leaves the sprint, so any blocking smell against it must

--- a/scripts/sftdd/smells.ts
+++ b/scripts/sftdd/smells.ts
@@ -783,6 +783,35 @@ export function resolveOpenSmells(
   return n;
 }
 
+/**
+ * Resolve EVERY open smell scoped strictly to a story (regardless of name), for a
+ * clean rebuild of that story (Finding 27). A `rebuild-story` supersedes all prior
+ * observations about the story it is re-driving, so any blocking smell (spec OR
+ * build level) against it must be cleared or the drive re-blocks at raise-to-hil
+ * on a smell for code that no longer exists. Strictly story-scoped: a feature-wide
+ * (story_id undefined) smell is left untouched (it is not this story's to clear).
+ * Marked `cleared` (never `revised`), so it does not spend the one-revise budget.
+ * Returns the resolved smell names.
+ */
+export function resolveAllOpenSmellsForStory(
+  sftddDir: string,
+  story: string,
+  note?: string,
+): string[] {
+  const file = join(sftddDir, "smells.json");
+  if (!existsSync(file)) return [];
+  const log: SmellsLog = JSON.parse(readFileSync(file, "utf8"));
+  const cleared: string[] = [];
+  for (const d of log.detected) {
+    if (d.resolution || d.story_id !== story) continue;
+    d.resolution = note ?? "cleared for rebuild-story";
+    d.resolution_kind = "cleared";
+    cleared.push(d.smell);
+  }
+  if (cleared.length) writeFileSync(file, JSON.stringify(log, null, 2) + "\n");
+  return cleared;
+}
+
 /** How many times this (smell, story) has already been revised: the
  *  count of resolved-as-`revised` entries. The one-revise-per-(smell,story) bound
  *  compares against this so a re-fired-then-revised smell can't loop forever. */

--- a/scripts/sftdd/story-experiment.cli.ts
+++ b/scripts/sftdd/story-experiment.cli.ts
@@ -4,7 +4,7 @@
 // into the tested orchestration (experiment-lifecycle.ts) and records the
 // pipeline-state transition (story-pipeline.ts).
 //
-//   lakebase-sftdd-experiment cut      --feature F --story S --slug X --branch B --parent FB --instance I [--ttl T] [--project-dir P] [--tdd-dir D]
+//   lakebase-sftdd-experiment cut      --feature F --story S --slug X --branch B --parent FB --instance I [--ttl T] [--reset-stale-branch] [--project-dir P] [--tdd-dir D]
 //   lakebase-sftdd-experiment merge    --feature F --story S --slug X --experiment-branch B --feature-branch FB --instance I --approver A [--at ISO] [--project-dir P] [--tdd-dir D]
 //   lakebase-sftdd-experiment discard  --feature F --story S --slug X --instance I --approver A --reason R [--revise] [--at ISO] [--tdd-dir D]
 //
@@ -51,7 +51,7 @@ function usage(msg: string): number {
   process.stderr.write(
     `${msg}\n` +
       `Usage: lakebase-sftdd-experiment <cut|merge|discard> --feature <F> --story <S> --slug <X> --instance <I> [--tdd-dir <D>]\n` +
-      `  cut needs --branch <B> --parent <FB> [--ttl <T>] [--project-dir <P>]\n` +
+      `  cut needs --branch <B> --parent <FB> [--ttl <T>] [--reset-stale-branch] [--project-dir <P>]\n` +
       `  merge needs --experiment-branch <B> --feature-branch <FB> --approver <A> [--at <ISO>] [--project-dir <P>]\n` +
       `  discard needs --approver <A> --reason <R> [--revise] [--at <ISO>]\n`,
   );
@@ -84,6 +84,7 @@ async function main(): Promise<number> {
         branch: args.branch as string,
         parentBranch: args.parent as string,
         ttl: args.ttl,
+        ...(args.resetStaleBranch ? { resetStaleBranch: true } : {}),
       });
       const p = readPipeline(sftddDir, feature);
       cutStoryExperiment(p, story, {

--- a/scripts/sftdd/story-pipeline.cli.ts
+++ b/scripts/sftdd/story-pipeline.cli.ts
@@ -18,6 +18,7 @@
 //   lakebase-sftdd-pipeline accept         --feature F --story S --approver A    (PO accepts -> experiment merged, story done, lane freed)
 //   lakebase-sftdd-pipeline discard        --feature F --story S --approver A --reason R   (PO discards -> torn down, out of sprint)
 //   lakebase-sftdd-pipeline revise         --feature F --story S --approver A --reason R   (PO sends back -> designing; self-heals a blocking smell)
+//   lakebase-sftdd-pipeline rebuild-story  --feature F --story S [--approver A] [--at ISO]  (clean-slate re-drive: clears build cycles + escalations + smells, re-forks the experiment, back on the build lane)
 //   lakebase-sftdd-pipeline resolve-smell  --feature F --smell NAME --approver A [--story S] [--reason R]   (clear a blocking smell without revise/discard)
 //
 // The formal per-story spec gate is surface -> approve-gate; approve-gate is
@@ -56,7 +57,7 @@ import {
 } from "./story-pipeline";
 import { join } from "path";
 import { resolveSftddDir } from "./sftdd-paths.js";
-import { reviseStoryWithSelfHeal, clearStoryBlockingSmellOnDiscard } from "./revise.js";
+import { reviseStoryWithSelfHeal, clearStoryBlockingSmellOnDiscard, rebuildStory } from "./revise.js";
 import { markSmellResolved } from "./smells.js";
 import { resolveAcceptMergeArgs, experimentMergeArgv } from "./experiment-merge.js";
 import { runKitBinSync } from "./kit-bin.js";
@@ -113,7 +114,7 @@ function parse(argv: string[]): Args {
 function usage(msg: string): number {
   process.stderr.write(
     `${msg}\n` +
-      `Usage: lakebase-sftdd-pipeline <status|set|surface|approve-gate|withdraw-gate|enqueue|dispatch|complete|cut-experiment|await-acceptance|accept|discard|revise|resolve-smell> --feature <F> [--tdd-dir <dir>]\n` +
+      `Usage: lakebase-sftdd-pipeline <status|set|surface|approve-gate|withdraw-gate|enqueue|dispatch|complete|cut-experiment|await-acceptance|accept|discard|revise|rebuild-story|resolve-smell> --feature <F> [--tdd-dir <dir>]\n` +
       `  set additionally needs --story <S> --status <${STORY_STATUSES.join("|")}>\n` +
       `  surface needs --story <S>\n` +
       `  approve-gate needs --story <S> --approver <A> [--spec-hash <H>] [--at <ISO>]\n` +
@@ -123,6 +124,7 @@ function usage(msg: string): number {
       `  await-acceptance needs --story <S>\n` +
       `  accept needs --story <S> --approver <A> [--at <ISO>]\n` +
       `  discard / revise need --story <S> --approver <A> --reason <R> [--at <ISO>]\n` +
+      `  rebuild-story needs --story <S> [--approver <A>] [--at <ISO>]\n` +
       `  resolve-smell needs --smell <NAME> --approver <A> [--story <S>] [--reason <R>]\n`,
   );
   return 2;
@@ -359,6 +361,33 @@ async function main(): Promise<number> {
       } else {
         process.stdout.write(`revising ${args.story} (${args.reason}); experiment torn down, back to designing, lane freed\n`);
       }
+      return 0;
+    }
+    case "rebuild-story": {
+      // The sanctioned "re-drive this story from a clean slate" op (Finding 27):
+      // clears the build cycles + test-list, the story's HIL escalations AND
+      // blocking smells, resets the experiment for a clean re-fork, and puts the
+      // story back on the build lane , so recovering a story after a caught
+      // false-GREEN never needs `rm -rf .sftdd/cycles/...` + hand-edits.
+      if (!args.story) return usage("rebuild-story needs --story");
+      let r;
+      try {
+        r = rebuildStory(sftddDir, feature, args.story, {
+          ...(args.approver ? { approver: args.approver } : {}),
+          ...(args.at ? { at: args.at } : {}),
+        });
+      } catch (e) {
+        process.stderr.write(`rebuild-story: ${e instanceof Error ? e.message : String(e)}\n`);
+        return 2;
+      }
+      const parts = [
+        r.cyclesCleared ? "cleared build cycles" : "no build cycles to clear",
+        `${r.testItemsReset} test item(s) reset`,
+        `${r.escalationsCleared.length} escalation(s) cleared`,
+        r.smellsCleared.length ? `smells cleared: ${r.smellsCleared.join(", ")}` : "no smells to clear",
+        r.experimentReset ? "experiment reset for re-fork" : "no experiment to reset",
+      ];
+      process.stdout.write(`rebuild-story ${args.story}: ${parts.join("; ")}; back on the build lane (building)\n`);
       return 0;
     }
     case "resolve-smell": {

--- a/tests/bdd/orchestrator-derive.test.ts
+++ b/tests/bdd/orchestrator-derive.test.ts
@@ -89,6 +89,10 @@ describe("deriveDriveState: gate + acceptance mapping", () => {
     expect(st.stories.S1.build.accepted).toBe(true);
     expect(st.stories.S1.build.experimentCut).toBe(true);
     expect(st.stories.S2.build.experimentCut).toBe(false);
+    // Finding 27: a discarded experiment marks the story for a re-cut re-fork
+    // (--reset-stale-branch); a merged/active one does not.
+    expect(st.stories.S2.build.experimentDiscarded).toBe(true);
+    expect(st.stories.S1.build.experimentDiscarded).toBe(false);
   });
 });
 

--- a/tests/bdd/orchestrator-drive.test.ts
+++ b/tests/bdd/orchestrator-drive.test.ts
@@ -230,6 +230,16 @@ describe("nextTransition: build lane (after a story is gated)", () => {
     expect(nextTransition(st)).toEqual({ kind: "complete", story: "S1" });
   });
 
+  it("re-cuts with resetStaleBranch when a prior experiment was discarded (Finding 27)", () => {
+    // A revised / rebuilt story has a DISCARDED experiment (experimentCut false,
+    // experimentDiscarded true): the re-cut must re-fork the polluted paired
+    // branch clean rather than reuse it.
+    const v = gatedUnbuilt();
+    v.build.experimentDiscarded = true;
+    const st = ws({ stories: { S1: v }, buildActive: "S1" });
+    expect(nextTransition(st)).toEqual({ kind: "cut-experiment", story: "S1", resetStaleBranch: true });
+  });
+
   it("opt-in 'ac' granularity: does a pending AC's REVIEW before writing the next AC's tests (per-AC RED-GREEN-REVIEW-REFACTOR)", () => {
     // AC1's tests are all green (reviewAc=AC1) but the story is not all-green yet
     // (AC2's tests are still pending -> testsWritten false). The lane must REVIEW

--- a/tests/bdd/orchestrator-experiment-contract.test.ts
+++ b/tests/bdd/orchestrator-experiment-contract.test.ts
@@ -46,6 +46,18 @@ describe("driver -> experiment CLI contract (the shipped path, not the module)",
     expect(args[0]).toBe("cut");
     // Validate through the CLI's OWN required-arg contract.
     expect(validateExperimentArgs(parseExperimentArgs(args))).toBeNull();
+    // A first cut does NOT re-fork (nothing stale to reset).
+    expect(args).not.toContain("--reset-stale-branch");
+    expect(parseExperimentArgs(args).resetStaleBranch).toBeUndefined();
+  });
+
+  it("a RE-cut (resetStaleBranch) emits --reset-stale-branch the CLI parses (Finding 27)", () => {
+    const args = experimentArgs({ kind: "cut-experiment", story: "S1-create-bug-form", resetStaleBranch: true }, cfg());
+    expect(args[0]).toBe("cut");
+    expect(args).toContain("--reset-stale-branch");
+    const parsed = parseExperimentArgs(args);
+    expect(parsed.resetStaleBranch).toBe(true);
+    expect(validateExperimentArgs(parsed)).toBeNull();
   });
 
   it("accept emits pipeline accept (which performs the merge), NOT an experiment CLI command (FEIP-8013)", () => {

--- a/tests/bdd/sftdd-experiment-lifecycle.test.ts
+++ b/tests/bdd/sftdd-experiment-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   writeOutcomes,
   deleteExperiment,
   cutExperiment,
+  type CutExperimentDeps,
 } from "../../scripts/sftdd/experiment";
 
 // LIVE gate uses LAKEBASE_TEST_INSTANCE (the bare project id; substrate's
@@ -34,6 +35,54 @@ afterEach(() => {
 describe("experiment lifecycle (hermetic)", () => {
   it("listExperiments returns empty when no experiments dir exists", () => {
     expect(listExperiments(tdd, "F1", "S1")).toEqual([]);
+  });
+
+  // Finding 27: a re-cut after a discarded experiment must re-fork the polluted
+  // paired branch. cutExperiment(resetStaleBranch) drops it BEFORE forking; the
+  // ordering is proven hermetically via the injected paired-branch ops seam (the
+  // live drop+fork is exercised by the LIVE gate above).
+  function pairedSeam(calls: string[]): CutExperimentDeps {
+    return {
+      createPairedBranch: (async () => {
+        calls.push("create");
+        return { branch: { name: "experiment/S1-exp1" }, gitBranch: "experiment-s1-exp1", gitBranchCreated: true, envSynced: true, warnings: [] };
+      }) as unknown as CutExperimentDeps["createPairedBranch"],
+      deletePairedBranch: (async () => {
+        calls.push("drop");
+        return { deleted: true, warnings: [] };
+      }) as unknown as CutExperimentDeps["deletePairedBranch"],
+    };
+  }
+  const cutArgs = {
+    instance: "lb", sftddDir: "", projectDir: "", featureId: "F1", storyId: "S1",
+    experimentSlug: "exp1", branch: "experiment/S1-exp1", parentBranch: "feature/x",
+  };
+
+  it("resetStaleBranch drops the existing paired branch BEFORE forking (Finding 27)", async () => {
+    const calls: string[] = [];
+    const rec = await cutExperiment({ ...cutArgs, sftddDir: tdd, projectDir: tdd, resetStaleBranch: true }, pairedSeam(calls));
+    expect(calls).toEqual(["drop", "create"]);
+    expect(rec.branch_id).toBe("S1-exp1");
+  });
+
+  it("a first cut (no resetStaleBranch) forks WITHOUT dropping", async () => {
+    const calls: string[] = [];
+    await cutExperiment({ ...cutArgs, sftddDir: tdd, projectDir: tdd }, pairedSeam(calls));
+    expect(calls).toEqual(["create"]);
+  });
+
+  it("a resetStaleBranch drop that throws (no stale branch) still forks clean", async () => {
+    const calls: string[] = [];
+    const seam: CutExperimentDeps = {
+      ...pairedSeam(calls),
+      deletePairedBranch: (async () => {
+        calls.push("drop-throw");
+        throw new Error("branch not found");
+      }) as unknown as CutExperimentDeps["deletePairedBranch"],
+    };
+    const rec = await cutExperiment({ ...cutArgs, sftddDir: tdd, projectDir: tdd, resetStaleBranch: true }, seam);
+    expect(calls).toEqual(["drop-throw", "create"]); // best-effort: the fork still ran
+    expect(rec.branch_id).toBe("S1-exp1");
   });
 
   it("listExperiments reads existing experiment dirs", () => {

--- a/tests/bdd/sftdd-revise-routing.test.ts
+++ b/tests/bdd/sftdd-revise-routing.test.ts
@@ -22,7 +22,7 @@ import {
   priorReviseCount,
   readSmellsLog,
 } from "../../scripts/sftdd/smells";
-import { recordBlockingSmellFlag } from "../../scripts/sftdd/escalation";
+import { recordBlockingSmellFlag, writeEscalation, readEscalations } from "../../scripts/sftdd/escalation";
 import { nextTransition, actionLane, type DriveState } from "../../scripts/sftdd/orchestrator-drive";
 import { commandsForAction, type DriveEffectsConfig } from "../../scripts/sftdd/orchestrator-effects";
 import { diskArtifactProbe } from "../../scripts/sftdd/orchestrator-probe";
@@ -31,7 +31,10 @@ import {
   reviseStoryWithSelfHeal,
   revisableSmellForStory,
   clearStoryBlockingSmellOnDiscard,
+  rebuildStory,
 } from "../../scripts/sftdd/revise";
+import { storyTestProgress } from "../../scripts/sftdd/cycle-record";
+import { cyclesRootDir } from "../../scripts/sftdd/sftdd-paths";
 import { readFileSync as readFileSyncNode } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { writeReflectVerdict, reflectionVerdictWritten } from "../../scripts/sftdd/reflection";
@@ -206,6 +209,32 @@ function seedDesignArtifacts(tdd: string): void {
   );
 }
 
+/** Seed a GREEN cycle on disk for AC1-x/T1 (red_at + green_at), mirroring a story
+ *  the build lane already drove green. resetStoryBuildState must remove it so a
+ *  revised/rebuilt story re-drives RED/GREEN instead of resurrecting the stale
+ *  green_at against a regenerated (same-id) test-list (Finding 27). */
+function seedGreenCycle(tdd: string): void {
+  const dir = join(cyclesRootDir(tdd), FEATURE, STORY, "AC1-x");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "cycle-001.json"),
+    JSON.stringify({
+      cycle_id: "cycle-001",
+      feature_id: FEATURE,
+      story_id: STORY,
+      ac_id: "AC1-x",
+      test_id: "T1",
+      red_at: "2026-07-17T00:00:00.000Z",
+      green_at: "2026-07-17T00:01:00.000Z",
+    }) + "\n",
+  );
+}
+
+/** True when the story has any cycle artifact on disk. */
+function hasCycles(tdd: string): boolean {
+  return existsSync(join(cyclesRootDir(tdd), FEATURE, STORY));
+}
+
 describe("applyReviseSelfHeal (the revise self-heal transition)", () => {
   let tdd: string;
   beforeEach(() => {
@@ -237,6 +266,19 @@ describe("applyReviseSelfHeal (the revise self-heal transition)", () => {
 
     // The smell is resolved-as-revised: the one-revise budget is now spent.
     expect(priorReviseCount(tdd, "ac-overlap", STORY)).toBe(1);
+  });
+
+  it("resets the story's BUILD state so it re-drives RED/GREEN, not re-deploy (Finding 27)", () => {
+    // A revised story that kept its stale green_at cycles resurrects allGreen once
+    // the design lane regenerates a same-id test-list, so the drive skips the build
+    // and re-fails at deploy. The revise must clear the cycle records.
+    seedGreenCycle(tdd);
+    expect(hasCycles(tdd)).toBe(true);
+    applyReviseSelfHeal({
+      featureId: FEATURE, story: STORY, smell: "ac-overlap",
+      routedTo: "spec-author", gate: "spec", reason: "AC4 implied by AC2", sftddDir: tdd,
+    });
+    expect(hasCycles(tdd)).toBe(false);
   });
 
   it("is NOT hollow: stales the owning author's artifacts + writes the verdict brief", () => {
@@ -333,6 +375,21 @@ describe("reviseStoryWithSelfHeal (operator pipeline revise)", () => {
     expect(readPipeline(tdd, FEATURE).stories[STORY].status).toBe("designing");
   });
 
+  it("the PLAIN reset also clears stale build cycles so the story re-drives (Finding 27)", () => {
+    // The plain (no-smell) revise flips status to designing but leaves the test
+    // list intact, so without a cycle reset every item reads green from the stale
+    // cycles and the build lane skips straight to deploy.
+    seedGreenCycle(tdd);
+    expect(storyTestProgress(tdd, FEATURE, STORY).allGreen).toBe(true);
+    const outcome = reviseStoryWithSelfHeal(tdd, FEATURE, STORY, {
+      approver: "po@example.com",
+      reason: "PO wants a different approach",
+    });
+    expect(outcome.mode).toBe("plain");
+    expect(hasCycles(tdd)).toBe(false);
+    expect(storyTestProgress(tdd, FEATURE, STORY).allGreen).toBe(false);
+  });
+
   it("revisableSmellForStory ignores a build-level (non-spec) smell", () => {
     recordBlockingSmellFlag(tdd, "cycle-stall", "stalled", { story_id: STORY });
     expect(revisableSmellForStory(tdd, FEATURE, STORY)).toBeNull();
@@ -345,6 +402,67 @@ describe("reviseStoryWithSelfHeal (operator pipeline revise)", () => {
     // Resolved, but NOT as a revise (discard does not spend the one-revise budget).
     expect(readSmellsLog(tdd).detected.some((d) => !d.resolution && d.smell === "reflect-testlist-defect")).toBe(false);
     expect(priorReviseCount(tdd, "reflect-testlist-defect", STORY)).toBe(0);
+  });
+});
+
+// ---- rebuild-story: the explicit clean-slate re-drive op (Finding 27) ----------
+
+describe("rebuildStory (pipeline rebuild-story)", () => {
+  let tdd: string;
+  beforeEach(() => {
+    tdd = mkdtempSync(join(tmpdir(), "tdd-rebuild-"));
+    writePipeline(tdd, pipelineBuilding()); // STORY building + active, experiment active
+    seedDesignArtifacts(tdd);
+  });
+  afterEach(() => rmSync(tdd, { recursive: true, force: true }));
+
+  it("clears cycles, escalations, smells, re-forks the experiment, and re-lanes the story", () => {
+    seedGreenCycle(tdd);
+    // The two escalation sources that pin a story to the HIL after a false-GREEN:
+    writeEscalation(tdd, { source: "deploy-verify", reason: "S2 verify failed", feature_id: FEATURE, story_id: STORY });
+    // A build-level blocking smell (rebuild clears these too, not just spec-level).
+    recordBlockingSmellFlag(tdd, "cycle-stall", "stuck at deploy", { story_id: STORY });
+    expect(hasCycles(tdd)).toBe(true);
+
+    const r = rebuildStory(tdd, FEATURE, STORY, { approver: "po@example.com" });
+
+    expect(r.cyclesCleared).toBe(true);
+    expect(r.testItemsReset).toBeGreaterThanOrEqual(0);
+    expect(r.escalationsCleared).toHaveLength(1);
+    expect(r.smellsCleared).toContain("cycle-stall");
+    expect(r.experimentReset).toBe(true);
+
+    // Build state is clean -> the drive re-runs RED/GREEN, not deploy.
+    expect(hasCycles(tdd)).toBe(false);
+    expect(storyTestProgress(tdd, FEATURE, STORY).allGreen).toBe(false);
+    // Both HIL sources are cleared (dual-source rule): no unresolved escalation,
+    // no open smell for the story.
+    expect(readEscalations(tdd).every((e) => e.resolved_at || e.story_id !== STORY)).toBe(true);
+    expect(readSmellsLog(tdd).detected.some((d) => !d.resolution && d.story_id === STORY)).toBe(false);
+    // The story is back on the single build lane from a clean slate.
+    const p = readPipeline(tdd, FEATURE);
+    expect(p.stories[STORY].status).toBe("building");
+    expect(p.build_active).toBe(STORY);
+    expect(p.stories[STORY].experiment?.status).toBe("discarded");
+  });
+
+  it("refuses when the build lane is busy on a different story (single-lane invariant)", () => {
+    const p = readPipeline(tdd, FEATURE);
+    p.build_active = "S9-other";
+    writePipeline(tdd, p);
+    expect(() => rebuildStory(tdd, FEATURE, STORY)).toThrow(/busy on S9-other/);
+  });
+
+  it("throws when the story is not in the pipeline", () => {
+    expect(() => rebuildStory(tdd, FEATURE, "S404-missing")).toThrow(/not in the pipeline/);
+  });
+
+  it("is idempotent enough to re-run: a second call is a clean no-op on the cycles", () => {
+    seedGreenCycle(tdd);
+    rebuildStory(tdd, FEATURE, STORY);
+    const r2 = rebuildStory(tdd, FEATURE, STORY);
+    expect(r2.cyclesCleared).toBe(false);
+    expect(r2.escalationsCleared).toHaveLength(0);
   });
 });
 
@@ -361,6 +479,10 @@ describe("story-pipeline CLI wires the self-heal (static)", () => {
   });
   it("exposes a resolve-smell subcommand", () => {
     expect(cliSrc).toMatch(/case "resolve-smell"/);
+  });
+  it("exposes a rebuild-story subcommand wired to rebuildStory", () => {
+    expect(cliSrc).toMatch(/case "rebuild-story"/);
+    expect(cliSrc).toMatch(/rebuildStory\(/);
   });
 });
 


### PR DESCRIPTION
## Finding 27 (Medium)

A story sent back to be rebuilt could not be cleanly re-driven: `discard` / `pipeline revise` / `set --status building` reset the pipeline status but left the per-story cycle records under `.sftdd/cycles/` intact. The drive derives "build already GREEN" (`codeWritten -> storyTestProgress.allGreen`) from those stale `green_at` files, so a re-driven story skipped RED/GREEN and jumped straight to deploy, re-failing the same deploy-verify in a loop. Recovery required hand-deleting kit-internal cycle records + the paired Lakebase experiment branch.

**Root cause:** split-brain. `resetStoryBuildState` (the exact clear-cycles + reset-test-list primitive) existed but was wired into **only** the `lakebase-sftdd-experiment discard --revise` door.

## Fix (3 parts)

1. **Wire `resetStoryBuildState` into both revise doors** (`applyReviseSelfHeal` + the plain-reset branch of `reviseStoryWithSelfHeal`), so the operator `pipeline revise` and the driver's auto revise-route re-drive from a clean slate.
2. **New `pipeline rebuild-story` op** — clears build cycles + test-list, **both** HIL escalation sources (escalation files via `resolveEscalationsForStory`, blocking smells via `resolveAllOpenSmellsForStory` — the dual-source rule), marks the experiment for re-fork, and re-lanes the story (single-lane guarded). Replaces the `rm -rf .sftdd/cycles/...` recovery dance.
3. **`experiment cut --reset-stale-branch`** (drop-then-fork), auto-passed by the drive on a re-cut after a discarded experiment, mirroring the ci-pr `--reset-stale-branch` precedent. Drop-then-fork **ordering** is hermetic (injected paired-branch ops seam); the **live** DROP + re-fork against a real Lakebase branch is live-unproven and flagged for the pending live drive.

## Verification
- `npm run typecheck` clean
- Full `npx vitest run` green: **2856 passed** (+12), 138 skipped, 2 todo

This pull request and its description were written by Isaac.