### PR TITLE
feat(dashboard): observer parity — surface the agent exchange & make the event stream scannable

### DIFF
--- a/apps/dashboard/app/DrilldownPanel.tsx
+++ b/apps/dashboard/app/DrilldownPanel.tsx
@@ -249,7 +249,7 @@ function Section({ label, children }: { label: string; children: React.ReactNode
 type TurnKind = "code" | "artifact";
 
 // Most fields optional because the corpus's turn.json genuinely omits them (mode on 36/126, etc.).
-interface TurnPayload {
+export interface TurnPayload {
   ordinal: number;
   step: number;
   label: string;
@@ -429,7 +429,7 @@ function TabButton({ active, onClick, disabled, children }: { active: boolean; o
   );
 }
 
-function TranscriptView({ turn }: { turn: TurnPayload }) {
+export function TranscriptView({ turn }: { turn: TurnPayload }) {
   if (!turn.transcript) {
     return (
       <div style={{ fontSize: "0.76rem", color: "var(--text-faint)" }}>
@@ -438,24 +438,38 @@ function TranscriptView({ turn }: { turn: TurnPayload }) {
     );
   }
   const { prompt, tools, reasoning } = turn.transcript;
+  // Frame the turn as the EXCHANGE Kevin's original made obvious: an inbound prompt sent TO the
+  // role (▸), then what the role sent back (◂) — its tools and its reasoning. The direction glyphs
+  // + the role name in each label make "what was passed back and forth" legible at a glance rather
+  // than three flat sections a viewer has to mentally assign a direction to.
+  const role = turn.role ?? "agent";
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-      <Section label="Prompt">
+      <Section label={`▸ Prompt → ${role}`}>
         <Pre>{prompt || "(empty)"}</Pre>
       </Section>
       {tools.length > 0 ? (
-        <Section label={`Tools used (${tools.length})`}>
+        <Section label={`◂ Tools ${role} invoked (${tools.length})`}>
           <div style={{ display: "flex", flexDirection: "column", gap: 2, maxHeight: 168, overflowY: "auto" }}>
-            {tools.map((t, i) => (
-              <div key={i} title={t} style={{ fontSize: "0.68rem", fontFamily: font.mono, color: "var(--text-muted)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                {t}
-              </div>
-            ))}
+            {tools.map((t, i) => {
+              // Tool lines arrive as "ToolName rest of the call…"; bold the tool name and mute the
+              // arguments so a viewer scans WHICH tools ran without the args drowning them out
+              // (Kevin's `.tn` treatment).
+              const sp = t.indexOf(" ");
+              const name = sp > 0 ? t.slice(0, sp) : t;
+              const rest = sp > 0 ? t.slice(sp) : "";
+              return (
+                <div key={i} title={t} style={{ fontSize: "0.68rem", fontFamily: font.mono, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                  <span style={{ fontWeight: 700, color: "var(--text-body)" }}>{name}</span>
+                  <span style={{ color: "var(--text-muted)" }}>{rest}</span>
+                </div>
+              );
+            })}
           </div>
         </Section>
       ) : null}
       {reasoning ? (
-        <Section label="Final reasoning">
+        <Section label={`◂ ${role}'s final reasoning`}>
           <Pre>{reasoning}</Pre>
         </Section>
       ) : null}

--- a/apps/dashboard/app/board-parts.tsx
+++ b/apps/dashboard/app/board-parts.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect, useRef } from "react";
 import type { DashboardState } from "@/lib/types";
-import { font, radius } from "@/lib/theme";
+import { colorForRole, font, radius } from "@/lib/theme";
 
 /**
  * `?mode=live|replay` from the page URL, so a mode is linkable.
@@ -138,21 +138,37 @@ export function EventTicker({
           const artifactPath = openTurn ? null : onOpenArtifact ? artifactPathOf(e) : null;
           const clickable = openTurn || artifactPath !== null;
           const onClick = openTurn ? () => onOpenTurn!(turn!) : artifactPath !== null ? () => onOpenArtifact!(artifactPath) : undefined;
+          // A `reasoning` event is the agent narrating its own thinking ("established the layer
+          // canon …") — the single most demo-worthy line in the stream, and the thing Kevin's
+          // original surfaced inline. Every other row is a machine event clipped to one column-
+          // aligned line; a reasoning row instead WRAPS (so the whole thought is legible without a
+          // drill-down) and is tied to its agent by the role colour + a 💭 marker. This is the
+          // "you see what's passed back and forth" parity fix.
+          const isReasoning = e.event === "reasoning";
+          const roleColor = e.role ? colorForRole(e.role) : "var(--text-on-dark-accent)";
+          // Role-tint the marker/columns only on a NON-clickable reasoning row. A clickable row sits
+          // on the light `.consort-open` highlight, where a saturated role hue (e.g. amber dba) is
+          // unreadable in light mode — clickable rows must keep the semantic tokens the affordance
+          // comment below relies on. In practice reasoning events don't begin a turn, so this is a
+          // guard, not a common case.
+          const reasonTint = isReasoning && !clickable;
           return (
             <div
               key={i}
               onClick={onClick}
               className={clickable ? "consort-open" : undefined}
-              title={openTurn ? `Open turn ${turn} — transcript and produced files` : artifactPath !== null ? `Open ${artifactPath} — content at HEAD` : undefined}
+              title={openTurn ? `Open turn ${turn} — transcript and produced files` : artifactPath !== null ? `Open ${artifactPath} — content at HEAD` : isReasoning ? e.message : undefined}
               style={{
                 display: "flex",
                 gap: 10,
-                alignItems: "center",
+                // A wrapping reasoning row aligns its columns to the first line, not centre.
+                alignItems: isReasoning ? "flex-start" : "center",
                 // Clickable rows carry the accent rail (via the class), so pull their padding in by
                 // the 2px border to keep every row's text on the same left edge.
                 padding: clickable ? "2px 0 2px 4px" : "2px 0 2px 6px",
                 color: "var(--border-default)",
-                whiteSpace: "nowrap",
+                // Reasoning wraps to full text; all other rows stay single-line.
+                whiteSpace: isReasoning ? "normal" : "nowrap",
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 cursor: clickable ? "pointer" : undefined,
@@ -160,22 +176,36 @@ export function EventTicker({
             >
               {/* A fixed-width left gutter carrying a bold `»` on openable rows (blank otherwise, so
                   columns stay aligned). This is the marker Kevin remembers — leading the row, not a
-                  faint trailing span, so it survives the auto-scroll and reads at a glance. */}
+                  faint trailing span, so it survives the auto-scroll and reads at a glance. A
+                  reasoning row shows 💭 in its agent's colour instead. */}
               {/* A clickable row carries the `surface.inset` highlight (via .consort-open), so its
                   text must switch to the SEMANTIC tokens — the always-light onDark* colors used on
                   the dark-terminal rows are unreadable on that highlight in light mode (light-on-
                   white). Using strong/body/muted (not hardcoded black) makes it correct in both
                   palettes: light row + dark text in light mode, dark row + light text in dark. */}
-              <span style={{ width: 10, color: clickable ? "var(--status-accent)" : "transparent", fontWeight: 800 }}>{clickable ? "»" : ""}</span>
-              <span style={{ color: "var(--text-muted)" }}>{e.timestamp.slice(11, 19)}</span>
-              <span style={{ color: clickable ? "var(--text-muted)" : levelColor[e.level] ?? "var(--text-muted)", width: 42 }}>{e.event.split(".")[0]}</span>
-              <span style={{ color: clickable ? "var(--text-body)" : "var(--text-on-dark-accent)", width: 130, overflow: "hidden", textOverflow: "ellipsis" }}>{e.role}</span>
-              <span style={{ color: clickable ? "var(--text-strong)" : "var(--text-on-dark-muted)", overflow: "hidden", textOverflow: "ellipsis" }}>{e.message}</span>
+              {/* Gutter is a fixed 16px so an emoji (wider than the `»` it replaces) fits without
+                  pushing the timestamp column out of alignment; `»` wins over 💭 on a clickable row
+                  so the at-rest click affordance is never lost. */}
+              <span style={{ width: 16, flexShrink: 0, textAlign: "center", overflow: "hidden", lineHeight: 1, color: clickable ? "var(--status-accent)" : reasonTint ? roleColor : "transparent", fontWeight: 800, fontSize: isReasoning ? "0.7rem" : undefined }}>{clickable ? "»" : isReasoning ? "💭" : ""}</span>
+              <span style={{ color: "var(--text-muted)", flexShrink: 0 }}>{e.timestamp.slice(11, 19)}</span>
+              <span style={{ color: reasonTint ? roleColor : clickable ? "var(--text-muted)" : levelColor[e.level] ?? "var(--text-muted)", width: 42, flexShrink: 0 }}>{e.event.split(".")[0]}</span>
+              <span style={{ color: reasonTint ? roleColor : clickable ? "var(--text-body)" : "var(--text-on-dark-accent)", width: 130, flexShrink: 0, overflow: "hidden", textOverflow: "ellipsis" }}>{e.role}</span>
+              {/* Reasoning text is italic (it reads as narration, not a status line) and never
+                  clipped — the whole thought stays on screen. */}
+              <span
+                style={
+                  isReasoning
+                    ? { color: clickable ? "var(--text-strong)" : "var(--text-on-dark-accent)", fontStyle: "italic", flex: 1, whiteSpace: "normal", wordBreak: "break-word" }
+                    : { color: clickable ? "var(--text-strong)" : "var(--text-on-dark-muted)", overflow: "hidden", textOverflow: "ellipsis" }
+                }
+              >
+                {e.message}
+              </span>
               {/* The trailing label names the action (open …), accent-coloured so it reads as the
                   button it is rather than metadata. Only rows that begin a recorded turn / name an
                   artifact are openable, so the affordance marks exactly where the drill-down is. */}
-              {openTurn ? <span style={{ marginLeft: "auto", color: "var(--status-accent)", fontWeight: 700, paddingLeft: 8 }}>open turn {turn} ›</span> : null}
-              {artifactPath !== null ? <span style={{ marginLeft: "auto", color: "var(--status-accent)", fontWeight: 700, paddingLeft: 8 }}>open file ›</span> : null}
+              {openTurn ? <span style={{ marginLeft: "auto", color: "var(--status-accent)", fontWeight: 700, paddingLeft: 8, whiteSpace: "nowrap" }}>open turn {turn} ›</span> : null}
+              {artifactPath !== null ? <span style={{ marginLeft: "auto", color: "var(--status-accent)", fontWeight: 700, paddingLeft: 8, whiteSpace: "nowrap" }}>open file ›</span> : null}
             </div>
           );
         })}

--- a/apps/dashboard/app/board-parts.tsx
+++ b/apps/dashboard/app/board-parts.tsx
@@ -72,6 +72,30 @@ function artifactPathOf(e: DashboardState["recentEvents"][number]): string | nul
   return typeof p === "string" && p ? p : null;
 }
 
+// Colour the STATE-TRANSITION event kinds so the stream is scannable by category — Kevin's
+// original colour-coded its timeline, which is how a demo viewer spots "a gate surfaced" or "a
+// deploy verified" at a glance instead of reading every grey line. Kept to the board's existing
+// semantic palette (each token is already used as text ON the dark terminal, so it's readable in
+// both themes) and to the kinds that carry meaning; the structural rows (handoff/artifact/phase/
+// intake/usage) stay neutral so the colour actually means something. `reasoning` is handled
+// separately (its own role colour + 💭). The `label` doubles as the legend caption.
+//
+// Two deliberate exclusions: (1) these colours are used ONLY at info/debug level — a warn/error
+// row (e.g. `deploy.failed`, `verify.failed`, a rejected gate) keeps its level colour so a FAILURE
+// never renders in the green/purple a viewer would read as success (see eventAccent's caller). (2)
+// no TDD-cycle colour: `--status-accent` is reserved for the "openable" signal (the » gutter + open
+// links + the clickable rail), so tinting cycle rows with it would make inert rows read as clickable.
+const EVENT_LEGEND: { match: (event: string) => boolean; color: string; label: string }[] = [
+  { match: (e) => e.startsWith("gate"), color: "var(--status-gate)", label: "gate" },
+  { match: (e) => e.startsWith("escalation"), color: "var(--status-critical-text)", label: "escalation" },
+  { match: (e) => e.startsWith("deploy") || e.startsWith("verify"), color: "var(--status-good)", label: "deploy / verify" },
+];
+
+/** The categorical colour for a state-transition event kind, or null to fall back to the level colour. */
+function eventAccent(event: string): string | null {
+  return EVENT_LEGEND.find((k) => k.match(event))?.color ?? null;
+}
+
 export function EventTicker({
   state,
   onOpenTurn,
@@ -128,6 +152,21 @@ export function EventTicker({
         .consort-open { border-left: 2px solid var(--status-accent); background: var(--surface-inset); }
         .consort-open:hover { background: var(--surface-card); }
       `}</style>
+      {/* A colour key for the stream: names what the state-transition colours mean plus the 💭
+          reasoning marker, so a viewer reads the timeline at a glance (Kevin's legend). Sits above
+          the log on the page ground, so its labels use the theme-safe muted token. */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginBottom: 6, fontSize: "0.64rem", color: "var(--text-muted)" }}>
+        {EVENT_LEGEND.map((k) => (
+          <span key={k.label} style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: k.color, flexShrink: 0 }} />
+            {k.label}
+          </span>
+        ))}
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+          <span style={{ fontSize: "0.7rem" }}>💭</span>
+          reasoning
+        </span>
+      </div>
       <div ref={scrollRef} onScroll={onScroll} style={{ background: "var(--surface-terminal)", borderRadius: radius.panel, padding: "12px 14px", maxHeight: 240, overflowY: "auto", fontFamily: font.mono, fontSize: "0.72rem" }}>
         {merged.map((row, i) => {
           if (row.kind === "corr") return <CorrRow key={i} c={row.c} onOpenTurn={onOpenTurn} />;
@@ -152,6 +191,12 @@ export function EventTicker({
           // comment below relies on. In practice reasoning events don't begin a turn, so this is a
           // guard, not a common case.
           const reasonTint = isReasoning && !clickable;
+          // Categorical colour for a state-transition kind (gate/escalation/deploy·verify), used on
+          // the kind label of a non-clickable, non-reasoning row. Withheld at warn/error level so a
+          // FAILED deploy/verify or a rejected gate keeps its red/amber level colour instead of the
+          // green/purple that would read as success. Clickable rows keep the semantic tokens the
+          // highlight needs; reasoning rows already carry their role colour.
+          const kindAccent = !isReasoning && !clickable && e.level !== "warn" && e.level !== "error" ? eventAccent(e.event) : null;
           return (
             <div
               key={i}
@@ -188,7 +233,7 @@ export function EventTicker({
                   so the at-rest click affordance is never lost. */}
               <span style={{ width: 16, flexShrink: 0, textAlign: "center", overflow: "hidden", lineHeight: 1, color: clickable ? "var(--status-accent)" : reasonTint ? roleColor : "transparent", fontWeight: 800, fontSize: isReasoning ? "0.7rem" : undefined }}>{clickable ? "»" : isReasoning ? "💭" : ""}</span>
               <span style={{ color: "var(--text-muted)", flexShrink: 0 }}>{e.timestamp.slice(11, 19)}</span>
-              <span style={{ color: reasonTint ? roleColor : clickable ? "var(--text-muted)" : levelColor[e.level] ?? "var(--text-muted)", width: 42, flexShrink: 0 }}>{e.event.split(".")[0]}</span>
+              <span style={{ color: reasonTint ? roleColor : clickable ? "var(--text-muted)" : kindAccent ?? levelColor[e.level] ?? "var(--text-muted)", fontWeight: kindAccent ? 700 : undefined, width: 42, flexShrink: 0, overflow: "hidden", textOverflow: "ellipsis" }}>{e.event.split(".")[0]}</span>
               <span style={{ color: reasonTint ? roleColor : clickable ? "var(--text-body)" : "var(--text-on-dark-accent)", width: 130, flexShrink: 0, overflow: "hidden", textOverflow: "ellipsis" }}>{e.role}</span>
               {/* Reasoning text is italic (it reads as narration, not a status line) and never
                   clipped — the whole thought stays on screen. */}

--- a/apps/dashboard/app/render.test.tsx
+++ b/apps/dashboard/app/render.test.tsx
@@ -411,8 +411,8 @@ describe("render — EventTicker turn affordance", () => {
     const reasoningCount = state.recentEvents.filter((e) => e.event === "reasoning").length;
     expect(reasoningCount).toBeGreaterThan(0); // fixture guard: the assertions below are vacuous otherwise
     const markup = renderToStaticMarkup(<EventTicker state={state} />);
-    // One 💭 per reasoning event, and only for reasoning events.
-    expect((markup.match(/💭/g) ?? []).length).toBe(reasoningCount);
+    // One 💭 per reasoning event, plus the single 💭 in the legend key.
+    expect((markup.match(/💭/g) ?? []).length).toBe(reasoningCount + 1);
     // Reasoning narration is italic and set to wrap (never clipped to one line).
     expect(markup).toContain("font-style:italic");
     // A reasoning event's full message survives into the markup (wrapping is CSS, not truncation).
@@ -575,6 +575,38 @@ describe("render — DrilldownPanel", () => {
     // The tool NAME is bolded (its own span) and the args are present but rendered muted.
     expect(markup).toMatch(/font-weight:700[^>]*>Read<\/span>/);
     expect(markup).toContain("app/models.py lines 1-40");
+  });
+
+  // T5 parity: the stream is scannable by category, with a legend that explains the colours.
+  it("colour-codes state-transition event kinds and renders a legend", () => {
+    // The count-based assertions below assume no correspondence rows (CorrRow also uses the gate
+    // colour), which holds for this fixture.
+    expect(state.source?.correspondence?.recent?.length ?? 0).toBe(0);
+    const markup = renderToStaticMarkup(<EventTicker state={state} />);
+    // The legend names each colour category plus the reasoning marker.
+    for (const label of ["gate", "escalation", "deploy / verify", "reasoning"]) {
+      expect(markup).toContain(label);
+    }
+    // Row colouring, not just the legend swatch: the legend emits exactly one of each colour, so a
+    // count > 1 proves at least one actual event row carries it. The fixture has info-level gate and
+    // deploy/verify events.
+    expect(state.recentEvents.some((e) => e.event.startsWith("gate") && e.level !== "warn" && e.level !== "error")).toBe(true);
+    expect((markup.match(/var\(--status-gate\)/g) ?? []).length).toBeGreaterThan(1);
+    expect(state.recentEvents.some((e) => (e.event.startsWith("deploy") || e.event.startsWith("verify")) && e.level !== "warn" && e.level !== "error")).toBe(true);
+    expect((markup.match(/var\(--status-good\)/g) ?? []).length).toBeGreaterThan(1);
+  });
+
+  it("does NOT paint a failed deploy/verify green — a warn/error row keeps its level colour", () => {
+    // The demo hazard: `deploy.failed` matches the deploy/verify rule, but painting it green reads
+    // as success. At error level the category colour is withheld, so the only --status-good in the
+    // markup is the legend swatch (count 1), and the row shows the error colour instead.
+    const failed = {
+      ...state,
+      recentEvents: [{ timestamp: "2026-08-05T00:00:00.000Z", level: "error", role: "release-engineer", event: "deploy.failed", message: "DEPLOY failed", metadata: {} }],
+    } as DashboardState;
+    const markup = renderToStaticMarkup(<EventTicker state={failed} />);
+    expect((markup.match(/var\(--status-good\)/g) ?? []).length).toBe(1); // legend only, no green row
+    expect(markup).toContain("var(--status-critical-text)"); // the failure reads as error
   });
 
   it("says a non-role step has no transcript rather than rendering an empty exchange", () => {

--- a/apps/dashboard/app/render.test.tsx
+++ b/apps/dashboard/app/render.test.tsx
@@ -22,12 +22,16 @@ import { AgentBubble } from "./AgentBubble";
 import { WorkflowGraph } from "./WorkflowGraph";
 import { Transport } from "./Transport";
 import { LaneGraph } from "./LaneGraph";
-import { DrilldownPanel, turnUrl } from "./DrilldownPanel";
+import { DrilldownPanel, TranscriptView, turnUrl, type TurnPayload } from "./DrilldownPanel";
 import { DriftBanner, EventTicker, FidelityBanner, modeFromUrl } from "./board-parts";
 import type { DashboardState } from "@/lib/types";
 
 const fixture = (name: string): DashboardState =>
   JSON.parse(readFileSync(join(__dirname, "..", "lib", "__fixtures__", name), "utf8"));
+
+// React escapes &, <, > in text nodes; renderToStaticMarkup emits the escaped form. Mirror that so
+// a `toContain` on raw corpus text stays correct if the text ever carries an HTML-special char.
+const escapeHtml = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
 const state = fixture("render-state.json");
 // The same run pinned at event 40 — atLive false, so snapshot-fenced panels must differ.
@@ -393,6 +397,29 @@ describe("render — EventTicker turn affordance", () => {
     const s = withSource({ correlation: health({ recentTurns: state.recentEvents.map(() => 3) }) });
     expect(renderToStaticMarkup(<EventTicker state={s} />)).not.toContain("turn 3 ›");
   });
+
+  // Kevin's parity ask: the agent's own reasoning must be visible in the stream, not buried in a
+  // drill-down. A reasoning event renders distinctly — a 💭 marker and italic narration that
+  // WRAPS instead of ellipsis-clipping — so the "what's passed back and forth" reads at a glance.
+  it("renders reasoning events distinctly (💭 marker, italic, wrapping)", () => {
+    // EventTicker renders only the last MERGED_TAIL (60) rows of the merged events+correspondence
+    // stream. Pin the two premises that make the 💭 count exact for THIS fixture — no correspondence
+    // and ≤ 60 events, so every reasoning event is actually rendered — rather than silently counting
+    // events the component never drew.
+    expect(state.source?.correspondence?.recent?.length ?? 0).toBe(0);
+    expect(state.recentEvents.length).toBeLessThanOrEqual(60);
+    const reasoningCount = state.recentEvents.filter((e) => e.event === "reasoning").length;
+    expect(reasoningCount).toBeGreaterThan(0); // fixture guard: the assertions below are vacuous otherwise
+    const markup = renderToStaticMarkup(<EventTicker state={state} />);
+    // One 💭 per reasoning event, and only for reasoning events.
+    expect((markup.match(/💭/g) ?? []).length).toBe(reasoningCount);
+    // Reasoning narration is italic and set to wrap (never clipped to one line).
+    expect(markup).toContain("font-style:italic");
+    // A reasoning event's full message survives into the markup (wrapping is CSS, not truncation).
+    // Escape as React does for text nodes, so a message with &/</> in a future corpus still matches.
+    const firstReasoning = state.recentEvents.find((e) => e.event === "reasoning")!;
+    expect(markup).toContain(escapeHtml(firstReasoning.message));
+  });
 });
 
 describe("render — DriftBanner", () => {
@@ -524,6 +551,37 @@ describe("render — DrilldownPanel", () => {
     const markup = renderToStaticMarkup(<DrilldownPanel target={{ kind: "step", node: "plan" }} mode="replay" feature="F1-stock-visibility" onClose={() => {}} />);
     expect(markup).toContain("STEP OUTPUTS");
     expect(markup).toContain("Close drill-down panel");
+  });
+
+  // Kevin's ask, in the drill-down: the turn must read as an EXCHANGE — an inbound prompt to the
+  // role, then the role's tools + reasoning back — with the tool NAME legible apart from its args.
+  it("frames the transcript as a directional exchange with the role named, and splits tool name from args", () => {
+    const turn = {
+      ordinal: 20,
+      step: 20,
+      label: "spec-author",
+      kind: "invoke-role",
+      role: "spec-author",
+      produced: [],
+      deleted: [],
+      transcript: { prompt: "Propose the features.", tools: ["Read app/models.py lines 1-40", "Write .consort/spec.json"], reasoning: "Chose the thinnest slice." },
+      transcriptSummary: null,
+    } as TurnPayload;
+    const markup = renderToStaticMarkup(<TranscriptView turn={turn} />);
+    // Inbound and outbound are labelled and name the role.
+    expect(markup).toContain("▸ Prompt → spec-author");
+    expect(markup).toContain("◂ Tools spec-author invoked (2)");
+    expect(markup).toContain("◂ spec-author&#x27;s final reasoning");
+    // The tool NAME is bolded (its own span) and the args are present but rendered muted.
+    expect(markup).toMatch(/font-weight:700[^>]*>Read<\/span>/);
+    expect(markup).toContain("app/models.py lines 1-40");
+  });
+
+  it("says a non-role step has no transcript rather than rendering an empty exchange", () => {
+    const turn = { ordinal: 5, step: 5, label: "cut", kind: "experiment-cut", produced: [], deleted: [], transcript: null, transcriptSummary: null } as TurnPayload;
+    const markup = renderToStaticMarkup(<TranscriptView turn={turn} />);
+    expect(markup).toContain("no agent transcript");
+    expect(markup).not.toContain("Prompt →");
   });
 
   it("builds turn URLs without asserting a mode it wasn't given", () => {

--- a/apps/dashboard/run.sh
+++ b/apps/dashboard/run.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # Launch the Consort dashboard against a scaffolded Consort project.
-# Usage: ./run.sh /absolute/path/to/project   [PORT=3000] [THEME=dark]
+# Usage: ./run.sh /absolute/path/to/project   [PORT=3000] [THEME=dark] [CONSORT_RECORD_DIR=/path]
 #   THEME=dark boots the board in dark mode (Kevin's palette). Default is light; the in-app
 #   ☀️/🌙 toggle overrides this per viewer and is remembered in localStorage.
+#   CONSORT_RECORD_DIR (or LAKEBASE_CONSORT_RECORD_DIR) points at the drive's record-lane corpus.
+#   Set it to show the FULL agent exchange — the prompt sent to each role, plus its reasoning,
+#   tools and the HIL↔orchestrator conversation — LIVE as the build runs. Without it, a live board
+#   shows the event timeline + current outputs only (those richer streams live only in the record
+#   corpus); the in-app banner says so and points at replay mode. Same dir you pass the drive.
 set -euo pipefail
 DIR="${1:-${CONSORT_PROJECT_DIR:-}}"
 if [ -z "$DIR" ]; then
@@ -15,6 +20,17 @@ fi
 export CONSORT_PROJECT_DIR="$DIR"
 export PORT="${PORT:-3000}"
 export THEME="${THEME:-}" # "dark" boots dark; empty = light default (read by app/layout.tsx)
+# Accept either env-var name (recordDir() in lib/consort.ts reads both); normalise to the one name
+# so the message below is unambiguous, and say plainly whether the live board will show the exchange.
+REC="${CONSORT_RECORD_DIR:-${LAKEBASE_CONSORT_RECORD_DIR:-}}"
+export CONSORT_RECORD_DIR="$REC"
 echo "Watching: $CONSORT_PROJECT_DIR"
 echo "Dashboard: http://localhost:$PORT${THEME:+ (theme: $THEME)}"
+if [ -n "$REC" ]; then
+  # The corpus may not exist yet at launch — the drive writes it as the first turn lands, and the
+  # board's capabilities light up then. So confirm the wiring rather than asserting the dir exists.
+  echo "Live exchange: ON — companion recording at $REC (prompts, reasoning, tools & HIL conversation appear as turns are captured)"
+else
+  echo "Live exchange: event timeline only — set CONSORT_RECORD_DIR=/path (the drive's record-lane dir) to show prompts, reasoning & tools live, or open the recorded corpus in replay mode"
+fi
 exec npm run dev


### PR DESCRIPTION
## What

Closes the parity gap raised on the live dashboard: the original replay dashboard showed the inbound prompt to each agent role and the response (reasoning + tools) it sent back, and colour-coded its timeline — "you see what's passed back and forth," which made for a better demo. The vendored `apps/dashboard` had ported the per-turn transcript, but the exchange was buried behind a click, the agent's reasoning was clipped in the event stream, and the stream wasn't scannable by category.

Three commits, one per feature:

### 1. Surface the agent exchange (`prompt → reasoning + tools`)
- **Reasoning inline** (`EventTicker`) — `reasoning` events render with a 💭 marker in the agent's role colour and **wrap to full text** instead of clipping, so the agent's thinking reads at a glance as the run streams.
- **Directional exchange** (`TranscriptView`) — the drill-down reads as a conversation: `▸ Prompt → {role}` (inbound), `◂ Tools {role} invoked (N)` and `◂ {role}'s final reasoning` (outbound).
- **Tool rows** bold the tool name against muted arguments.

### 2. Colour-code the event stream by kind + a legend
- State-transition kinds carry a categorical colour on their kind label — **gate** (purple), **escalation** (red), **deploy / verify** (green) — with a **legend** above the stream. Structural rows stay neutral so the colour means something.
- Two guards keep it honest: the colour is applied only at info/debug level, so a **failed** deploy/verify or rejected gate keeps its red/amber level colour instead of reading as success; and TDD-cycle rows are deliberately not tinted (that colour is reserved for the "openable" affordance).

### 3. Make the live-recording exchange a documented `run.sh` option
- The live board *already* shows the full exchange (prompt/reasoning/tools/HIL conversation) when a companion record-lane corpus is configured — the live source lights up the `transcripts`/`correspondence`/`stepOutputs` capabilities from `CONSORT_RECORD_DIR` (Phase B, covered by `lib/source.test.ts`). `run.sh` now accepts and documents that env var (either name) and prints whether the live board will show the exchange or the event timeline only.

## Testing

- `npx vitest run` → **351 pass / 55 skipped**; `npx tsc --noEmit` clean. (+6 tests, incl. a regression test that a failed deploy is not painted green.)
- Verified live in dark mode against a recorded corpus: reasoning wraps and stays column-aligned; the turn drill-down shows the labelled exchange with bolded tool names; the legend renders and gate rows show purple labels.
- Ran the repo's code review over each change and addressed every finding.

## Scope notes

- This is the dashboard's read-only **rendering** of a corpus — independent of the replay **engine** / scenario re-recording (a separate effort).
- The live-recording path (commit 3) is verified at the enablement + unit-test level; a true **end-to-end live-recording demo** (drive writing the record lane + board showing it in real time) has not been run and depends on a live build.

This pull request and its description were written by Isaac.