### PR TITLE
feat(telemetry): Level 2 (opt-in) usage telemetry — failure taxonomy, per-role turn timing, loop dynamics

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -5,8 +5,11 @@ the deterministic orchestrator (`consort-drive`) is used in practice — which
 commands run, how many gates a run traverses, and how runs end. This document is
 the contract: what is collected, what is **not**, and how to turn it off.
 
-This is **Level 1**: `consort-drive` only, one trace per run, resource + span
-attributes drawn from a **closed allowlist**. No free-form data is ever collected.
+The default is **Level 1**: `consort-drive` only, one trace per run, resource +
+span attributes drawn from a **closed allowlist**. **Level 2** is a separate,
+explicit **opt-in** (off by default) that captures *more* — per-role turn timings
+and coarse repair/loop counts — still drawn from a closed allowlist. No free-form
+data is ever collected at either level. See [Level 2 (opt-in)](#level-2-opt-in).
 
 ## Why this is collected
 
@@ -116,7 +119,7 @@ consort-telemetry enable          # re-enable
 | `shell` | enum | `zsh` \| `bash` \| `fish` \| `powershell` \| `unknown` |
 | `ci` | bool | in CI? |
 | `tty` | bool | interactive terminal? |
-| `level` | number | `1` |
+| `level` | number | `1` (default) or `2` (opted in) |
 
 **Root span `consort.run`** (one per `consort-drive` run):
 `trace_id`, `span_id`, `name` (`"consort.run"`), `start_ts` / `end_ts` (epoch ms),
@@ -144,6 +147,65 @@ await-acceptance, accept, complete, feature-complete, deploy, approve-deploy-gat
 deploy-complete, prepare-pr, wait-ci, approve-promote-gate, merge, raise-to-hil,
 revise-route, done
 ```
+
+## Level 2 (opt-in)
+
+**Level 2 is OFF by default and is only ever reached by an explicit opt-in.** Where
+Level 1 answers *is it healthy / adopted*, Level 2 answers *why does a run fail and
+where is the bottleneck*. It is higher-volume and closer to your work, so it is a
+separate, deliberate choice — never on unless you turn it on. Everything it adds is
+still **allowlisted enums / counts / durations — never raw content**.
+
+### Turning Level 2 on and off
+
+```bash
+consort-telemetry enable --level 2   # opt in (persisted)
+CONSORT_TELEMETRY_LEVEL=2 consort-drive …   # opt in for one invocation
+consort-telemetry enable --level 1   # back to the Level-1 default
+consort-telemetry status             # shows the resolved level
+```
+
+`CONSORT_TELEMETRY_LEVEL` wins for that invocation (`2` opts in, `1` forces back to
+Level 1); otherwise the persisted level applies. Opting in to Level 2 does **not**
+change consent: every Level-1 opt-out (`disable`, `CONSORT_TELEMETRY=0`, CI /
+non-TTY, `CONSORT_TELEMETRY_SIGNOFF=0`) still applies unchanged. On the first run
+after you opt in, `consort-drive` prints a one-time Level-2 notice to stderr.
+
+### What Level 2 adds (schema `consort/v1`, `level = 2`)
+
+On top of everything in Level 1:
+
+**Turn span `consort.turn`** (one per role invocation): `trace_id`,
+`parent_span_id`, `span_id`, `name` (`"consort.turn"`), `role` (`spec-author` \|
+`architect-reviewer` \| `dba` \| `ux-designer` \| `test-strategist` \| `navigator`
+\| `driver` \| `product-owner`), `duration_ms`, plus the OPTIONAL coarse buckets
+`model` (`opus` \| `sonnet` \| `haiku` \| `fable` \| `other`), `effort` (`low` \|
+`medium` \| `high` \| `unknown`), `token_bucket` (`xs` \| `s` \| `m` \| `l` \|
+`xl`), and `retry_count` (a number). The optional buckets are only carried when the
+executor surfaces them; they are never the exact model id, and never a raw count.
+
+**Extra `consort.run` fields** (all counts / a boolean — never content):
+`red_green_cycles`, `refactor_iterations`, `revise_rounds`, `selfheal_attempts`,
+`hil_escalations` (repair / loop dynamics — *is the ensemble thrashing*),
+`story_count`, `ui_track`, and (reserved) `feature_count`, `ac_count`,
+`test_count` (coarse project shape — *how big is the work*, never *what* the work
+is).
+
+**Extra `consort.gate` field:** `fail_class` — a nullable **categorized signature**
+of a failure drawn from a closed enum (e.g. `merge-etimedout`, `npm-proxy-hang`,
+`deploy-verify-halt`, `review-blocked-protocol`, `ux-adherence-hil`, `other`).
+**Never the error text**, path, or any free string — only the category.
+
+**Hard line, even at Level 2:** no prompts, code, spec / feature text, error
+*messages*, file paths, branch names, hostnames, or usernames. Level 2 still cannot
+reconstruct *what* you built.
+
+> **Note on population.** This release ships the full Level-2 vocabulary + opt-in and
+> emits `consort.turn` (role + timing) and the coarse `consort.run` counts from the
+> deterministic driver seam. The optional turn buckets (`model` / `effort` /
+> `token_bucket` / `retry_count`) and `gate.fail_class` are part of the closed
+> allowlist and are populated as the executor / failure-classifier surfaces them;
+> until then they are simply absent (never guessed, never free text).
 
 ## Running the local collector
 

--- a/bin/consort/telemetry.cli.ts
+++ b/bin/consort/telemetry.cli.ts
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
-// consort-telemetry: inspect + toggle Consort's Level-1 usage telemetry.
+// consort-telemetry: inspect + toggle Consort's usage telemetry.
 //
-//   consort-telemetry status [--json]   show the consent state + install id
-//   consort-telemetry enable            persist telemetry_enabled = true
-//   consort-telemetry disable           persist telemetry_enabled = false
+//   consort-telemetry status [--json]     show consent state, level + install id
+//   consort-telemetry enable [--level N]   persist telemetry_enabled = true (N = 1|2)
+//   consort-telemetry disable              persist telemetry_enabled = false
 //
-// The enable/disable decision + the persistent install id live in the home-dir
-// config (~/.config/consort/telemetry.json, XDG-aware) , NOT the repo-committed
-// `.consort/`. `status` also reports whether telemetry WOULD emit right now (the
-// full consent conjunction against the live TTY + env) and whether a real
-// endpoint is armed (it never is until a maintainer sets both the endpoint and
-// the sign-off flag). See TELEMETRY.md.
+// The enable/disable decision, the opt-in level, and the persistent install id
+// live in the home-dir config (~/.config/consort/telemetry.json, XDG-aware) , NOT
+// the repo-committed `.consort/`. Telemetry is OPT-OUT and armed by default:
+// `status` reports whether it WOULD emit right now (the full consent conjunction
+// against the live TTY + env), the resolved level, and whether the endpoint is
+// armed (it is, by default; CONSORT_TELEMETRY_SIGNOFF=0 un-arms it). Level 2 is a
+// separate, explicit opt-in (`enable --level 2`). See TELEMETRY.md.
 
 import { isCliEntry } from "@databricks-solutions/lakebase-scm-utils/util";
 import {
-  TELEMETRY_LEVEL,
   TELEMETRY_SCHEMA,
+  type TelemetryLevel,
 } from "../../consort/telemetry/allowlist.js";
 import { shouldEmitTelemetry } from "../../consort/telemetry/consent.js";
 import { endpointMode } from "../../consort/telemetry/emitter.js";
@@ -23,7 +24,9 @@ import { ciBool } from "../../consort/telemetry/resource.js";
 import {
   ensureInstallId,
   isTelemetryEnabled,
+  resolveTelemetryLevel,
   setTelemetryEnabled,
+  setTelemetryLevel,
   telemetryConfigFile,
   type HomeConfigDeps,
 } from "../../consort/telemetry/home-config.js";
@@ -34,18 +37,38 @@ export interface TelemetryCliDeps extends HomeConfigDeps {
   isTTY?: boolean;
 }
 
-const HELP = `consort-telemetry , inspect + toggle Consort Level-1 usage telemetry
+const HELP = `consort-telemetry , inspect + toggle Consort usage telemetry
 
 Usage:
-  consort-telemetry status [--json]   Show consent state, install id, endpoint mode
-  consort-telemetry enable            Persist telemetry_enabled = true
-  consort-telemetry disable           Persist telemetry_enabled = false
+  consort-telemetry status [--json]     Show consent state, level, install id, endpoint
+  consort-telemetry enable [--level N]  Persist telemetry_enabled = true (N = 1 or 2)
+  consort-telemetry disable             Persist telemetry_enabled = false
 
-Telemetry is PSEUDONYMOUS (a random per-install UUID, no PII) and, by default,
-writes NOTHING off this machine (the sink is a local no-op until a maintainer
-arms a real endpoint). Silence it any time with 'disable' or CONSORT_TELEMETRY=0.
-See TELEMETRY.md.
+Telemetry is PSEUDONYMOUS (a random per-install UUID, no PII) and OPT-OUT: by
+default a normal interactive run reports to the Consort maintainers' endpoint ,
+only allowlisted enums / counts / durations (no paths, code, or names). Opt out
+any time with 'disable', CONSORT_TELEMETRY=0, or running non-interactively / in
+CI; un-arm the endpoint entirely with CONSORT_TELEMETRY_SIGNOFF=0.
+
+Level 2 is a SEPARATE, EXPLICIT opt-in (off by default) that captures more , per-
+role turn timings + coarse repair/loop counts (still allowlisted, no free text).
+Turn it on with 'enable --level 2' (or CONSORT_TELEMETRY_LEVEL=2); go back with
+'enable --level 1'. See TELEMETRY.md.
 `;
+
+/** Parse an optional `--level N` / `--level=N` flag into a TelemetryLevel (1 or 2),
+ *  or undefined when absent / unrecognized. */
+function parseLevelFlag(argv: string[]): TelemetryLevel | undefined {
+  const eq = argv.find((a) => a.startsWith("--level="));
+  let raw = eq ? eq.slice("--level=".length) : undefined;
+  if (raw === undefined) {
+    const i = argv.indexOf("--level");
+    if (i >= 0) raw = argv[i + 1];
+  }
+  if (raw === "2") return 2;
+  if (raw === "1") return 1;
+  return undefined;
+}
 
 /** The status snapshot (also the --json shape). */
 export interface TelemetryStatus {
@@ -77,7 +100,7 @@ function buildStatus(deps: TelemetryCliDeps): TelemetryStatus {
     endpoint_armed: mode.willPost,
     config_file: telemetryConfigFile(deps),
     schema: TELEMETRY_SCHEMA,
-    level: TELEMETRY_LEVEL,
+    level: resolveTelemetryLevel(deps),
   };
 }
 
@@ -89,7 +112,7 @@ function renderStatus(s: TelemetryStatus): string {
     `    tty:               ${s.is_tty}\n` +
     `    in CI:             ${s.in_ci}\n` +
     `    CONSORT_TELEMETRY=0: ${s.killed}\n` +
-    `  endpoint armed:      ${s.endpoint_armed} (default no-op sink until a maintainer signs off)\n` +
+    `  endpoint armed:      ${s.endpoint_armed} (opt-out, armed by default; CONSORT_TELEMETRY_SIGNOFF=0 to un-arm)\n` +
     `  install id:          ${s.install_id}\n` +
     `  config file:         ${s.config_file}\n`
   );
@@ -109,8 +132,15 @@ export function runTelemetryCli(argv: string[], deps: TelemetryCliDeps = {}): nu
       return 0;
     }
     case "enable": {
-      const cfg = setTelemetryEnabled(true, deps);
-      out(json ? JSON.stringify({ telemetry_enabled: cfg.telemetry_enabled }, null, 2) + "\n" : "telemetry enabled\n");
+      setTelemetryEnabled(true, deps);
+      const requested = parseLevelFlag(argv);
+      if (requested !== undefined) setTelemetryLevel(requested, deps);
+      const level = resolveTelemetryLevel(deps);
+      out(
+        json
+          ? JSON.stringify({ telemetry_enabled: true, level }, null, 2) + "\n"
+          : `telemetry enabled (level ${level})\n`,
+      );
       return 0;
     }
     case "disable": {

--- a/consort/telemetry/allowlist.ts
+++ b/consort/telemetry/allowlist.ts
@@ -19,11 +19,19 @@
 // branches, spec content, hostnames, or error messages) is ever allowlisted.
 
 export const TELEMETRY_SCHEMA = "consort/v1" as const;
-/** Level 1 (consort-drive only): one trace per run, root + per-action spans. */
+/** The DEFAULT telemetry level. Level 1 (consort-drive only): one trace per run,
+ *  root + per-action spans. Ships ON by default (opt-out). Level 2 is a SEPARATE,
+ *  EXPLICIT opt-in (OFF by default) — see resolveTelemetryLevel in home-config. */
 export const TELEMETRY_LEVEL = 1 as const;
+/** The valid telemetry levels. L1 answers "is it healthy / adopted"; L2 adds the
+ *  failure taxonomy, per-turn timing, and loop dynamics that answer "why does it
+ *  fail / where is the bottleneck". L2 is higher-volume and opt-in only. */
+export const TELEMETRY_LEVELS = [1, 2] as const;
+export type TelemetryLevel = (typeof TELEMETRY_LEVELS)[number];
 
 /** The Resource attributes shipped once per trace. All are enum / boolean /
- *  numeric / structured-id , never free text. */
+ *  numeric / structured-id , never free text. `level` reflects the ACTIVE level
+ *  (1 by default, 2 only when the operator opts in); its key never changes. */
 export const RESOURCE_ATTR_KEYS = [
   "schema",
   "install_id",
@@ -38,8 +46,8 @@ export const RESOURCE_ATTR_KEYS = [
 ] as const;
 export type ResourceAttrKey = (typeof RESOURCE_ATTR_KEYS)[number];
 
-/** The root `consort.run` span fields (one per runDriver invocation). */
-export const RUN_SPAN_FIELDS = [
+/** The Level-1 root `consort.run` span fields (one per runDriver invocation). */
+export const RUN_SPAN_FIELDS_L1 = [
   "trace_id",
   "span_id",
   "name",
@@ -51,10 +59,35 @@ export const RUN_SPAN_FIELDS = [
   "exit_code",
   "gates_total",
 ] as const;
+
+/** The ADDITIONAL Level-2 `consort.run` span fields (present only on a level-2
+ *  run). All are counts (numbers) or a single boolean lever — never free text.
+ *  Repair & loop dynamics + coarse project shape, i.e. "is the ensemble
+ *  thrashing" and "how big is the work", never WHAT the work is. */
+export const RUN_SPAN_FIELDS_L2 = [
+  // Repair & loop dynamics (counts).
+  "red_green_cycles",
+  "refactor_iterations",
+  "revise_rounds",
+  "selfheal_attempts",
+  "hil_escalations",
+  // Project shape (counts, not content), each suffixed `_count` so it reads as a
+  // count and never collides with a `.consort` layout path segment. The gate COUNT
+  // is already carried by the L1 `gates_total`, so it is not duplicated here.
+  "feature_count",
+  "story_count",
+  "ac_count",
+  "test_count",
+  // Config/levers: whether the UX-adherence track is engaged (boolean).
+  "ui_track",
+] as const;
+
+/** The root `consort.run` span fields (L1 + the opt-in L2 additions). */
+export const RUN_SPAN_FIELDS = [...RUN_SPAN_FIELDS_L1, ...RUN_SPAN_FIELDS_L2] as const;
 export type RunSpanField = (typeof RUN_SPAN_FIELDS)[number];
 
-/** The child `consort.gate` span fields (one per performed action). */
-export const GATE_SPAN_FIELDS = [
+/** The Level-1 child `consort.gate` span fields (one per performed action). */
+export const GATE_SPAN_FIELDS_L1 = [
   "trace_id",
   "parent_span_id",
   "span_id",
@@ -66,7 +99,32 @@ export const GATE_SPAN_FIELDS = [
   "duration_ms",
   "outcome",
 ] as const;
+
+/** The ADDITIONAL Level-2 `consort.gate` span fields. `fail_class` is a nullable
+ *  CATEGORY enum (the failure taxonomy) — the categorized signature of an
+ *  abort/escalation, NEVER the error text. */
+export const GATE_SPAN_FIELDS_L2 = ["fail_class"] as const;
+
+/** The child `consort.gate` span fields (L1 + the opt-in L2 additions). */
+export const GATE_SPAN_FIELDS = [...GATE_SPAN_FIELDS_L1, ...GATE_SPAN_FIELDS_L2] as const;
 export type GateSpanField = (typeof GATE_SPAN_FIELDS)[number];
+
+/** The Level-2-only `consort.turn` span fields (one per role invocation). Answers
+ *  "who is slow / expensive / flaky". Every constrained field is a closed enum;
+ *  the rest are counts / durations / structured ids — never free text. */
+export const TURN_SPAN_FIELDS = [
+  "trace_id",
+  "parent_span_id",
+  "span_id",
+  "name",
+  "role",
+  "model",
+  "effort",
+  "duration_ms",
+  "retry_count",
+  "token_bucket",
+] as const;
+export type TurnSpanField = (typeof TURN_SPAN_FIELDS)[number];
 
 // ── Closed enums the constrained fields draw from ──────────────────
 export const OS_VALUES = ["darwin", "linux", "win32", "other"] as const;
@@ -82,9 +140,53 @@ export type GateOutcome = (typeof GATE_OUTCOMES)[number];
 export const COMMANDS = ["plan", "design", "build", "deploy"] as const;
 export type TelemetryCommand = (typeof COMMANDS)[number];
 
-/** The two span names (constants, never free text). */
+// ── Closed enums the LEVEL-2 constrained fields draw from ───────────
+//
+// The role ensemble (matches the `role` literals in the WorkflowAction union:
+// spec-author | architect-reviewer | dba | ux-designer | test-strategist |
+// navigator | driver | product-owner). Used on the `consort.turn` span. */
+export const ROLE_VALUES = [
+  "spec-author",
+  "architect-reviewer",
+  "dba",
+  "ux-designer",
+  "test-strategist",
+  "navigator",
+  "driver",
+  "product-owner",
+] as const;
+export type RoleValue = (typeof ROLE_VALUES)[number];
+
+/** The model FAMILY a turn ran on (coarse bucket, never the exact model id). */
+export const MODEL_VALUES = ["opus", "sonnet", "haiku", "fable", "other"] as const;
+export type ModelValue = (typeof MODEL_VALUES)[number];
+
+/** The reasoning-effort lever for a turn. */
+export const EFFORT_VALUES = ["low", "medium", "high", "unknown"] as const;
+export type EffortValue = (typeof EFFORT_VALUES)[number];
+
+/** A COARSE token-usage bucket for a turn (never a raw token count). */
+export const TOKEN_BUCKET_VALUES = ["xs", "s", "m", "l", "xl"] as const;
+export type TokenBucketValue = (typeof TOKEN_BUCKET_VALUES)[number];
+
+/** The FAILURE TAXONOMY: the categorized class of an abort/escalation. A closed
+ *  enum of signatures (the RUNBOOK §10 seed set + an `other` catch-all). This is
+ *  the category ONLY — never the error message, path, or any free text. */
+export const FAIL_CLASSES = [
+  "merge-etimedout",
+  "npm-proxy-hang",
+  "alembic-multi-head",
+  "review-blocked-protocol",
+  "deploy-verify-halt",
+  "ux-adherence-hil",
+  "other",
+] as const;
+export type FailClass = (typeof FAIL_CLASSES)[number];
+
+/** The three span names (constants, never free text). */
 export const RUN_SPAN_NAME = "consort.run" as const;
 export const GATE_SPAN_NAME = "consort.gate" as const;
+export const TURN_SPAN_NAME = "consort.turn" as const;
 
 // ── The FROZEN gate enum: the real WorkflowAction `kind` values ────
 //
@@ -128,6 +230,10 @@ export const isAllowedResourceKey = (k: string): k is ResourceAttrKey => RESOURC
 const GATE_KIND_SET = new Set<string>(GATE_KINDS);
 /** True when `k` is one of the frozen WorkflowAction kinds. */
 export const isKnownGateKind = (k: string): k is GateKind => GATE_KIND_SET.has(k);
+
+const ROLE_VALUE_SET = new Set<string>(ROLE_VALUES);
+/** True when `r` is one of the role ensemble members. */
+export const isKnownRole = (r: string): r is RoleValue => ROLE_VALUE_SET.has(r);
 
 /**
  * Keep ONLY the allowlisted keys of `obj`, dropping every other key. The runtime

--- a/consort/telemetry/emitter.ts
+++ b/consort/telemetry/emitter.ts
@@ -14,9 +14,7 @@
 
 import {
   isRunSpan,
-  sanitizeGateSpan,
-  sanitizeRunSpan,
-  type GateSpan,
+  sanitizeSpan,
   type ResourceAttrs,
   type TelemetrySpan,
   type TracePayload,
@@ -113,7 +111,7 @@ export function httpSink(opts: HttpSinkOptions): TelemetrySink {
 /** One NDJSON wire line for a span: the sanitized span + schema, with the trace's
  *  resource attached to the root span's line only (so it ships once). */
 function wireLine(span: TelemetrySpan, payload: TracePayload): Record<string, unknown> {
-  const clean = isRunSpan(span) ? sanitizeRunSpan(span) : sanitizeGateSpan(span as GateSpan);
+  const clean = sanitizeSpan(span);
   return isRunSpan(span)
     ? { schema: payload.schema, ...clean, resource: payload.resource }
     : { schema: payload.schema, ...clean };
@@ -192,7 +190,7 @@ export class TelemetryEmitter {
    *  so a non-allowlisted field never reaches the queue. Never throws. */
   enqueue(span: TelemetrySpan): void {
     try {
-      const clean = isRunSpan(span) ? sanitizeRunSpan(span) : sanitizeGateSpan(span as GateSpan);
+      const clean = sanitizeSpan(span);
       if (this.queue.length >= this.cap) this.queue.shift();
       this.queue.push(clean);
     } catch {

--- a/consort/telemetry/home-config.ts
+++ b/consort/telemetry/home-config.ts
@@ -18,6 +18,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
+import { type TelemetryLevel } from "./allowlist.js";
 
 /** Overridable inputs, so tests isolate the config to a temp dir. */
 export interface HomeConfigDeps {
@@ -26,17 +27,24 @@ export interface HomeConfigDeps {
   homedir?: string;
 }
 
-/** The persisted shape. `telemetry_enabled` is opt-out (defaults true); nothing
- *  leaves the machine regardless until a human flips the real endpoint (the sink
- *  defaults to a local no-op). */
+/** The persisted shape. `telemetry_enabled` is opt-out (defaults true).
+ *  `telemetry_level` is opt-IN (absent / 1 = Level 1; 2 only after an explicit
+ *  `enable --level 2` or CONSORT_TELEMETRY_LEVEL=2). `l2_opt_in_notified` records
+ *  that the one-time Level-2 opt-in notice has already been shown. */
 export interface StoredTelemetryConfig {
   install_id: string;
   telemetry_enabled: boolean;
+  telemetry_level?: TelemetryLevel;
+  l2_opt_in_notified?: boolean;
 }
 
 /** Default consent when no decision has been recorded yet (opt-out model, paired
  *  with the one-time first-run notice + the default no-op sink). */
 export const DEFAULT_TELEMETRY_ENABLED = true;
+
+/** The DEFAULT telemetry level: Level 1. Level 2 is only ever reached by an
+ *  explicit opt-in (persisted flag or CONSORT_TELEMETRY_LEVEL=2). */
+export const DEFAULT_TELEMETRY_LEVEL: TelemetryLevel = 1;
 
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const isUuidV4 = (s: unknown): s is string => typeof s === "string" && UUID_V4.test(s);
@@ -73,11 +81,20 @@ export function readStoredConfig(deps: HomeConfigDeps = {}): StoredTelemetryConf
     return null;
   }
   try {
-    const data = JSON.parse(raw) as { install_id?: unknown; telemetry_enabled?: unknown };
+    const data = JSON.parse(raw) as {
+      install_id?: unknown;
+      telemetry_enabled?: unknown;
+      telemetry_level?: unknown;
+      l2_opt_in_notified?: unknown;
+    };
     if (!isUuidV4(data.install_id)) return null;
     const telemetry_enabled =
       typeof data.telemetry_enabled === "boolean" ? data.telemetry_enabled : DEFAULT_TELEMETRY_ENABLED;
-    return { install_id: data.install_id, telemetry_enabled };
+    // A stored level is honored only when it is a valid level; anything else
+    // (garbage, 0, 3, "2") falls back to the default (Level 1). Never throws.
+    const telemetry_level: TelemetryLevel = data.telemetry_level === 2 ? 2 : DEFAULT_TELEMETRY_LEVEL;
+    const l2_opt_in_notified = data.l2_opt_in_notified === true;
+    return { install_id: data.install_id, telemetry_enabled, telemetry_level, l2_opt_in_notified };
   } catch {
     return null;
   }
@@ -138,11 +155,56 @@ export function isFirstRun(deps: HomeConfigDeps = {}): boolean {
   return readStoredConfig(deps) === null;
 }
 
-/** Persist the enable/disable decision, preserving the existing install id (or
- *  minting one if none exists yet). Returns the config (whether or not the write
- *  actually landed , writeStoredConfig never throws). */
-export function setTelemetryEnabled(enabled: boolean, deps: HomeConfigDeps = {}): StoredTelemetryConfig {
+/** Merge a partial update onto the existing config (minting an install id + the
+ *  defaults when none exists yet) and persist it, preserving every other field.
+ *  The single write path for the toggles below; never throws. */
+function updateStoredConfig(
+  patch: Partial<Omit<StoredTelemetryConfig, "install_id">>,
+  deps: HomeConfigDeps = {},
+): StoredTelemetryConfig {
   const existing = readStoredConfig(deps);
-  const install_id = existing?.install_id ?? randomUUID();
-  return writeStoredConfig({ install_id, telemetry_enabled: enabled }, deps).cfg;
+  const base: StoredTelemetryConfig = existing ?? {
+    install_id: randomUUID(),
+    telemetry_enabled: DEFAULT_TELEMETRY_ENABLED,
+    telemetry_level: DEFAULT_TELEMETRY_LEVEL,
+  };
+  return writeStoredConfig({ ...base, ...patch }, deps).cfg;
+}
+
+/** Persist the enable/disable decision, preserving the existing install id, level,
+ *  and notice flag (or minting an install id if none exists yet). Returns the
+ *  config (whether or not the write landed , writeStoredConfig never throws). */
+export function setTelemetryEnabled(enabled: boolean, deps: HomeConfigDeps = {}): StoredTelemetryConfig {
+  return updateStoredConfig({ telemetry_enabled: enabled }, deps);
+}
+
+/** Persist the telemetry LEVEL (the Level-2 opt-in). Setting level 2 is the
+ *  explicit, separate opt-in; setting level 1 returns to the default. Preserves
+ *  install id + consent + notice flag. Never throws. */
+export function setTelemetryLevel(level: TelemetryLevel, deps: HomeConfigDeps = {}): StoredTelemetryConfig {
+  return updateStoredConfig({ telemetry_level: level }, deps);
+}
+
+/**
+ * The RESOLVED active level for this run. An explicit `CONSORT_TELEMETRY_LEVEL`
+ * env var wins (`2` opts in, `1` forces back to Level 1 for this run); otherwise
+ * the persisted level; otherwise the default (Level 1). Level 2 is ALWAYS an
+ * explicit opt-in , there is no path that reaches it without one. Pure read.
+ */
+export function resolveTelemetryLevel(deps: HomeConfigDeps = {}): TelemetryLevel {
+  const env = deps.env ?? process.env;
+  const raw = (env.CONSORT_TELEMETRY_LEVEL ?? "").trim();
+  if (raw === "2") return 2;
+  if (raw === "1") return 1;
+  return readStoredConfig(deps)?.telemetry_level === 2 ? 2 : DEFAULT_TELEMETRY_LEVEL;
+}
+
+/** True when the one-time Level-2 opt-in notice has already been shown. */
+export function isL2NoticeSeen(deps: HomeConfigDeps = {}): boolean {
+  return readStoredConfig(deps)?.l2_opt_in_notified === true;
+}
+
+/** Record that the one-time Level-2 opt-in notice has been shown. Never throws. */
+export function markL2NoticeSeen(deps: HomeConfigDeps = {}): void {
+  updateStoredConfig({ l2_opt_in_notified: true }, deps);
 }

--- a/consort/telemetry/index.ts
+++ b/consort/telemetry/index.ts
@@ -1,4 +1,4 @@
-// Barrel for the Consort telemetry emitter (Level 1). See TELEMETRY.md.
+// Barrel for the Consort telemetry emitter (Level 1 default + Level 2 opt-in). See TELEMETRY.md.
 export * from "./allowlist.js";
 export * from "./spans.js";
 export * from "./home-config.js";

--- a/consort/telemetry/resource.ts
+++ b/consort/telemetry/resource.ts
@@ -10,13 +10,13 @@ import {
   ARCH_VALUES,
   OS_VALUES,
   SHELL_VALUES,
-  TELEMETRY_LEVEL,
   TELEMETRY_SCHEMA,
   type ArchValue,
   type OsValue,
   type ShellValue,
+  type TelemetryLevel,
 } from "./allowlist.js";
-import { ensureInstallId, type HomeConfigDeps } from "./home-config.js";
+import { ensureInstallId, resolveTelemetryLevel, type HomeConfigDeps } from "./home-config.js";
 import type { ResourceAttrs } from "./spans.js";
 
 /** Normalize a Node platform string into the os enum. */
@@ -56,6 +56,8 @@ export interface ResourceDeps extends HomeConfigDeps {
   isTTY?: boolean;
   /** Override the consort version (defaults to kitVersion()). */
   version?: string;
+  /** Override the active telemetry level (defaults to resolveTelemetryLevel(deps)). */
+  level?: TelemetryLevel;
 }
 
 /**
@@ -74,6 +76,6 @@ export function buildResourceAttrs(deps: ResourceDeps = {}): ResourceAttrs {
     shell: normalizeShell(env),
     ci: ciBool(env),
     tty: deps.isTTY ?? !!process.stdout.isTTY,
-    level: TELEMETRY_LEVEL,
+    level: deps.level ?? resolveTelemetryLevel(deps),
   };
 }

--- a/consort/telemetry/spans.ts
+++ b/consort/telemetry/spans.ts
@@ -13,14 +13,21 @@ import {
   GATE_SPAN_NAME,
   RUN_SPAN_FIELDS,
   RUN_SPAN_NAME,
+  TURN_SPAN_FIELDS,
+  TURN_SPAN_NAME,
   pickAllowed,
   type ArchValue,
+  type EffortValue,
+  type FailClass,
   type GateKind,
   type GateOutcome,
+  type ModelValue,
   type OsValue,
+  type RoleValue,
   type RunOutcome,
   type ShellValue,
   type TelemetryCommand,
+  type TokenBucketValue,
 } from "./allowlist.js";
 
 /** A 128-bit trace id as 32 lowercase hex chars (OTLP width). */
@@ -43,7 +50,9 @@ export interface ResourceAttrs {
   level: number;
 }
 
-/** The root span: one per runDriver invocation. */
+/** The root span: one per runDriver invocation. The L2 fields are OPTIONAL and
+ *  present only on a level-2 (opted-in) run; they are all counts / a boolean lever
+ *  , never free text. See RUN_SPAN_FIELDS_L2 in the allowlist. */
 export interface RunSpan {
   trace_id: string;
   span_id: string;
@@ -55,9 +64,22 @@ export interface RunSpan {
   outcome: RunOutcome;
   exit_code: number;
   gates_total: number;
+  // ── Level-2 (opt-in) additions: repair/loop dynamics + coarse project shape ──
+  red_green_cycles?: number;
+  refactor_iterations?: number;
+  revise_rounds?: number;
+  selfheal_attempts?: number;
+  hil_escalations?: number;
+  feature_count?: number;
+  story_count?: number;
+  ac_count?: number;
+  test_count?: number;
+  ui_track?: boolean;
 }
 
-/** The child span: one per performed action/gate, parented to the root span. */
+/** The child span: one per performed action/gate, parented to the root span. The
+ *  L2 `fail_class` is OPTIONAL (present only on a level-2 run, and only when a
+ *  fail/abort was categorized): the categorized signature enum, NEVER error text. */
 export interface GateSpan {
   trace_id: string;
   parent_span_id: string;
@@ -69,9 +91,27 @@ export interface GateSpan {
   end_ts: number;
   duration_ms: number;
   outcome: GateOutcome;
+  fail_class?: FailClass | null;
 }
 
-export type TelemetrySpan = RunSpan | GateSpan;
+/** The LEVEL-2-only span: one per role invocation ("who is slow / expensive /
+ *  flaky"). `role` is a closed enum; `model` / `effort` / `token_bucket` are
+ *  closed-enum coarse buckets and OPTIONAL (only carried when the executor layer
+ *  surfaces them , they are not available at every seam). Never free text. */
+export interface TurnSpan {
+  trace_id: string;
+  parent_span_id: string;
+  span_id: string;
+  name: typeof TURN_SPAN_NAME;
+  role: RoleValue;
+  model?: ModelValue;
+  effort?: EffortValue;
+  duration_ms: number;
+  retry_count?: number;
+  token_bucket?: TokenBucketValue;
+}
+
+export type TelemetrySpan = RunSpan | GateSpan | TurnSpan;
 
 /** The internal batch handed to a sink: the trace's resource + its spans. The
  *  wire encoding (NDJSON, OTLP, ...) is the sink's concern, not this model's. */
@@ -85,6 +125,14 @@ export interface TracePayload {
 export const sanitizeRunSpan = (s: RunSpan): RunSpan => pickAllowed(s, RUN_SPAN_FIELDS) as unknown as RunSpan;
 /** Drop any non-allowlisted key from a child span (runtime tooth). */
 export const sanitizeGateSpan = (s: GateSpan): GateSpan => pickAllowed(s, GATE_SPAN_FIELDS) as unknown as GateSpan;
+/** Drop any non-allowlisted key from a turn span (runtime tooth). */
+export const sanitizeTurnSpan = (s: TurnSpan): TurnSpan => pickAllowed(s, TURN_SPAN_FIELDS) as unknown as TurnSpan;
 
 /** True when a span is the root run span (by its constant name). */
 export const isRunSpan = (s: TelemetrySpan): s is RunSpan => s.name === RUN_SPAN_NAME;
+/** True when a span is a level-2 turn span (by its constant name). */
+export const isTurnSpan = (s: TelemetrySpan): s is TurnSpan => s.name === TURN_SPAN_NAME;
+
+/** Sanitize ANY span by its kind (the single dispatch point for the emitter). */
+export const sanitizeSpan = (s: TelemetrySpan): TelemetrySpan =>
+  isRunSpan(s) ? sanitizeRunSpan(s) : isTurnSpan(s) ? sanitizeTurnSpan(s) : sanitizeGateSpan(s as GateSpan);

--- a/consort/telemetry/with-telemetry.ts
+++ b/consort/telemetry/with-telemetry.ts
@@ -17,27 +17,50 @@
 // is the emitter's fire-and-forget flush.
 
 import type { DriveEffects } from "../orchestrator/drive/orchestrator-run.js";
-import type { WorkflowAction } from "../orchestrator/workflow/workflow-vocabulary.js";
+import type { DriveState, WorkflowAction } from "../orchestrator/workflow/workflow-vocabulary.js";
 import {
   GATE_SPAN_NAME,
   RUN_SPAN_NAME,
+  TURN_SPAN_NAME,
   isKnownGateKind,
+  isKnownRole,
   type GateOutcome,
   type RunOutcome,
   type TelemetryCommand,
+  type TelemetryLevel,
 } from "./allowlist.js";
 import { shouldEmitTelemetry } from "./consent.js";
 import { TelemetryEmitter, resolveSink, type TelemetrySink } from "./emitter.js";
-import { isFirstRun, isTelemetryEnabled, telemetryDebug } from "./home-config.js";
+import {
+  isFirstRun,
+  isL2NoticeSeen,
+  isTelemetryEnabled,
+  markL2NoticeSeen,
+  resolveTelemetryLevel,
+  telemetryDebug,
+} from "./home-config.js";
 import { buildResourceAttrs, type ResourceDeps } from "./resource.js";
-import { newSpanId, newTraceId, type GateSpan, type RunSpan } from "./spans.js";
+import { newSpanId, newTraceId, type GateSpan, type RunSpan, type TurnSpan } from "./spans.js";
 
-/** The one-time first-run notice (stderr). Pseudonymous, local no-op by default. */
+/** The one-time first-run notice (stderr). Pseudonymous, armed by default. */
 export const FIRST_RUN_NOTICE =
   "[consort] Anonymous* usage telemetry is on (*pseudonymous: a random per-install id, no PII).\n" +
   "          Each interactive run reports to the Consort maintainers' endpoint; only\n" +
   "          allowlisted, non-sensitive fields are sent (no paths, code, or names).\n" +
   "          Turn it off any time: `consort-telemetry disable` (or CONSORT_TELEMETRY=0).\n" +
+  "          Details: TELEMETRY.md.\n";
+
+/** The one-time LEVEL-2 opt-in notice (stderr). Shown once, on the first run after
+ *  a user explicitly opts in to Level 2. Level 2 is a SEPARATE opt-in on top of the
+ *  Level-1 default; it captures MORE (per-role turn timings, coarse repair/loop
+ *  counts, a categorized failure class) , still only allowlisted enums / counts /
+ *  durations, never prompts, code, paths, or names. */
+export const L2_OPT_IN_NOTICE =
+  "[consort] Level-2 usage telemetry is ON (you opted in).\n" +
+  "          On top of Level 1, it reports per-role turn timings and coarse\n" +
+  "          repair/loop counts , still only allowlisted enums, counts, and\n" +
+  "          durations (no prompts, code, paths, error text, or names).\n" +
+  "          Back to Level 1 any time: `consort-telemetry enable --level 1`.\n" +
   "          Details: TELEMETRY.md.\n";
 
 export interface RunFinishInfo {
@@ -71,6 +94,8 @@ export interface BeginRunDeps extends ResourceDeps {
   onNotice?: (msg: string) => void;
   /** Register a best-effort exit flush (default true). Off in tests to avoid leaks. */
   registerExitFlush?: boolean;
+  /** Active telemetry level override (tests). Defaults to resolveTelemetryLevel(deps). */
+  level?: TelemetryLevel;
 }
 
 /** The immutable no-op session returned when consent fails. */
@@ -114,11 +139,18 @@ function beginTelemetryRunUnsafe(deps: BeginRunDeps): TelemetryRun {
   if (!shouldEmitTelemetry({ telemetryEnabled: enabledFlag, isTTY, env })) return NOOP_RUN;
 
   const now = deps.now ?? Date.now;
-  // Fire the one-time notice BEFORE building the resource (which creates the
+  const level = deps.level ?? resolveTelemetryLevel(deps);
+  const l2 = level === 2;
+  // Fire the one-time notices BEFORE building the resource (which creates the
   // config file), so "first run" is detected against the pre-existing state.
   if (deps.onNotice && isFirstRun(deps)) deps.onNotice(FIRST_RUN_NOTICE);
+  // The Level-2 opt-in notice fires once, on the first run after opting in.
+  if (deps.onNotice && l2 && !isL2NoticeSeen(deps)) {
+    deps.onNotice(L2_OPT_IN_NOTICE);
+    markL2NoticeSeen(deps);
+  }
 
-  const resource = buildResourceAttrs({ ...deps, isTTY });
+  const resource = buildResourceAttrs({ ...deps, isTTY, level });
   const sink = deps.sink ?? resolveSink(env);
   const emitter = new TelemetryEmitter({ sink, resource });
 
@@ -127,6 +159,44 @@ function beginTelemetryRunUnsafe(deps: BeginRunDeps): TelemetryRun {
   const rootStart = now();
   let gates = 0;
   let finished = false;
+
+  // ── Level-2 (opt-in) accumulators. Populated ONLY when l2; at Level 1 they
+  //    stay zero and are never attached to the root span. ──────────────────────
+  const l2Counts = {
+    red_green_cycles: 0,
+    refactor_iterations: 0,
+    revise_rounds: 0,
+    selfheal_attempts: 0,
+    hil_escalations: 0,
+  };
+  // The last DriveState the driver read (captured through the readState seam), so
+  // finish() can record coarse project shape WITHOUT an async read of its own.
+  let lastState: DriveState | undefined;
+
+  /** Tally the coarse L2 repair/loop dynamics from a performed action. Reads ONLY
+   *  the action's structured `kind` / `role` / `buildMode` / `mode` , never any
+   *  free-text field. */
+  const tallyL2 = (action: WorkflowAction): void => {
+    switch (action.kind) {
+      case "raise-to-hil":
+        l2Counts.hil_escalations += 1;
+        break;
+      case "revise-route":
+        l2Counts.revise_rounds += 1;
+        break;
+      case "invoke-role": {
+        const bm = "buildMode" in action ? action.buildMode : undefined;
+        if (bm && bm.startsWith("refactor")) l2Counts.refactor_iterations += 1;
+        else if (bm && (bm.startsWith("assess") || bm === "repair")) l2Counts.selfheal_attempts += 1;
+        else if (action.role === "driver" && bm === undefined) l2Counts.red_green_cycles += 1;
+        break;
+      }
+      case "deploy-verify-heal":
+        if (action.mode.startsWith("refactor")) l2Counts.refactor_iterations += 1;
+        else l2Counts.selfheal_attempts += 1;
+        break;
+    }
+  };
 
   const recordChild = (action: WorkflowAction, ordinal: number, start: number, threw: boolean): void => {
     // `done` is the terminal no-op, not real work , never a child span.
@@ -150,6 +220,25 @@ function beginTelemetryRunUnsafe(deps: BeginRunDeps): TelemetryRun {
     };
     emitter.enqueue(span);
     gates += 1;
+
+    // Level-2 (opt-in) only: tally coarse dynamics and, for a role invocation,
+    // emit a `consort.turn` span (role + timing). model / effort / token_bucket /
+    // retry_count are NOT available at this seam, so they are simply omitted , the
+    // sanitizer keeps only allowlisted keys either way.
+    if (l2) {
+      tallyL2(action);
+      if (action.kind === "invoke-role" && isKnownRole(action.role)) {
+        const turn: TurnSpan = {
+          trace_id: traceId,
+          parent_span_id: rootSpanId,
+          span_id: newSpanId(),
+          name: TURN_SPAN_NAME,
+          role: action.role,
+          duration_ms: end - start,
+        };
+        emitter.enqueue(turn);
+      }
+    }
   };
 
   const wrap = (inner: DriveEffects): DriveEffects => {
@@ -157,7 +246,13 @@ function beginTelemetryRunUnsafe(deps: BeginRunDeps): TelemetryRun {
     // loop iteration; capture it as the child span's ordinal.
     let pendingOrdinal = 0;
     return {
-      readState: () => inner.readState(),
+      // Tap the readState seam to capture the last state the driver observed, so
+      // finish() can record coarse L2 project shape without its own async read.
+      readState: async () => {
+        const s = await inner.readState();
+        lastState = s;
+        return s;
+      },
       onAction: (action, i) => {
         pendingOrdinal = i;
         inner.onAction?.(action, i);
@@ -224,6 +319,18 @@ function beginTelemetryRunUnsafe(deps: BeginRunDeps): TelemetryRun {
       exit_code: info.exit_code,
       gates_total: gates,
     };
+    // Level-2 (opt-in) only: attach the coarse repair/loop counts + project shape.
+    if (l2) {
+      root.red_green_cycles = l2Counts.red_green_cycles;
+      root.refactor_iterations = l2Counts.refactor_iterations;
+      root.revise_rounds = l2Counts.revise_rounds;
+      root.selfheal_attempts = l2Counts.selfheal_attempts;
+      root.hil_escalations = l2Counts.hil_escalations;
+      if (lastState) {
+        if (typeof lastState.uiTrack === "boolean") root.ui_track = lastState.uiTrack;
+        if (Array.isArray(lastState.storyOrder)) root.story_count = lastState.storyOrder.length;
+      }
+    }
     emitter.enqueue(root);
     emitter.flush();
   };

--- a/tests/bdd/telemetry-allowlist-reachability.test.ts
+++ b/tests/bdd/telemetry-allowlist-reachability.test.ts
@@ -22,16 +22,29 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   ARCH_VALUES,
+  EFFORT_VALUES,
+  FAIL_CLASSES,
   GATE_KINDS,
   GATE_SPAN_FIELDS,
+  MODEL_VALUES,
   OS_VALUES,
   RESOURCE_ATTR_KEYS,
+  ROLE_VALUES,
   RUN_SPAN_FIELDS,
   SHELL_VALUES,
+  TOKEN_BUCKET_VALUES,
+  TURN_SPAN_FIELDS,
   pickAllowed,
 } from "../../consort/telemetry/allowlist";
 import { buildResourceAttrs } from "../../consort/telemetry/resource";
-import { sanitizeGateSpan, sanitizeRunSpan, type GateSpan, type RunSpan } from "../../consort/telemetry/spans";
+import {
+  sanitizeGateSpan,
+  sanitizeRunSpan,
+  sanitizeTurnSpan,
+  type GateSpan,
+  type RunSpan,
+  type TurnSpan,
+} from "../../consort/telemetry/spans";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const VOCAB_FILE = join(repoRoot, "consort", "orchestrator", "workflow", "workflow-vocabulary.ts");
@@ -94,7 +107,9 @@ describe("telemetry allowlist reachability (no unlisted / no silent field)", () 
       error_message: "boom at /etc/passwd",
     } as unknown as RunSpan;
     const clean = sanitizeRunSpan(dirty);
-    expect(new Set(Object.keys(clean))).toEqual(new Set(RUN_SPAN_FIELDS));
+    // sanitize is a key filter: it keeps the allowlisted keys PRESENT on the object
+    // (the optional L2 fields are simply absent on this L1 span) and drops the rest.
+    expect(new Set(Object.keys(clean))).toEqual(new Set(RUN_SPAN_FIELDS.filter((k) => k in dirty)));
     expect(clean as unknown as Record<string, unknown>).not.toHaveProperty("branch");
     expect(clean as unknown as Record<string, unknown>).not.toHaveProperty("cwd");
     expect(clean as unknown as Record<string, unknown>).not.toHaveProperty("error_message");
@@ -113,7 +128,7 @@ describe("telemetry allowlist reachability (no unlisted / no silent field)", () 
       note: "free text about the failure",
     } as unknown as GateSpan;
     const cleanGate = sanitizeGateSpan(dirtyGate);
-    expect(new Set(Object.keys(cleanGate))).toEqual(new Set(GATE_SPAN_FIELDS));
+    expect(new Set(Object.keys(cleanGate))).toEqual(new Set(GATE_SPAN_FIELDS.filter((k) => k in dirtyGate)));
     expect(cleanGate as unknown as Record<string, unknown>).not.toHaveProperty("note");
   });
 
@@ -131,5 +146,93 @@ describe("telemetry allowlist reachability (no unlisted / no silent field)", () 
 
   it("pickAllowed is a pure key filter", () => {
     expect(pickAllowed({ a: 1, b: 2, c: 3 }, ["a", "c"])).toEqual({ a: 1, c: 3 });
+  });
+
+  // ── Level 2 (opt-in) additions: the same teeth extended to the L2 vocabulary ──
+
+  it("L2: sanitizing a turn span DROPS any non-allowlisted key (runtime tooth)", () => {
+    const dirty = {
+      trace_id: "t",
+      parent_span_id: "p",
+      span_id: "s",
+      name: "consort.turn",
+      role: "driver",
+      model: "opus",
+      effort: "high",
+      duration_ms: 5,
+      retry_count: 0,
+      token_bucket: "m",
+      // forbidden extras a turn span must never ship:
+      prompt: "write the failing test for AC-3",
+      cwd: "/Users/someone/secret",
+      error_message: "boom",
+    } as unknown as TurnSpan;
+    const clean = sanitizeTurnSpan(dirty);
+    expect(new Set(Object.keys(clean))).toEqual(new Set(Object.keys(dirty).filter((k) => (TURN_SPAN_FIELDS as readonly string[]).includes(k))));
+    expect(new Set(Object.keys(clean))).toEqual(new Set(TURN_SPAN_FIELDS));
+    for (const forbidden of ["prompt", "cwd", "error_message"]) {
+      expect(clean as unknown as Record<string, unknown>).not.toHaveProperty(forbidden);
+    }
+  });
+
+  it("L2: the run span's L2 count fields SURVIVE sanitize; junk is still dropped", () => {
+    const dirty = {
+      trace_id: "t",
+      span_id: "s",
+      name: "consort.run",
+      start_ts: 1,
+      end_ts: 2,
+      duration_ms: 1,
+      command: "build",
+      outcome: "aborted",
+      exit_code: 3,
+      gates_total: 4,
+      // L2 additions (must survive):
+      red_green_cycles: 2,
+      refactor_iterations: 1,
+      revise_rounds: 1,
+      selfheal_attempts: 0,
+      hil_escalations: 1,
+      story_count: 3,
+      ui_track: true,
+      // forbidden free text (must drop):
+      branch: "feature/secret",
+    } as unknown as RunSpan;
+    const clean = sanitizeRunSpan(dirty) as unknown as Record<string, unknown>;
+    expect(clean.red_green_cycles).toBe(2);
+    expect(clean.hil_escalations).toBe(1);
+    expect(clean.ui_track).toBe(true);
+    expect(clean.story_count).toBe(3);
+    expect(clean).not.toHaveProperty("branch");
+  });
+
+  it("L2: a gate span's fail_class survives sanitize and is within the closed enum", () => {
+    const gate = {
+      trace_id: "t",
+      parent_span_id: "p",
+      span_id: "s",
+      name: "consort.gate",
+      gate: "deploy",
+      ordinal: 0,
+      start_ts: 1,
+      end_ts: 2,
+      duration_ms: 1,
+      outcome: "fail",
+      fail_class: "deploy-verify-halt",
+    } as unknown as GateSpan;
+    const clean = sanitizeGateSpan(gate) as unknown as Record<string, unknown>;
+    expect(clean.fail_class).toBe("deploy-verify-halt");
+    expect(FAIL_CLASSES).toContain(clean.fail_class);
+    expect(new Set(Object.keys(clean))).toEqual(new Set(GATE_SPAN_FIELDS.filter((k) => k in gate)));
+  });
+
+  it("L2: every constrained field is a CLOSED enum (no free text), incl. an 'other'/'unknown' catch-all where a value may be novel", () => {
+    // The enums exist and are non-empty closed sets , the emitter can only ship a
+    // member (a novel value collapses to the catch-all, never a raw string).
+    expect(ROLE_VALUES.length).toBeGreaterThan(0);
+    expect(MODEL_VALUES).toContain("other"); // a model family the bucket does not know
+    expect(EFFORT_VALUES).toContain("unknown");
+    expect(TOKEN_BUCKET_VALUES.length).toBeGreaterThan(0);
+    expect(FAIL_CLASSES).toContain("other"); // an uncategorized failure signature
   });
 });

--- a/tests/bdd/telemetry-with-driver.test.ts
+++ b/tests/bdd/telemetry-with-driver.test.ts
@@ -11,7 +11,8 @@ import { runDriver, type DriveEffects } from "../../consort/orchestrator/drive/o
 import type { DriveState, WorkflowAction } from "../../consort/orchestrator/workflow/workflow-vocabulary";
 import { beginTelemetryRun, type BeginRunDeps, type TelemetryRun } from "../../consort/telemetry/with-telemetry";
 import { memorySink, type MemorySink } from "../../consort/telemetry/emitter";
-import { isRunSpan, type GateSpan, type RunSpan } from "../../consort/telemetry/spans";
+import { isRunSpan, isTurnSpan, type GateSpan, type RunSpan, type TurnSpan } from "../../consort/telemetry/spans";
+import { ROLE_VALUES } from "../../consort/telemetry/allowlist";
 
 /** A scripted DriveEffects that performs `actions` in order then reaches `done`.
  *  `transition` ignores state; `perform` advances a cursor (optionally throwing). */
@@ -279,5 +280,85 @@ describe("withTelemetry over the driver loop", () => {
 
     // The write genuinely failed: no config file was created under the file-home.
     expect(existsSync(join(fileAsHome, ".config", "consort", "telemetry.json"))).toBe(false);
+  });
+
+  // ── Level 2 (opt-in) ────────────────────────────────────────────────────────
+  // At Level 2 the SAME driver pass additionally emits a `consort.turn` span per
+  // role invocation (role + timing) and attaches coarse repair/loop counts +
+  // project shape to the root span. At Level 1 (the default) neither appears.
+  const L2_ACTIONS: WorkflowAction[] = [
+    { kind: "invoke-role", role: "navigator", story: "S1" }, // RED: turn span, NOT a red_green_cycle
+    { kind: "invoke-role", role: "driver", story: "S1" }, // GREEN: turn span + red_green_cycles++
+    { kind: "invoke-role", role: "driver", story: "S1", buildMode: "refactor" }, // turn span + refactor_iterations++
+    { kind: "revise-route", story: "S1", role: "spec-author", gate: "spec", reason: "r", source: "s" }, // revise_rounds++
+    { kind: "raise-to-hil", reason: "x", source: "y" }, // hil_escalations++ (terminal, so keep it last)
+  ];
+
+  it("Level 2 (opt-in) emits consort.turn spans + coarse run counts (resource level = 2)", async () => {
+    const sink = memorySink();
+    const run = beginTelemetryRun({ ...CONSENTING(home, sink), level: 2 });
+    const effects: DriveEffects = {
+      async readState() {
+        return { storyOrder: ["S1", "S2"], uiTrack: true } as unknown as DriveState;
+      },
+      async perform() {},
+    };
+    let i = 0;
+    const transition = (): WorkflowAction => (i < L2_ACTIONS.length ? L2_ACTIONS[i++] : { kind: "done" });
+    await runDriver(run.wrap(effects), { transition, enforceExpectations: false });
+    run.finish({ outcome: "aborted", exit_code: 3 });
+
+    const payload = sink.payloads[0];
+    const turns = payload.spans.filter(isTurnSpan) as TurnSpan[];
+    const root = payload.spans.filter(isRunSpan)[0] as RunSpan;
+
+    // The resource carries the opted-in level.
+    expect(payload.resource.level).toBe(2);
+
+    // One turn span per role invocation, carrying role (within the closed enum) +
+    // timing, parented to the root and sharing the trace id. No free-text fields.
+    expect(turns.map((t) => t.role)).toEqual(["navigator", "driver", "driver"]);
+    for (const t of turns) {
+      expect(ROLE_VALUES).toContain(t.role);
+      expect(t.trace_id).toBe(root.trace_id);
+      expect(t.parent_span_id).toBe(root.span_id);
+      expect(t.duration_ms).toBeGreaterThanOrEqual(0);
+    }
+
+    // Coarse repair/loop dynamics tallied from the structured action kinds.
+    expect(root.red_green_cycles).toBe(1);
+    expect(root.refactor_iterations).toBe(1);
+    expect(root.revise_rounds).toBe(1);
+    expect(root.hil_escalations).toBe(1);
+    expect(root.selfheal_attempts).toBe(0);
+    // Coarse project shape from the last state the driver observed.
+    expect(root.story_count).toBe(2);
+    expect(root.ui_track).toBe(true);
+  });
+
+  it("Level 1 (default) emits NO turn spans and NO L2 fields on the root", async () => {
+    const sink = memorySink();
+    const run = beginTelemetryRun({ ...CONSENTING(home, sink), level: 1 });
+    let i = 0;
+    const transition = (): WorkflowAction => (i < L2_ACTIONS.length ? L2_ACTIONS[i++] : { kind: "done" });
+    await runDriver(
+      run.wrap({
+        async readState() {
+          return { storyOrder: ["S1", "S2"], uiTrack: true } as unknown as DriveState;
+        },
+        async perform() {},
+      }),
+      { transition, enforceExpectations: false },
+    );
+    run.finish({ outcome: "aborted", exit_code: 3 });
+
+    const payload = sink.payloads[0];
+    expect(payload.resource.level).toBe(1);
+    expect(payload.spans.some(isTurnSpan)).toBe(false);
+    const root = payload.spans.filter(isRunSpan)[0] as RunSpan;
+    expect(root.red_green_cycles).toBeUndefined();
+    expect(root.hil_escalations).toBeUndefined();
+    expect(root.story_count).toBeUndefined();
+    expect(root.ui_track).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

Adds **Level 2 (opt-in)** usage telemetry to `consort-drive`, on top of the shipped Level 1.

- **Level 1 is unchanged** — still opt-out / armed-by-default.
- **Level 2 is a separate, explicit opt-in, OFF by default.** It answers *why does a run fail / where is the bottleneck*, and it genuinely captures more (it does not just define fields — it emits them):
  - `consort.turn` span **emitted** per role invocation — `role` + timing. `model` / `effort` / `token_bucket` / `retry_count` are allowlisted **optional** coarse buckets, populated as the executor surfaces them (never the exact model id, never a raw count).
  - coarse `consort.run` loop dynamics — `red_green_cycles`, `refactor_iterations`, `revise_rounds`, `selfheal_attempts`, `hil_escalations` — **tallied from the deterministic driver seam** (structured action kinds only).
  - coarse project shape — `story_count` + `ui_track` (`feature_count` / `ac_count` / `test_count` reserved), from the last observed `DriveState`.
  - gate `fail_class` — a closed failure-signature enum, **never the error text**.
- **No free text at either level** — every field is a closed enum / count / duration. No prompts, code, spec/feature text, error messages, paths, branch names, hostnames, or usernames.

## Opt in / out

```
consort-telemetry enable --level 2        # persist L2 opt-in
CONSORT_TELEMETRY_LEVEL=2 consort-drive …  # per-invocation
consort-telemetry enable --level 1        # back to Level 1
consort-telemetry status                  # shows the resolved level
```

All Level-1 opt-outs still apply unchanged (`disable`, `CONSORT_TELEMETRY=0`, CI / non-TTY, `CONSORT_TELEMETRY_SIGNOFF=0`). A one-time Level-2 notice prints on the first opted-in run.

## Notes for review

- Emitter sanitize dispatch is now 3-way (run / gate / turn); the closed-allowlist **reachability guard is extended to the L2 vocabulary** and still drops any non-allowlisted / free-text key.
- Project-shape count fields are suffixed `_count` so they never collide with the `.consort` layout path guard — **the `consort-paths` guard is left fully intact** (no telemetry dir carve-out).
- Fixes the stale `consort-telemetry` help/status strings that still described a "local no-op sink until a maintainer arms" (contradicted the armed-by-default behavior).
- Server-side note: the L2 `telemetry.turns` / `fail_class` columns are not yet in the ingest schema — that lands with the backend hardening. L2 emits client-side only when a user opts in.

## Tests

`npm run typecheck` clean; `npm test` green (telemetry suites incl. a new Level-2 emission test that asserts turn spans + counts appear at L2 and are absent at L1; the reachability + `consort-paths` guards pass). Verified again by the pre-push hook.