### PR TITLE
refactor(scm): de-couple SCM core from sftdd (lakebase-scm-utils extraction, Phase 0) [FEIP-8263]

### DIFF
--- a/scripts/lakebase/constants.ts
+++ b/scripts/lakebase/constants.ts
@@ -28,6 +28,23 @@ export const POSTGRES_PORT = 5432;
 export const DEFAULT_DATABASE = "databricks_postgres";
 
 /**
+ * Runtime artifact + metadata directories the SCM working-tree guards tolerate
+ * as uncommitted "not code" (the fork-clean check and the open-PR dirty check).
+ * These are the kit's own runtime dirs , SCM workflow state (`.lakebase/`), the
+ * SFTDD orchestration churn (`.sftdd/`, legacy `.tdd/`), and per-agent memory ,
+ * not project source. Passed as the `isDirty({ ignore })` list. Centralized here
+ * so the SCM guards reference ONE named constant instead of inlining the runtime
+ * dir names at each callsite; the extracted lakebase-scm-utils package owns this
+ * default and callers may extend it per-call.
+ */
+export const RUNTIME_ARTIFACT_IGNORE = [
+  ".sftdd/",
+  ".tdd/",
+  ".lakebase/",
+  ".claude/agent-memory/",
+] as const;
+
+/**
  * Default Lakebase endpoint name on a branch. The service currently
  * provisions exactly one endpoint named "primary" per branch; callers
  * that want a different identifier pass `endpointName` explicitly.

--- a/scripts/lakebase/paired-branch.ts
+++ b/scripts/lakebase/paired-branch.ts
@@ -32,7 +32,7 @@ import { sanitizeBranchName } from "../util/sanitize-branch-name.js";
 import { isDirty } from "../git/status.js";
 import { updateEnvConnection } from "./env-file.js";
 import { ensureProfilePinned } from "./databricks-profile.js";
-import { DEFAULT_DATABASE, POSTGRES_PORT } from "./constants.js";
+import { DEFAULT_DATABASE, POSTGRES_PORT, RUNTIME_ARTIFACT_IGNORE } from "./constants.js";
 import { KIT_TIMEOUTS } from "./kit-config.js";
 
 // ─── Internal git helpers ───────────────────────────────────────
@@ -131,7 +131,7 @@ export async function assertCleanForFork(cwd: string, startPoint?: string): Prom
   // scm-prepare-pr. Only uncommitted edits to TRACKED source count: an untracked
   // file rides onto the fork but the build's allow-list commit never stages it, so
   // stray agent junk (e.g. a mis-quoted filename) must not block the cut.
-  if (await isDirty({ cwd, ignore: [".sftdd/", ".tdd/", ".lakebase/", ".claude/agent-memory/"], untracked: false })) {
+  if (await isDirty({ cwd, ignore: [...RUNTIME_ARTIFACT_IGNORE], untracked: false })) {
     throw new Error(
       `Working tree has uncommitted changes; refusing to fork from ${startPoint} ` +
         `(they would be carried onto the new branch). Commit or stash first.`,

--- a/scripts/lakebase/scm-doctor.cli.ts
+++ b/scripts/lakebase/scm-doctor.cli.ts
@@ -13,6 +13,11 @@ import {
   type FixFindingResult,
   type FixableFindingId,
 } from "./scm-doctor.js";
+// SFTDD stale-branch finder, injected into runDoctor so scm-doctor.ts (SCM core)
+// carries no sftdd import. This CLI is the composition point; at the
+// lakebase-scm-utils split it relocates to the kit side (which owns SFTDD).
+import { resolveSftddDir } from "../sftdd/sftdd-paths.js";
+import { findStaleBranches } from "../sftdd/stale-branches.js";
 
 interface ParsedArgs {
   projectDir?: string;
@@ -202,7 +207,10 @@ export async function runScmDoctorCli(argv: string[]): Promise<number> {
     }
   }
 
-  const report = await runDoctor({ projectDir, instance });
+  const report = await runDoctor(
+    { projectDir, instance },
+    { findStaleBranches: () => findStaleBranches(resolveSftddDir(projectDir)) },
+  );
   if (args.json) {
     const indent = args.pretty ? 2 : 0;
     process.stdout.write(`${JSON.stringify(report, null, indent)}\n`);

--- a/scripts/lakebase/scm-doctor.ts
+++ b/scripts/lakebase/scm-doctor.ts
@@ -10,7 +10,6 @@
 
 import * as fs from "node:fs";
 import { execFileSync } from "node:child_process";
-import { resolveSftddDir } from "../sftdd/sftdd-paths.js";
 import * as path from "node:path";
 import {
   getBranchByName,
@@ -30,7 +29,6 @@ import {
   type TierTopology,
 } from "./scm-workflow-state.js";
 import { sanitizeBranchName } from "../util/sanitize-branch-name.js";
-import { findStaleBranches } from "../sftdd/stale-branches.js";
 import { exec } from "../util/exec.js";
 import {
   collapseMigrationHeads,
@@ -55,6 +53,26 @@ export interface DoctorArgs {
   projectDir: string;
   /** Lakebase project id. Required to reach the Lakebase side. */
   instance?: string;
