### PR TITLE
Fix bootstrap.sh reporting a green environment it cannot run on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`bootstrap.sh` no longer reports a green environment it cannot actually run on.** Three prerequisite checks could pass while the tool was present-but-unusable. The Python check only tested that `python3` existed, never its version, so macOS's system 3.9 satisfied a floor CONTRIBUTING documents as 3.10+. The JDK and Node checks offered `brew install openjdk@17` / `node@20`, both **keg-only** formulas: brew installs them without linking them onto PATH, so `java` / `node` still failed immediately afterwards, and because a successful install made `offer_brew_install` return 0, `MISSING` stayed at zero and the script exited 0 ("All required tools are present") with no working toolchain. Every check now judges the **end state** rather than the installer's exit status: after any remediation it re-probes the tool and only counts it present if it actually resolves. Keg paths resolve via `brew --prefix` (falling back to the well-known prefixes, linuxbrew included) instead of two hardcoded macOS locations, and a detected keg-only install prints the exact `export PATH=...` line for the user's real shell rather than dead-ending. Also folded three hand-rolled version idioms into one `version_at_least` helper and added the JDK 17 floor that CONTRIBUTING promises but nothing enforced (a JDK 8 previously passed green). The JDK is reported as an **advisory, not a blocker**, matching `consort/lakebase/create-doctor-gate.ts`: it gates creation only for java/kotlin, and `bootstrap.sh` has no `--language`, so failing the run would block Python and Node authors who need no JDK at all. Advisories print on both the success and failure paths so a broken JDK is never a silent green. Test: `tests/bdd/bootstrap-prereqs.test.ts` (+8).
+
 ## [0.3.56] - 2026-08-28
 
 ### Added

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -84,46 +84,152 @@ offer_brew_install() {
   fi
 }
 
+# Locate a keg-only formula's install prefix. Two of the three formulas this
+# script offers (node@20, openjdk@17, python@3.11 - all but plain `node`) are
+# KEG-ONLY: brew installs them without linking them onto PATH, so a successful
+# `brew install` does not make the tool usable. Derive the prefix from
+# `brew --prefix` so linuxbrew and a custom HOMEBREW_PREFIX work too, and fall
+# back to the well-known prefixes only if brew cannot answer.
+brew_keg() {
+  local formula="$1" prefix
+  if [ "$BREW" = true ]; then
+    prefix="$( { brew --prefix 2>/dev/null; } || true )"
+    if [ -n "$prefix" ] && [ -d "$prefix/opt/$formula" ]; then
+      printf '%s' "$prefix/opt/$formula"; return 0
+    fi
+  fi
+  for prefix in /opt/homebrew /usr/local /home/linuxbrew/.linuxbrew; do
+    if [ -d "$prefix/opt/$formula" ]; then printf '%s' "$prefix/opt/$formula"; return 0; fi
+  done
+  return 1
+}
+
+# version_at_least MIN ACTUAL -> 0 when ACTUAL >= MIN. One comparison for every
+# floor in this script, so a new floor is a one-line addition rather than a
+# fourth hand-rolled idiom.
+version_at_least() {
+  local min="$1" actual="$2"
+  [ -n "$actual" ] && [ "$(printf '%s\n%s\n' "$min" "$actual" | sort -V | head -1)" = "$min" ]
+}
+
+# The rc file for the user's ACTUAL shell. linuxbrew users are commonly on bash,
+# so a hardcoded ~/.zshrc remediation would edit a file their shell never reads.
+shell_rc() {
+  case "$(basename "${SHELL:-}")" in
+    zsh)  printf '%s' "$HOME/.zshrc" ;;
+    bash) printf '%s' "$HOME/.bashrc" ;;
+    *)    printf '' ;;
+  esac
+}
+
+# Print the keg-only remediation for <label>/<formula>. Returns non-zero when no
+# keg is present (i.e. the tool is genuinely absent, not merely unlinked).
+keg_hint() {
+  local label="$1" formula="$2" keg rc
+  keg="$( brew_keg "$formula" || true )"
+  [ -z "$keg" ] && return 1
+  [ -d "$keg/bin" ] || return 1
+  rc="$(shell_rc)"
+  echo -e "  ${YELLOW}!${NC} $label is at $keg but is keg-only, so it is not on PATH."
+  if [ -n "$rc" ]; then
+    echo -e "     Add it, then re-run this script:"
+    echo -e "       echo 'export PATH=\"$keg/bin:\$PATH\"' >> $rc"
+  else
+    echo -e "     Add its bin directory to PATH, then re-run this script:"
+    echo -e "       export PATH=\"$keg/bin:\$PATH\""
+  fi
+  return 0
+}
+
+# `java` probes read the FULL output, never `head -1`: a JVM may print a
+# "Picked up JAVA_TOOL_OPTIONS: ..." preamble first, which would make a
+# first-line probe report a perfectly good JDK as missing.
+java_raw()     { { java -version 2>&1; } || true; }
+java_works()   { printf '%s' "$1" | grep -qiE 'version|openjdk'; }
+java_version() { printf '%s' "$1" | sed -nE 's/.*"([0-9][^"]*)".*/\1/p' | head -1; }
+
 echo -e "${BLUE}consort bootstrap: checking prerequisites${NC}"
 echo
 
 MISSING=0
 AUTH_REMINDERS=()
