### PR TITLE
docs(readme): reframe the trust gap as maintainability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Consort takes its name from the field of music. A *consort* is an ensemble that 
 
 ## Why Consort
 
-AI agents write code fast, but you can't trust that it works. On their own they mock the database, mark a task "done" with no test behind it, drift off the request, weaken a test to reach green, and lose the plan across a context reset. The database makes it worse: it's the one dependency you can't cheaply branch, so it gets faked with mocks and shared staging.
+AI agents write code fast, but you can't trust that the code it writes is maintainable or refactorable over the long term. On their own they mark a task "done" with no test behind it, drift off the request, weaken a test to reach green, smear logic across layers, lean on mocks that fall out of sync with the real dependency, and lose the plan across a context reset. The database makes it worse: it's the one dependency you can't cheaply branch, so it gets faked with mocks and shared staging.
 
 Lakebase removes that constraint. A database branch is a real, governed, copy-on-write copy created in about a second, so the work runs against real data instead of a mock. Consort builds on that to make an agent's "done" checkable. Every increment is:
 


### PR DESCRIPTION
Follow-up to #180.

The lede claimed "you can't trust that it works," but agent code often does work on the first pass. The real gap is whether it stays maintainable and refactorable. This reframes the opening and aligns the failure list:

- Drop bare "mock the database" from the list (normal practice, not a failure; it stays in the next sentence as the forced compromise).
- Add "smear logic across layers" and "mocks that fall out of sync with the real dependency" as the maintainability failures.