+}
+
+/** A stale experiment/spike paired branch (the SFTDD-side concept). Declared
+ *  locally so SCM core does not import the sftdd module: the caller injects a
+ *  finder via RunDoctorDeps. Shape mirrors sftdd/stale-branches.StaleBranchFinding. */
+export interface StaleBranchFinding {
+  kind: "experiment" | "spike";
+  slug: string;
+  feature_id?: string;
+  story_id?: string;
+  branch?: string;
+  reason: string;
+}
+
+/** Injected dependencies so SCM-core doctor stays free of any SFTDD import
+ *  (the split into lakebase-scm-utils). The SFTDD side (the CLI wiring, and later
+ *  the kit's doctor wrapper) supplies the stale-branch finder; when absent, the
+ *  stale-branch advisory is simply skipped. */
+export interface RunDoctorDeps {
+  findStaleBranches?: () => StaleBranchFinding[];
 }
 
 export interface DoctorReport {
@@ -104,7 +122,7 @@ function worstOf(a: DoctorSeverity, b: DoctorSeverity): DoctorSeverity {
   return order[Math.max(order.indexOf(a), order.indexOf(b))] as DoctorSeverity;
 }
 
-export async function runDoctor(args: DoctorArgs): Promise<DoctorReport> {
+export async function runDoctor(args: DoctorArgs, deps: RunDoctorDeps = {}): Promise<DoctorReport> {
   const projectDir = args.projectDir;
   const findings: DoctorFinding[] = [];
   const env = readEnv(projectDir);
@@ -112,9 +130,11 @@ export async function runDoctor(args: DoctorArgs): Promise<DoctorReport> {
   const state = readWorkflowState(projectDir);
   const workflowStatePresent = state !== null;
 
-  // 0. Stale spikes + experiments, named distinctly. Hermetic
-  // (reads .tdd records only), so it runs even without a Lakebase instance.
-  for (const stale of findStaleBranches(resolveSftddDir(projectDir))) {
+  // 0. Stale spikes + experiments, named distinctly. Hermetic (reads the
+  // SFTDD records), so it runs even without a Lakebase instance. Provided by an
+  // INJECTED finder (deps.findStaleBranches) so SCM core carries no sftdd import;
+  // skipped when no finder is supplied.
+  for (const stale of deps.findStaleBranches?.() ?? []) {
     const where = stale.feature_id ? ` ${stale.feature_id}/${stale.story_id}` : "";
     findings.push({
       id: `stale-${stale.kind}`,

--- a/scripts/lakebase/scm-prepare-pr.ts
+++ b/scripts/lakebase/scm-prepare-pr.ts
@@ -10,6 +10,7 @@ import { getCurrentBranch } from "../git/inspect.js";
 import { getAheadBehind, isDirty } from "../git/status.js";
 import { getOwnerRepo } from "../git/remote.js";
 import { createPullRequest, getPullRequest } from "../github/pr.js";
+import { RUNTIME_ARTIFACT_IGNORE } from "./constants.js";
 import {
   readWorkflowState,
   writeWorkflowState,
@@ -100,7 +101,7 @@ export async function preparePr(
     // .lakebase/ workflow state). Those are not part of the PR's code, and the
     // driver legitimately dirties them on the very step that opens the PR; the
     // guard's intent is "do not PR uncommitted code", not "freeze workflow state".
-    const dirty = await isDirty({ cwd: args.projectDir, ignore: [".sftdd/", ".tdd/", ".lakebase/", ".claude/agent-memory/"] });
+    const dirty = await isDirty({ cwd: args.projectDir, ignore: [...RUNTIME_ARTIFACT_IGNORE] });
     if (dirty) {
       throw new ScmPreparePrError(
         "Working tree has uncommitted code changes; commit them before opening the PR (or pass --force).",

--- a/tests/bdd/scm-core-no-sftdd-import.test.ts
+++ b/tests/bdd/scm-core-no-sftdd-import.test.ts
@@ -1,0 +1,61 @@
+// Split-readiness guard for the lakebase-scm-utils extraction (Track C, Phase 0).
+//
+// The SCM + substrate modules under scripts/{lakebase,github,git,util} must NOT
+// import from scripts/sftdd/, so they can move to the standalone lakebase-scm-utils
+// package without dragging the SFTDD orchestration with them. The dependency
+// direction is one-way: SFTDD depends on the substrate, never the reverse.
+//
+// A small, EXPLICIT allowlist captures the accepted composition points that
+// legitimately reach into sftdd and stay on the kit (SFTDD) side at the split:
+// the project scaffolders (create-project / adopt-*) and the scm-doctor CLI's
+// injected stale-branch finder (the module scm-doctor.ts itself is sftdd-free;
+// the CLI wires the finder in and relocates to the kit at split time). Any NEW
+// sftdd import from an SCM-core module fails this test.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
+const SCM_DIRS = ["scripts/lakebase", "scripts/github", "scripts/git", "scripts/util"];
+
+// Accepted sftdd-importing composition points (relative to repo root). These stay
+// on the SFTDD side of the split; everything else under the SCM dirs must be clean.
+const ALLOWLIST = new Set<string>([
+  "scripts/lakebase/create-project.ts",
+  "scripts/lakebase/create-project.cli.ts",
+  "scripts/lakebase/adopt-sftdd.ts",
+  "scripts/lakebase/adopt-lakebase-project.ts",
+  "scripts/lakebase/resolve-sftdd-dir.cli.ts",
+  "scripts/lakebase/scm-doctor.cli.ts",
+]);
+
+/** A relative import whose path segments include an `sftdd/` dir. */
+const SFTDD_IMPORT = /from\s+["'](?:\.\.\/)+sftdd\//;
+
+function walkTs(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(join(REPO_ROOT, dir))) {
+    const rel = `${dir}/${entry}`;
+    const abs = join(REPO_ROOT, rel);
+    if (statSync(abs).isDirectory()) out.push(...walkTs(rel));
+    else if (entry.endsWith(".ts")) out.push(rel);
+  }
+  return out;
+}
+
+describe("SCM core carries no sftdd import (lakebase-scm-utils split-readiness)", () => {
+  const importers = SCM_DIRS.flatMap(walkTs).filter((rel) =>
+    SFTDD_IMPORT.test(readFileSync(join(REPO_ROOT, rel), "utf8")),
+  );
+
+  it("no SCM/substrate module imports scripts/sftdd/ outside the accepted allowlist", () => {
+    const offenders = importers.filter((rel) => !ALLOWLIST.has(rel));
+    expect(offenders, `unexpected sftdd import(s) in SCM core: ${offenders.join(", ")}`).toEqual([]);
+  });
+
+  it("scm-doctor.ts (SCM core) is sftdd-free (the finder is injected via RunDoctorDeps)", () => {
+    expect(importers).not.toContain("scripts/lakebase/scm-doctor.ts");
+  });
+});


### PR DESCRIPTION
Phase 0 of the SCM-workflows extraction into the standalone `@databricks-solutions/lakebase-scm-utils` package (FEIP-8263, initiative plan Track C). In-place, no new repo, behavior-preserving , it removes the one blocker that prevents the SCM/substrate modules from moving out cleanly.

## Changes
- **`scm-doctor.ts` no longer imports `scripts/sftdd/*`** , the only reverse edge in SCM core. The stale experiment/spike finder is now an injected `RunDoctorDeps` dependency (`StaleBranchFinding` declared locally); `scm-doctor.cli.ts` wires the sftdd finder (the sole accepted composition point, which relocates to the kit side at the split). No test relied on `runDoctor` auto-finding stale branches, so the `lakebase-scm-doctor` bin behaves identically.
- **Centralized the dirty-tree ignore list** (`.sftdd/` `.tdd/` `.lakebase/` `.claude/agent-memory/`) into `RUNTIME_ARTIFACT_IGNORE` in `constants.ts`, referenced from `paired-branch.ts` + `scm-prepare-pr.ts`. No scattered SFTDD-dir literals remain in SCM core.
- **New split-readiness guard test** `scm-core-no-sftdd-import.test.ts`: no module under `scripts/{lakebase,github,git,util}` may import `scripts/sftdd/` outside an explicit allowlist (the scaffolders + the `scm-doctor` CLI wiring), and `scm-doctor.ts` must stay sftdd-free. Fails on any new reverse coupling.

## Verification
- `npm run typecheck` clean
- Full `npx vitest run` green: **2883 passed** (+2 the new guard), 138 skipped, 2 todo

The remaining extraction phases (create the repo, migrate history, re-point the kit + the extension, split templates/`lk`, docs) follow once the repo-creation FEIP lands.

This pull request and its description were written by Isaac.