+# Advisories are NOT failures. Per consort/lakebase/create-doctor-gate.ts, the
+# JDK blocks creation only for java/kotlin projects: "a Python (alembic) or Node
+# project does not need a JDK and must not be gated on it". bootstrap.sh has no
+# --language, so it must report a JDK problem without failing the run.
+ADVISORIES=()
 
-# node + npm (npm ships with node)
-if have node; then
-  NODE_MAJOR="$(node -v 2>/dev/null | sed -E 's/^v?([0-9]+).*/\1/')"
-  if [ "${NODE_MAJOR:-0}" -ge 20 ]; then
-    echo -e "  ${GREEN}✓${NC} Node.js $(node -v)"
-  else
-    echo -e "  ${YELLOW}!${NC} Node.js $(node -v) - Consort needs 20+"
-    offer_brew_install "Node.js 20" "node@20" "https://nodejs.org" || MISSING=$((MISSING+1))
-  fi
+# node + npm (npm ships with node). `node@20` is keg-only, so judge the END
+# STATE after any install rather than the installer's exit status.
+NODE_MIN=20
+node_major() { { node -v 2>/dev/null | sed -E 's/^v?([0-9]+).*/\1/'; } || true; }
+NODE_MAJOR="$(node_major)"
+if [ -n "$NODE_MAJOR" ] && [ "$NODE_MAJOR" -ge "$NODE_MIN" ] 2>/dev/null; then
+  echo -e "  ${GREEN}✓${NC} Node.js $(node -v)"
 else
-  echo -e "  ${RED}✗${NC} Node.js not found"
-  offer_brew_install "Node.js" "node" "https://nodejs.org" || MISSING=$((MISSING+1))
+  if [ -n "$NODE_MAJOR" ]; then
+    echo -e "  ${YELLOW}!${NC} Node.js $(node -v) - Consort needs ${NODE_MIN}+"
+    offer_brew_install "Node.js $NODE_MIN" "node@$NODE_MIN" "https://nodejs.org" || true
+    NODE_FORMULA="node@$NODE_MIN"
+  else
+    echo -e "  ${RED}✗${NC} Node.js not found"
+    offer_brew_install "Node.js" "node" "https://nodejs.org" || true
+    NODE_FORMULA="node"
+  fi
+  NODE_MAJOR="$(node_major)"
+  if [ -z "$NODE_MAJOR" ] || ! [ "$NODE_MAJOR" -ge "$NODE_MIN" ] 2>/dev/null; then
+    keg_hint "Node.js $NODE_MIN" "$NODE_FORMULA" || true
+    MISSING=$((MISSING+1))
+  fi
 fi
 have npm && echo -e "  ${GREEN}✓${NC} npm $(npm -v)" || { echo -e "  ${RED}✗${NC} npm not found (ships with Node.js)"; MISSING=$((MISSING+1)); }
 
-# python 3.10+
-if have python3; then
-  echo -e "  ${GREEN}✓${NC} $(python3 --version 2>&1)"
+# python 3.10+ (CONTRIBUTING). `have python3` alone is not enough: macOS ships
+# /usr/bin/python3 (3.9 on current releases), which satisfies a presence check
+# but sits below the floor, so an unusable interpreter reported green. And
+# `python@3.11` is keg-only - it installs python3.11 without taking over
+# `python3` - so re-test the END STATE instead of trusting the install.
+PY_MIN="3.10"
+py_ver() { { python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null; } || true; }
+PY_VER="$(py_ver)"
+if version_at_least "$PY_MIN" "$PY_VER"; then
+  echo -e "  ${GREEN}✓${NC} Python $PY_VER"
 else
-  echo -e "  ${RED}✗${NC} Python 3 not found"
-  offer_brew_install "Python 3.11" "python@3.11" "https://www.python.org/downloads" || MISSING=$((MISSING+1))
+  if [ -n "$PY_VER" ]; then
+    echo -e "  ${YELLOW}!${NC} Python $PY_VER found, but ${PY_MIN}+ is required"
+  else
+    echo -e "  ${RED}✗${NC} Python 3 not found"
+  fi
+  offer_brew_install "Python 3.11" "python@3.11" "https://www.python.org/downloads" || true
+  PY_VER="$(py_ver)"
+  if ! version_at_least "$PY_MIN" "$PY_VER"; then
+    keg_hint "Python 3.11" "python@3.11" || true
+    MISSING=$((MISSING+1))
+  fi
 fi
 
-# jdk 17+. `have java` is not enough: macOS ships a /usr/bin/java stub that
-# exists on PATH but errors ("Unable to locate a Java Runtime") when no JDK is
-# installed. Require `java -version` to actually succeed.
-# `|| true`: java exits non-zero when no runtime is installed, and with
-# `set -e`/pipefail that would abort the script mid-check.
-JAVA_VER="$( { java -version 2>&1 | head -1; } || true )"
-if have java && printf '%s' "$JAVA_VER" | grep -qiE 'version|openjdk'; then
-  echo -e "  ${GREEN}✓${NC} $JAVA_VER"
+# jdk 17+ (CONTRIBUTING), for the Flyway live path. This is an ADVISORY, not a
+# blocker: create-doctor-gate.ts gates the JDK only for java/kotlin projects, and
+# bootstrap has no --language, so failing the run here would block a Python or
+# Node author who needs no JDK at all. Report it accurately, do not gate on it.
+JDK_MIN="17"
+JAVA_RAW="$(java_raw)"
+JAVA_VER="$(java_version "$JAVA_RAW")"
+if java_works "$JAVA_RAW" && version_at_least "$JDK_MIN" "$JAVA_VER"; then
+  echo -e "  ${GREEN}✓${NC} JDK $JAVA_VER"
 else
-  echo -e "  ${YELLOW}!${NC} JDK not found (needed for the Flyway live path)"
-  offer_brew_install "JDK 17" "openjdk@17" "https://adoptium.net" || MISSING=$((MISSING+1))
+  if java_works "$JAVA_RAW"; then
+    echo -e "  ${YELLOW}!${NC} JDK $JAVA_VER found, but ${JDK_MIN}+ is needed for the Flyway live path"
+  else
+    echo -e "  ${YELLOW}!${NC} JDK not found on PATH (needed for the Flyway live path)"
+  fi
+  offer_brew_install "JDK $JDK_MIN" "openjdk@$JDK_MIN" "https://adoptium.net" || true
+  JAVA_RAW="$(java_raw)"
+  JAVA_VER="$(java_version "$JAVA_RAW")"
+  if ! java_works "$JAVA_RAW" || ! version_at_least "$JDK_MIN" "$JAVA_VER"; then
+    keg_hint "JDK $JDK_MIN" "openjdk@$JDK_MIN" || true
+    ADVISORIES+=("JDK ${JDK_MIN}+ is not on PATH. Only java/kotlin projects need it; the Flyway live path will fail without it.")
+  fi
 fi
 
 # gh: presence is the tool requirement; authentication is a reminder, not a
@@ -156,10 +262,21 @@ fi
 echo
 if [ "$MISSING" -gt 0 ]; then
   echo -e "${YELLOW}$MISSING required tool(s) still missing. Install them (see above), then re-run.${NC}"
+  if [ "${#ADVISORIES[@]}" -gt 0 ]; then
+    for a in "${ADVISORIES[@]}"; do echo -e "  ${YELLOW}-${NC} $a"; done
+  fi
   exit 1
 fi
 
 echo -e "${GREEN}All required tools are present.${NC}"
+
+# Advisories print on the success path too: a green "all present" that hides a
+# broken JDK is the false-green this script exists to avoid.
+if [ "${#ADVISORIES[@]}" -gt 0 ]; then
+  echo
+  echo -e "${YELLOW}Advisories (not blocking):${NC}"
+  for a in "${ADVISORIES[@]}"; do echo "  - $a"; done
+fi
 
 # Auth reminders are NOT failures: the tools are installed, and these one-liners
 # are quick to run whenever you are ready.

--- a/tests/bdd/bootstrap-prereqs.test.ts
+++ b/tests/bdd/bootstrap-prereqs.test.ts
@@ -1,0 +1,137 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Hermetic coverage for bootstrap.sh's prerequisite gate.
+ *
+ * Every case runs the real script with `--check-only` (so it installs nothing)
+ * against a directory of shims prepended to PATH. That is the only way to reach
+ * these branches without mutating the developer's machine: the bug class this
+ * guards against is "a tool is present but unusable", which cannot be provoked
+ * by inspecting the host's real toolchain.
+ */
+
+const BOOTSTRAP = resolve(__dirname, "../../bootstrap.sh");
+
+/** Tools every run needs green so a case can isolate the one under test. */
+interface Shims {
+  node?: string;
+  python3?: string;
+  java?: string;
+}
+
+function shimDir(shims: Shims): string {
+  const dir = mkdtempSync(join(tmpdir(), "consort-bootstrap-"));
+
+  const write = (name: string, body: string) => {
+    const p = join(dir, name);
+    writeFileSync(p, `#!/usr/bin/env bash\n${body}\n`);
+    chmodSync(p, 0o755);
+  };
+
+  // Defaults are all-green so each test varies exactly one dimension.
+  write("node", `[ "$1" = "-v" ] && echo "v${shims.node ?? "20.11.0"}" || exit 0`);
+  write("npm", `echo "10.2.4"`);
+  write(
+    "python3",
+    `if [ "$1" = "-c" ]; then
+       printf '%s\\n' "${shims.python3 ?? "3.11"}"
+     else
+       echo "Python ${shims.python3 ?? "3.11"}.0"
+     fi`,
+  );
+  // A java shim: empty string means "no runtime", mimicking the macOS stub that
+  // exists on PATH but exits non-zero.
+  if (shims.java === "") {
+    write("java", `echo "The operation couldn't be completed. Unable to locate a Java Runtime." >&2\nexit 1`);
+  } else {
+    write("java", `echo '${shims.java ?? 'openjdk version "17.0.20.1" 2026-08-18'}' >&2`);
+  }
+  write("gh", `[ "$1" = "auth" ] && exit 0 || echo "gh version 2.89.0"`);
+  write("databricks", `[ "$1" = "auth" ] && exit 0 || echo "Databricks CLI v1.12.1"`);
+  write("brew", `[ "$1" = "--prefix" ] && echo "${dir}/nonexistent-prefix" || exit 0`);
+
+  return dir;
+}
+
+function run(shims: Shims): { stdout: string; status: number } {
+  const dir = shimDir(shims);
+  try {
+    const stdout = execFileSync("bash", [BOOTSTRAP, "--check-only"], {
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, SHELL: "/bin/bash" },
+    });
+    return { stdout, status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; status?: number };
+    return { stdout: e.stdout ?? "", status: e.status ?? 1 };
+  }
+}
+
+describe("bootstrap.sh prerequisite floors", () => {
+  it("accepts a python3 at the documented 3.10 floor", () => {
+    const { stdout } = run({ python3: "3.11" });
+    expect(stdout).toContain("Python 3.11");
+    expect(stdout).not.toContain("3.10+ is required");
+  });
+
+  it("rejects a python3 below the floor and fails the run", () => {
+    // macOS's /usr/bin/python3. Previously this reported green because the check
+    // only tested that python3 existed, never its version.
+    const { stdout, status } = run({ python3: "3.9" });
+    expect(stdout).toContain("Python 3.9 found, but 3.10+ is required");
+    expect(status).toBe(1);
+  });
+
+  it("treats 3.10 itself as satisfying the floor (boundary)", () => {
+    const { stdout } = run({ python3: "3.10" });
+    expect(stdout).toContain("Python 3.10");
+    expect(stdout).not.toContain("3.10+ is required");
+  });
+
+  it("rejects a node below 20 and fails the run", () => {
+    const { stdout, status } = run({ node: "18.19.0" });
+    expect(stdout).toContain("Consort needs 20+");
+    expect(status).toBe(1);
+  });
+});
+
+describe("bootstrap.sh JDK handling", () => {
+  it("accepts a JDK at or above 17", () => {
+    const { stdout } = run({ java: 'openjdk version "17.0.20.1" 2026-08-18' });
+    expect(stdout).toContain("JDK 17");
+    expect(stdout).not.toContain("Advisories");
+  });
+
+  it("does not false-negative when the JVM prints a JAVA_TOOL_OPTIONS preamble", () => {
+    // A `head -1` probe reads the preamble instead of the version line and
+    // reports a working JDK as missing.
+    const { stdout } = run({
+      java: 'Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8\nopenjdk version "17.0.20.1" 2026-08-18',
+    });
+    expect(stdout).toContain("JDK 17");
+    expect(stdout).not.toContain("JDK not found on PATH");
+  });
+
+  it("flags a below-floor JDK as an advisory without failing the run", () => {
+    // create-doctor-gate.ts: the JDK blocks only java/kotlin projects, and
+    // bootstrap has no --language, so it must not gate every user on it.
+    const { stdout, status } = run({ java: 'java version "1.8.0_402"' });
+    expect(stdout).toContain("17+ is needed for the Flyway live path");
+    expect(stdout).toContain("Advisories (not blocking)");
+    expect(status).toBe(0);
+  });
+
+  it("reports a missing JDK as an advisory, never as a silent green", () => {
+    const { stdout, status } = run({ java: "" });
+    expect(stdout).toContain("JDK not found on PATH");
+    expect(stdout).toContain("Advisories (not blocking)");
+    // Green summary is still printed (nothing REQUIRED is missing) but it can no
+    // longer hide the broken JDK.
+    expect(stdout).toContain("All required tools are present");
+    expect(status).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`bootstrap.sh` could report a green environment that Consort cannot actually run on. Three prerequisite checks passed while the tool was present-but-unusable.

**Python floor never compared.** The check tested only that `python3` existed, never its version, so macOS's `/usr/bin/python3` (3.9) satisfied a floor CONTRIBUTING documents as 3.10+.

**Keg-only installs dead-ended.** The JDK and Node paths offer `brew install openjdk@17` / `node@20`. Both are keg-only: brew installs them without linking them onto PATH, so `java` / `node` still fail immediately afterwards. Because a successful install made `offer_brew_install` return 0, `MISSING` stayed at zero and the script exited **0 — "All required tools are present"** — with no working toolchain.

Reproduced on a clean macOS machine: `brew install openjdk@17` exited 0, `java -version` still reported "Unable to locate a Java Runtime", and re-running bootstrap reported all tools present.

## How

Every check now judges the **end state** rather than the installer's exit status: after any remediation it re-probes the tool and counts it present only if it actually resolves. Supporting changes:

- Keg paths resolve via `brew --prefix` with the well-known prefixes (linuxbrew included) as fallback, instead of two hardcoded macOS locations — the previous shape silently never fired on Linux, which `offer_brew_install` explicitly supports.
- A detected keg-only install prints the exact `export PATH=...` line for the user's real shell (`$SHELL`-aware) rather than dead-ending.
- Three hand-rolled version idioms folded into one `version_at_least` helper.
- Added the **JDK 17 floor** that CONTRIBUTING promises but nothing enforced — a JDK 8 previously passed green.
- The `java` probe now reads the full `java -version` output. A `JAVA_TOOL_OPTIONS` preamble previously hid a working JDK from the first-line probe, and the two probes in the block disagreed with each other.

## One decision worth your review

I made the **JDK an advisory rather than a blocker**, based on `consort/lakebase/create-doctor-gate.ts`:

> JDK 17 is the Flyway live-path requirement, so it blocks only for java/kotlin; a Python (alembic) or Node project does not need a JDK and must not be gated on it.

`bootstrap.sh` has no `--language`, so failing the run would block Python and Node authors who need no JDK at all. Advisories print on both the success and failure paths, so a broken JDK is reported honestly without failing a run that doesn't need it.

That's my reading of your intent, not something the script stated — if you'd rather bootstrap be strict regardless of language, say so and I'll make it increment `MISSING` instead.

## Tests

`tests/bdd/bootstrap-prereqs.test.ts` (+8), hermetic. Each case runs the real script under `--check-only` against PATH shims, which is the only way to reach these branches without mutating the developer's machine — the bug class is "present but unusable", which the host's real toolchain cannot provoke.

Covers: both floors, the 3.10 boundary, node below 20, the `JAVA_TOOL_OPTIONS` preamble, and advisory-not-blocking for both a below-floor and an absent JDK.

Full hermetic suite green: 4204 passed, 262 files, no regressions.

## Heads-up on a related bug outside this PR

The doctor that actually gates provisioning lives in `@databricks-solutions/lakebase-scm-utils`, and it has the same Python gap. Its `PREREQS` entry is:

```js
{ name: "python", cmd: "python3", versionArgs: ["--version"], minMajor: 3,
  hint: "Install Python 3.10+ (e.g. `brew install python@3.11` ...)" }
```

`minMajor: 3` can only express "some Python 3", so 3.9 passes there too while the hint promises 3.10+ — the schema has no minor component to express the real floor. Observed directly: `lakebase-create-project` printed `[doctor] environment ok` on a machine whose `python3` was 3.9.6.

Not fixable from this repo. Happy to open that separately against `lakebase-scm-utils` if you want it — the fix is a `minMinor` (or full version) field on the prereq spec.
