### PR TITLE
fix(replay): unbreak the capture/replay harness (lk resolution + env-name refresh)

### DIFF
--- a/examples/replay/.env.example
+++ b/examples/replay/.env.example
@@ -29,4 +29,4 @@ export GITHUB_OWNER=<your-github-user-or-org>
 
 # Auto-answer the pause-at-handoff gates in run-to-navigator.sh /
 # run-to-release-engineer.sh (non-interactive / CI). Leave unset to be prompted.
-# export LAKEBASE_SFTDD_AUTO_CONTINUE=1
+# export LAKEBASE_CONSORT_AUTO_CONTINUE=1

--- a/examples/replay/CAPTURE-RUNBOOK.md
+++ b/examples/replay/CAPTURE-RUNBOOK.md
@@ -96,13 +96,13 @@ different kit is the split-brain trap.
 - [ ] Cache not stale: Mode B ran `lk --rewarm`; Mode A rebuilt `dist`.
 - [ ] `DATABRICKS_CONFIG_PROFILE` valid for the target workspace.
 - [ ] Port 8000 free (the local deploy verify binds it): `lsof -iTCP:8000 -sTCP:LISTEN`.
-- [ ] `LAKEBASE_SFTDD_AUTO_CONTINUE=1` (headless, required for `--create`).
+- [ ] `LAKEBASE_CONSORT_AUTO_CONTINUE=1` (headless, required for `--create`).
 - [ ] No leftover orphan from a prior failed run (see Teardown).
 
 ## Run
 
 ```
-LAKEBASE_SFTDD_AUTO_CONTINUE=1 DATABRICKS_CONFIG_PROFILE=<profile> \
+LAKEBASE_CONSORT_AUTO_CONTINUE=1 DATABRICKS_CONFIG_PROFILE=<profile> \
 bash examples/replay/capture-scenario.sh \
   --scenario <name> --create \
   --databricks-host <url> --github-owner <owner> \
@@ -141,7 +141,7 @@ phase and no-op.
 
 In `--sprint` the harness does NOT pre-seed the feature-requests: the planning
 lane authors them LIVE (the proxy-as-PO author-requests step, fed by
-`LAKEBASE_SFTDD_SPRINT_REQUESTS`), so `sync-backlog` projects `backlog.json` from
+`LAKEBASE_CONSORT_SPRINT_REQUESTS`), so `sync-backlog` projects `backlog.json` from
 just those features. After the plan gate, `runSprint`'s `commitAndPushRequests`
 commits + pushes the just-authored requests to `origin/<entry-tier>` before the
 first fork, so each feature branch (forked from origin) inherits its request.

--- a/examples/replay/_replay-smoke.sh
+++ b/examples/replay/_replay-smoke.sh
@@ -13,7 +13,7 @@
 #
 # At the handoff the driver PAUSES (a HITL [Y/n] gate), waits for the human, and
 # RESUMES the same run on Y , it never bails out of the state machine. Set
-# LAKEBASE_SFTDD_AUTO_CONTINUE=1 to auto-confirm (non-interactive / CI).
+# LAKEBASE_CONSORT_AUTO_CONTINUE=1 to auto-confirm (non-interactive / CI).
 #
 # Determinism (in code): the create-project bootstrap, the scaffolded project's
 # scripts/lk, and every drive turn all resolve the kit through the SAME committed
@@ -92,7 +92,7 @@ replay_smoke() {
   source "${REPLAY_DIR}/lib/pin-local-kit.sh"
   resolve_kit_single_source "${REPLAY_DIR}" "${KIT_REF}" || return 1
   KIT_ROOT="${KIT_SINGLE_ROOT}"
-  KIT_LK="${KIT_ROOT}/templates/project/common/scripts/lk"
+  KIT_LK="$(kit_lk_path "$KIT_ROOT")"
 
   # UI track is a PROJECT setting (project.uiTrack, set at create by --ui-track
   # below), not an env door. Only the run-mode Human Proxy is env here.
@@ -234,13 +234,13 @@ replay_smoke() {
     local FR="${CORPUS_DIR}/features/${FEATURE_ID}/feature-request.md"
     [[ -f "$FR" ]] || { err "planning replay needs the recorded feature-request at ${FR}"; return 2; }
     [[ "${REPLAY_DESIGN:-1}" == "1" ]] && export LAKEBASE_CONSORT_REPLAY_DIR="${CORPUS_DIR}"
-    export LAKEBASE_SFTDD_SPRINT_REQUESTS="${FEATURE_ID}"$'\t'"${FR}"$'\n'
+    export LAKEBASE_CONSORT_SPRINT_REQUESTS="${FEATURE_ID}"$'\t'"${FR}"$'\n'
     local _plan_mode; [[ "${REPLAY_DESIGN:-1}" == "1" ]] && _plan_mode="REPLAYED from corpus" || _plan_mode="LIVE (recording)"
     local _plan_flag=""; [[ "$PLAN_ONLY" == "1" ]] && _plan_flag="--plan-only"
     log "PLANNING lane , sprint '${REPLAY_SPRINT}' (propose + estimate ${_plan_mode} via the executor; author-requests deterministic)${_plan_flag:+ , STOP after planning-complete}"
     lk consort-drive --sprint "$REPLAY_SPRINT" --project-dir "$PROJECT_DIR" --gates proxy $_plan_flag \
       || { err "planning-lane ${_plan_flag:-drive} (--sprint ${REPLAY_SPRINT}) failed"; return 2; }
-    unset LAKEBASE_SFTDD_SPRINT_REQUESTS
+    unset LAKEBASE_CONSORT_SPRINT_REQUESTS
     # --plan-only: the planning lane IS the whole run (capture the plan turns, then stop). Skip the
     # per-feature request/claim/drive below , there is no feature to build here.
     if [[ "$PLAN_ONLY" == "1" ]]; then
@@ -320,7 +320,7 @@ replay_smoke() {
   # INTERNAL to this one drive process, so recording + the turn timeline span
   # design and build continuously (as if there were no pause).
   # This harness is headless BY CONSTRUCTION (it exports LAKEBASE_SFTDD_HUMAN_PROXY=1
-  # and its callers set LAKEBASE_SFTDD_AUTO_CONTINUE=1), so it ALWAYS runs the
+  # and its callers set LAKEBASE_CONSORT_AUTO_CONTINUE=1), so it ALWAYS runs the
   # proxy gate policy: the Human Proxy approves each per-story spec gate without a
   # human, in both the capture and replay directions. This is a deliberate,
   # explicit opt-in , the project's declared gate policy is now interactive

--- a/examples/replay/_replay-smoke.sh
+++ b/examples/replay/_replay-smoke.sh
@@ -92,7 +92,7 @@ replay_smoke() {
   source "${REPLAY_DIR}/lib/pin-local-kit.sh"
   resolve_kit_single_source "${REPLAY_DIR}" "${KIT_REF}" || return 1
   KIT_ROOT="${KIT_SINGLE_ROOT}"
-  KIT_LK="$(kit_lk_path "$KIT_ROOT")"
+  KIT_LK="$(kit_lk_path "$KIT_ROOT")" || return 1
 
   # UI track is a PROJECT setting (project.uiTrack, set at create by --ui-track
   # below), not an env door. Only the run-mode Human Proxy is env here.
@@ -298,7 +298,16 @@ replay_smoke() {
   local _FEATURE_BRANCH
   _FEATURE_BRANCH="$(printf '%s' "$_CLAIM_JSON" | sed -n 's/.*"branch":"\([^"]*\)".*/\1/p' | head -1)"
   [[ -n "$_FEATURE_BRANCH" ]] || { err "could not parse claimed feature branch from claim JSON"; return 2; }
-  git -C "$PROJECT_DIR" checkout "$_FEATURE_BRANCH" >/dev/null 2>&1 \
+  # Force the checkout. On a RESUME (alreadyClaimed) HEAD is on the parent tier and
+  # the per-run .consort/.lakebase metadata (workflow-state.json, pipeline.json,
+  # smells.json, ...) is dirty + tracked, so a plain `git checkout` ABORTS ("local
+  # changes would be overwritten") and wedges the whole resume. That churn is
+  # disposable here , the feature branch carries its OWN committed state, and landing
+  # on it is the whole point , so -f discards the parent-tier churn and switches.
+  # Mirrors the deterministic force-checkout the orchestrator's `done` phase uses for
+  # the identical condition (orchestrator-effects.ts) and the fork-guard's tolerance
+  # of the same metadata.
+  git -C "$PROJECT_DIR" checkout -f "$_FEATURE_BRANCH" >/dev/null 2>&1 \
     || { err "could not checkout claimed feature branch ${_FEATURE_BRANCH}"; return 2; }
   lk lakebase-branch checkout-paired --project-dir "$PROJECT_DIR" >/dev/null 2>&1 \
     || log "  (warn: checkout-paired .env sync for ${_FEATURE_BRANCH} reported an issue; continuing)"

--- a/examples/replay/_replay-smoke.sh
+++ b/examples/replay/_replay-smoke.sh
@@ -45,7 +45,7 @@ replay_smoke() {
   ASSERT_DIR="${REPLAY_ASSERT_DIR:-${REPLAY_DIR}/assertions}"
   INTAKE_DIR="${REPLAY_INTAKE_DIR:-${REPLAY_DIR}/corpora/bug-tracker}"
   CORPUS_DIR="${REPLAY_DIR}/corpora/bug-tracker/recorded-artifacts"
-  BUILD_CORPUS_DIR="${LAKEBASE_SFTDD_REPLAY_BUILD_DIR:-${REPLAY_DIR}/corpora/bug-tracker/recorded-build}"
+  BUILD_CORPUS_DIR="${LAKEBASE_CONSORT_REPLAY_BUILD_DIR:-${REPLAY_DIR}/corpora/bug-tracker/recorded-build}"
 
   local FEATURE_ID="F1-file-bug"
   local REPLAY_SPRINT="${REPLAY_SPRINT:-}"   # when set (once per project), replay the PLANNING lane
@@ -96,7 +96,7 @@ replay_smoke() {
 
   # UI track is a PROJECT setting (project.uiTrack, set at create by --ui-track
   # below), not an env door. Only the run-mode Human Proxy is env here.
-  export LAKEBASE_SFTDD_HUMAN_PROXY=1
+  export LAKEBASE_CONSORT_HUMAN_PROXY=1
 
   # When recording a run (LAKEBASE_CONSORT_RECORD_DIR set), capture the BUILD corpus
   # too, not just the design mirror: default the per-turn build-record dir under
@@ -307,6 +307,17 @@ replay_smoke() {
   # Mirrors the deterministic force-checkout the orchestrator's `done` phase uses for
   # the identical condition (orchestrator-effects.ts) and the fork-guard's tolerance
   # of the same metadata.
+  #
+  # -f discards ALL dirty tracked files, but the ONLY dirt we intend to drop is that
+  # disposable metadata. A dirty tracked SOURCE/intake file here is a real change and
+  # must NOT be silently nuked , fail loud if any dirty tracked file lives outside
+  # .consort/.lakebase (mirrors cutExperiment's fork-guard: tolerate the run metadata,
+  # refuse everything else). `cut -c4-` drops the porcelain XY status prefix.
+  _DIRTY_SRC="$(git -C "$PROJECT_DIR" status --porcelain --untracked-files=no | cut -c4- | grep -vE '^(\.consort/|\.lakebase/)' || true)"
+  if [[ -n "$_DIRTY_SRC" ]]; then
+    err "refusing to force-checkout ${_FEATURE_BRANCH}: dirty tracked file(s) outside .consort/.lakebase would be discarded:"$'\n'"${_DIRTY_SRC}"
+    return 2
+  fi
   git -C "$PROJECT_DIR" checkout -f "$_FEATURE_BRANCH" >/dev/null 2>&1 \
     || { err "could not checkout claimed feature branch ${_FEATURE_BRANCH}"; return 2; }
   lk lakebase-branch checkout-paired --project-dir "$PROJECT_DIR" >/dev/null 2>&1 \
@@ -328,7 +339,7 @@ replay_smoke() {
   # same run on Y , it does NOT bail out of the state machine. The pause is
   # INTERNAL to this one drive process, so recording + the turn timeline span
   # design and build continuously (as if there were no pause).
-  # This harness is headless BY CONSTRUCTION (it exports LAKEBASE_SFTDD_HUMAN_PROXY=1
+  # This harness is headless BY CONSTRUCTION (it exports LAKEBASE_CONSORT_HUMAN_PROXY=1
   # and its callers set LAKEBASE_CONSORT_AUTO_CONTINUE=1), so it ALWAYS runs the
   # proxy gate policy: the Human Proxy approves each per-story spec gate without a
   # human, in both the capture and replay directions. This is a deliberate,
@@ -342,7 +353,7 @@ replay_smoke() {
   fi
   if [[ "$REPLAY_BUILD" == "1" ]]; then
     [[ -d "$BUILD_CORPUS_DIR" ]] || { err "build corpus missing: $BUILD_CORPUS_DIR"; return 2; }
-    export LAKEBASE_SFTDD_REPLAY_BUILD_DIR="$BUILD_CORPUS_DIR"
+    export LAKEBASE_CONSORT_REPLAY_BUILD_DIR="$BUILD_CORPUS_DIR"
   fi
   local DESIGN_MODE; [[ "${REPLAY_DESIGN:-1}" == "1" ]] && DESIGN_MODE="REPLAYED" || DESIGN_MODE="LIVE (recording)"
   local BUILD_NOTE=""; [[ "$REPLAY_BUILD" == "1" ]] && BUILD_NOTE=" + build RESTORED"

--- a/examples/replay/capture-scenario.sh
+++ b/examples/replay/capture-scenario.sh
@@ -175,7 +175,7 @@ KIT_ROOT="$KIT_SINGLE_ROOT"
 #    the FULL LIVE design lane (no replay) so the design roles + the pre-build
 #    reflection gate all run live and are recorded. ─────────────────────────────
 if [[ -n "$CREATE" ]]; then
-  KIT_LK="$(kit_lk_path "$KIT_ROOT")"
+  KIT_LK="$(kit_lk_path "$KIT_ROOT")" || exit 1
   HOST="${DATABRICKS_HOST_ARG:-${DATABRICKS_HOST:?--databricks-host or DATABRICKS_HOST required}}"
   OWNER="${GITHUB_OWNER_ARG:-${GITHUB_OWNER:?--github-owner or GITHUB_OWNER required}}"
   PROJECT_NAME="${PROJECT_NAME:-${SCENARIO}-cap-$(date +%Y%m%d-%H%M%S)}"
@@ -202,7 +202,13 @@ if [[ -n "$CREATE" ]]; then
   # stockflow-optimize first live run provisioned Spring Boot/Java, not python+UI).
   SCENARIO_MANIFEST="${INPUTS}/scenario.json"
   [[ -f "$SCENARIO_MANIFEST" ]] || SCENARIO_MANIFEST="${INPUTS}/scenario.json.pending"
-  sc() { node "${KIT_ROOT}/dist/bin/consort/scenario-conditions.cli.js" --manifest "$SCENARIO_MANIFEST" --field "$1" 2>/dev/null || true; }
+  # Warn LOUD when the conditions reader is missing (unbuilt/stale dist): sc() then
+  # returns empty for every field and the run silently scaffolds the WRONG stack
+  # (java, no UI, wrong tiers) instead of the manifest's , the exact silent-default
+  # failure the comment above records. Non-fatal (we still degrade to the --ui flag).
+  SC_CLI="${KIT_ROOT}/dist/bin/consort/scenario-conditions.cli.js"
+  [[ -f "$SC_CLI" ]] || echo "capture-scenario: WARNING , conditions reader missing (${SC_CLI}); scenario conditions will DEFAULT (run 'npm run build' in the kit). Scaffolding may use the wrong language/UI/tiers." >&2
+  sc() { node "$SC_CLI" --manifest "$SCENARIO_MANIFEST" --field "$1" 2>/dev/null || true; }
   SC_UI="$(sc uiTrack)"; SC_LANG="$(sc language)"; SC_RUNNER="$(sc runner)"; SC_TIERS="$(sc tiers)"
   create_flags=(--tiers "${SC_TIERS:-$TIERS}")
   [[ "$SC_UI" == "true" || -n "$UI" ]] && create_flags+=(--ui-track)

--- a/examples/replay/capture-scenario.sh
+++ b/examples/replay/capture-scenario.sh
@@ -34,7 +34,7 @@
 #     --sprint <sprint-name> --feature F1-... --feature F6-...
 #   # The whole-sprint orchestrator plans to the plan gate (sync-backlog projects
 #   # backlog.json from just these features), then claims + drives each. The
-#   # feature-requests are supplied to planning via LAKEBASE_SFTDD_SPRINT_REQUESTS.
+#   # feature-requests are supplied to planning via LAKEBASE_CONSORT_SPRINT_REQUESTS.
 #
 #   # Plan-only: capture JUST the planning lane (propose/estimate via the executor +
 #   # author-requests/sync-backlog/estimate-committed/gate-plan) and STOP at
@@ -42,7 +42,7 @@
 #   capture-scenario.sh --scenario <name> --create ... \
 #     --sprint <name> --feature <F1> --plan-only
 # Env: DATABRICKS_HOST, DATABRICKS_CONFIG_PROFILE, GITHUB_OWNER.
-#      LAKEBASE_SFTDD_AUTO_CONTINUE=1 to run headless (required for --create).
+#      LAKEBASE_CONSORT_AUTO_CONTINUE=1 to run headless (required for --create).
 #      Do NOT set LAKEBASE_KIT_DIR: the script refuses it (it would split-brain
 #      the orchestrator vs the claude -p agents). The script instead pins one dev
 #      ref (CAPTURE_KIT_REF, default sftdd-capture-local) symlinked to THIS kit
@@ -175,7 +175,7 @@ KIT_ROOT="$KIT_SINGLE_ROOT"
 #    the FULL LIVE design lane (no replay) so the design roles + the pre-build
 #    reflection gate all run live and are recorded. ─────────────────────────────
 if [[ -n "$CREATE" ]]; then
-  KIT_LK="${KIT_ROOT}/templates/project/common/scripts/lk"
+  KIT_LK="$(kit_lk_path "$KIT_ROOT")"
   HOST="${DATABRICKS_HOST_ARG:-${DATABRICKS_HOST:?--databricks-host or DATABRICKS_HOST required}}"
   OWNER="${GITHUB_OWNER_ARG:-${GITHUB_OWNER:?--github-owner or GITHUB_OWNER required}}"
   PROJECT_NAME="${PROJECT_NAME:-${SCENARIO}-cap-$(date +%Y%m%d-%H%M%S)}"
@@ -257,7 +257,7 @@ if [[ -n "$CREATE" ]]; then
   # PER-FEATURE mode: pre-seed each feature-request on the entry tier so the fork
   # inherits it. SPRINT mode does NOT pre-seed: the planning lane authors the
   # feature-requests LIVE (the proxy-as-PO author-requests step, fed by
-  # LAKEBASE_SFTDD_SPRINT_REQUESTS), and runSprint's commitAndPushRequests commits
+  # LAKEBASE_CONSORT_SPRINT_REQUESTS), and runSprint's commitAndPushRequests commits
   # + pushes them to origin AFTER the plan gate, BEFORE the first fork. Pre-seeding
   # here would defeat the point of exercising the planning lane.
   if [[ ${#SPRINT_NAMES[@]} -eq 0 ]]; then
@@ -312,7 +312,7 @@ if [[ ${#SPRINT_NAMES[@]} -gt 0 ]]; then
   #    the PLANNING lane and emits backlog.json. Each sprint's backlog is EXACTLY
   #    its own --feature group, and the feature-requests are authored LIVE by the
   #    planning lane (NOT pre-seeded above):
-  #      - LAKEBASE_SFTDD_SPRINT_REQUESTS supplies THIS sprint's recorded requests
+  #      - LAKEBASE_CONSORT_SPRINT_REQUESTS supplies THIS sprint's recorded requests
   #        to the planning author-requests step (proxy-as-PO), so sync-backlog
   #        projects the backlog from just this sprint's features; AND
   #      - runSprint's commitAndPushRequests commits + pushes the just-authored
@@ -334,7 +334,7 @@ if [[ ${#SPRINT_NAMES[@]} -gt 0 ]]; then
       [[ -f "$FR" ]] || { echo "capture-scenario: --sprint '${sname}' needs a recorded feature-request for ${FID} at ${FR}" >&2; exit 2; }
       reqs+="${FID}"$'\t'"${FR}"$'\n'
     done
-    export LAKEBASE_SFTDD_SPRINT_REQUESTS="$reqs"
+    export LAKEBASE_CONSORT_SPRINT_REQUESTS="$reqs"
     echo "[capture-scenario] recording ${SCENARIO} SPRINT '${sname}' (backlog: ${sfeats[*]}) into ${SCEN}" >&2
     # Honor the drive's exit code: a raise-to-HIL (or any failure) exits non-zero,
     # and the sprint's feature is still claimed. Advancing to the NEXT sprint would

--- a/examples/replay/capture-scenario.sh
+++ b/examples/replay/capture-scenario.sh
@@ -210,6 +210,13 @@ if [[ -n "$CREATE" ]]; then
   [[ -f "$SC_CLI" ]] || echo "capture-scenario: WARNING , conditions reader missing (${SC_CLI}); scenario conditions will DEFAULT (run 'npm run build' in the kit). Scaffolding may use the wrong language/UI/tiers." >&2
   sc() { node "$SC_CLI" --manifest "$SCENARIO_MANIFEST" --field "$1" 2>/dev/null || true; }
   SC_UI="$(sc uiTrack)"; SC_LANG="$(sc language)"; SC_RUNNER="$(sc runner)"; SC_TIERS="$(sc tiers)"
+  # A present-but-STALE/BROKEN dist passes the -f check above yet throws at runtime,
+  # and `|| true` swallows it , so ALSO warn when the reader yielded NOTHING despite a
+  # real manifest (every field empty = conditions silently defaulted, the same
+  # wrong-stack failure). Non-fatal; still degrades to the --ui flag.
+  if [[ -f "$SC_CLI" && -f "$SCENARIO_MANIFEST" && -z "${SC_UI}${SC_LANG}${SC_RUNNER}${SC_TIERS}" ]]; then
+    echo "capture-scenario: WARNING , conditions reader (${SC_CLI}) returned NO fields from ${SCENARIO_MANIFEST} (stale/broken dist?); scenario conditions will DEFAULT (run 'npm run build' in the kit). Scaffolding may use the wrong language/UI/tiers." >&2
+  fi
   create_flags=(--tiers "${SC_TIERS:-$TIERS}")
   [[ "$SC_UI" == "true" || -n "$UI" ]] && create_flags+=(--ui-track)
   [[ -n "$SC_LANG" ]] && create_flags+=(--language "$SC_LANG")

--- a/examples/replay/launch-stockflow-instrumented.sh
+++ b/examples/replay/launch-stockflow-instrumented.sh
@@ -55,7 +55,7 @@ export GITHUB_OWNER="${GITHUB_OWNER:-${LAKEBASE_TEST_GITHUB_OWNER:-}}"
 
 # --- recording + unattended resume ---
 export LAKEBASE_CONSORT_RECORD_DIR="$REC"   # turns/ + routing-decisions.jsonl + correspondence.jsonl
-export LAKEBASE_SFTDD_AUTO_CONTINUE=1        # auto-confirm the navigator pause (unattended)
+export LAKEBASE_CONSORT_AUTO_CONTINUE=1        # auto-confirm the navigator pause (unattended)
 # Manifest-steps path is ON (the executor is the sole agent path + the route-contract seam fires). It
 # is ON by default, but set it EXPLICITLY here so a stray USE_MANIFEST_STEPS=0 in the environment can
 # never silently drop the capture onto the retired legacy dispatch. (The flag is not retired , it does

--- a/examples/replay/launch-stockflow-instrumented.sh
+++ b/examples/replay/launch-stockflow-instrumented.sh
@@ -60,7 +60,7 @@ export LAKEBASE_CONSORT_AUTO_CONTINUE=1        # auto-confirm the navigator paus
 # is ON by default, but set it EXPLICITLY here so a stray USE_MANIFEST_STEPS=0 in the environment can
 # never silently drop the capture onto the retired legacy dispatch. (The flag is not retired , it does
 # not prevent capture , per the "flag on unless it blocks" rule; keep it pinned on for the capture.)
-export LAKEBASE_SFTDD_USE_MANIFEST_STEPS=1
+export LAKEBASE_CONSORT_USE_MANIFEST_STEPS=1
 
 echo "[launch] record dir : $REC"
 echo "[launch] project    : $PROJECT_NAME  ($PROJECT_DIR)"

--- a/examples/replay/lib/pin-local-kit.sh
+++ b/examples/replay/lib/pin-local-kit.sh
@@ -13,11 +13,30 @@
 
 LOCAL_KIT_REF_DEFAULT="sftdd-capture-local"
 
+# The kit package these launchers resolve. The scaffold `lk` shim is generic
+# across substrate + kit, so a PRE-project call (no .lakebase/kit-package yet) must
+# be told which package to load; resolve_kit_single_source exports this as
+# LAKEBASE_KIT_PACKAGE for that reason.
+KIT_PACKAGE_DEFAULT="@databricks-solutions/consort"
+
 # The cache slot (node_modules/<pkg> symlink target) for a local ref.
 local_kit_cache_link() {
   local ref="${1:-$LOCAL_KIT_REF_DEFAULT}"
   local cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/consort"
-  printf '%s\n' "${cache_root}/${ref}/node_modules/@databricks-solutions/consort"
+  printf '%s\n' "${cache_root}/${ref}/node_modules/${KIT_PACKAGE_DEFAULT}"
+}
+
+# Path to the scaffold `lk` shim a launcher invokes BEFORE a project exists (for
+# --warm / lakebase-create-project). The shim used to live in-repo at
+# templates/project/common/scripts/lk, but it was moved into the
+# @databricks-solutions/lakebase-scm-utils substrate package (installed under the
+# kit's node_modules). Return the installed path; fall back to the legacy in-repo
+# location for older checkouts that still ship it.
+kit_lk_path() {
+  local kit_root="$1" p
+  p="${kit_root}/node_modules/@databricks-solutions/lakebase-scm-utils/templates/project/common/scripts/lk"
+  [ -f "$p" ] || p="${kit_root}/templates/project/common/scripts/lk"
+  printf '%s\n' "$p"
 }
 
 # Plant (idempotent) the cache symlink -> the working tree, so a bin run finds
@@ -66,6 +85,11 @@ resolve_kit_single_source() {
   # in a SUBSHELL so `pwd` runs on exactly one branch (|| + && are equal precedence, left-assoc).
   root="$(git -C "$start_dir" rev-parse --show-toplevel 2>/dev/null || (cd "$start_dir/../.." && pwd))"
   export KIT_SINGLE_ROOT="$root"
+  # Tell the generic scaffold `lk` which kit to resolve for PRE-project calls
+  # (a scaffolded project reads .lakebase/kit-package, but the launchers invoke
+  # `lk --warm` / lakebase-create-project before any project exists). Respect an
+  # already-set value so a caller can override the package under test.
+  export LAKEBASE_KIT_PACKAGE="${LAKEBASE_KIT_PACKAGE:-$KIT_PACKAGE_DEFAULT}"
   if [ -n "$published_ref" ]; then
     # Escape hatch: a real remote ref, resolved by lk from github , no local cache pin.
     export LAKEBASE_KIT_REF="$published_ref"

--- a/examples/replay/lib/pin-local-kit.sh
+++ b/examples/replay/lib/pin-local-kit.sh
@@ -33,9 +33,19 @@ local_kit_cache_link() {
 # kit's node_modules). Return the installed path; fall back to the legacy in-repo
 # location for older checkouts that still ship it.
 kit_lk_path() {
-  local kit_root="$1" p
+  local kit_root="$1" p legacy
   p="${kit_root}/node_modules/@databricks-solutions/lakebase-scm-utils/templates/project/common/scripts/lk"
-  [ -f "$p" ] || p="${kit_root}/templates/project/common/scripts/lk"
+  legacy="${kit_root}/templates/project/common/scripts/lk"
+  if [ ! -f "$p" ] && [ ! -f "$legacy" ]; then
+    # Neither the substrate-package shim nor the legacy in-repo path exists. The
+    # usual cause is that `npm install` has not been run in the kit (the substrate
+    # package, which ships the shim, is not installed). Fail LOUD here rather than
+    # returning a dead path and letting a later `bash "$KIT_LK" ...` die with an
+    # opaque "No such file or directory".
+    echo "kit_lk_path: no scaffold lk found under ${kit_root} , run 'npm install' in the kit first (expected ${p})." >&2
+    return 1
+  fi
+  [ -f "$p" ] || p="$legacy"
   printf '%s\n' "$p"
 }
 

--- a/examples/replay/lib/pin-local-kit.sh
+++ b/examples/replay/lib/pin-local-kit.sh
@@ -97,9 +97,12 @@ resolve_kit_single_source() {
   export KIT_SINGLE_ROOT="$root"
   # Tell the generic scaffold `lk` which kit to resolve for PRE-project calls
   # (a scaffolded project reads .lakebase/kit-package, but the launchers invoke
-  # `lk --warm` / lakebase-create-project before any project exists). Respect an
-  # already-set value so a caller can override the package under test.
-  export LAKEBASE_KIT_PACKAGE="${LAKEBASE_KIT_PACKAGE:-$KIT_PACKAGE_DEFAULT}"
+  # `lk --warm` / lakebase-create-project before any project exists). This MUST match
+  # the package local_kit_cache_link pins the working-tree symlink under
+  # (KIT_PACKAGE_DEFAULT) , honoring an inbound override here while the cache slot
+  # stays under the default would point the shim at a package with no pinned slot.
+  # So the default is the single source for both; do not read an override.
+  export LAKEBASE_KIT_PACKAGE="$KIT_PACKAGE_DEFAULT"
   if [ -n "$published_ref" ]; then
     # Escape hatch: a real remote ref, resolved by lk from github , no local cache pin.
     export LAKEBASE_KIT_REF="$published_ref"

--- a/examples/replay/replay-scenario.sh
+++ b/examples/replay/replay-scenario.sh
@@ -16,7 +16,7 @@
 #   replay-scenario.sh --scenario <name> [--to navigator|release-engineer]
 #                      [--kit-ref <ref>] [--project-dir <dir>]
 # Env: DATABRICKS_HOST, GITHUB_OWNER, a CLI profile (same as run-smoke.sh).
-#      LAKEBASE_SFTDD_AUTO_CONTINUE=1 auto-confirms the handoff gate (CI).
+#      LAKEBASE_CONSORT_AUTO_CONTINUE=1 auto-confirms the handoff gate (CI).
 # Exit: 0 ok; 2 bad args / missing scenario; non-zero from a failed replay step.
 set -euo pipefail
 

--- a/examples/replay/replay-scenario.sh
+++ b/examples/replay/replay-scenario.sh
@@ -71,7 +71,7 @@ if [[ -f "${SCEN}/intake/product-overview.md" ]]; then
 else
   export REPLAY_INTAKE_DIR="${SCEN}/recorded-artifacts"
 fi
-export LAKEBASE_SFTDD_REPLAY_BUILD_DIR="${SCEN}/recorded-build"
+export LAKEBASE_CONSORT_REPLAY_BUILD_DIR="${SCEN}/recorded-build"
 
 # One project for the whole scenario, so feature N+1 builds on feature N's merged
 # state (the recorded DB + git lineage). Default name is scenario-scoped.

--- a/examples/replay/replay-stockflow-rerecord.sh
+++ b/examples/replay/replay-stockflow-rerecord.sh
@@ -105,7 +105,7 @@ green "  DATABRICKS_HOST=$DATABRICKS_HOST  GITHUB_OWNER=$GITHUB_OWNER  profile=$
 # the delegate's job; setting them twice would risk drift). LAKEBASE_KIT_DIR defaults to this
 # checkout's dist (deterministic, offline). AUTO_CONTINUE auto-confirms the handoff gate (headless).
 export LAKEBASE_SFTDD_USE_MANIFEST_STEPS=1
-export LAKEBASE_SFTDD_AUTO_CONTINUE=1
+export LAKEBASE_CONSORT_AUTO_CONTINUE=1
 
 # ── 5. Delegate to the generic scenario replay ────────────────────────────────
 # --sprint (when set) replays the PLANNING lane once on the first feature: propose + estimate

--- a/examples/replay/replay-stockflow-rerecord.sh
+++ b/examples/replay/replay-stockflow-rerecord.sh
@@ -104,7 +104,7 @@ green "  DATABRICKS_HOST=$DATABRICKS_HOST  GITHUB_OWNER=$GITHUB_OWNER  profile=$
 # from the scenario's own recorded-artifacts/ + recorded-build/ , we do NOT set them here (that is
 # the delegate's job; setting them twice would risk drift). LAKEBASE_KIT_DIR defaults to this
 # checkout's dist (deterministic, offline). AUTO_CONTINUE auto-confirms the handoff gate (headless).
-export LAKEBASE_SFTDD_USE_MANIFEST_STEPS=1
+export LAKEBASE_CONSORT_USE_MANIFEST_STEPS=1
 export LAKEBASE_CONSORT_AUTO_CONTINUE=1
 
 # ── 5. Delegate to the generic scenario replay ────────────────────────────────

--- a/examples/replay/run-capture.sh
+++ b/examples/replay/run-capture.sh
@@ -6,7 +6,7 @@
 # lane LIVE (real Spec Author / Architect / Test Strategist / UX Designer / PO,
 # gates approved headless by the Human Proxy) so a FRESH design corpus is
 # produced, then pauses at the build handoff for review/comparison against the
-# recorded replay corpus. Answer Y (write to LAKEBASE_SFTDD_GATE_ANSWER_FILE) to
+# recorded replay corpus. Answer Y (write to LAKEBASE_CONSORT_GATE_ANSWER_FILE) to
 # RESUME the SAME run into the live build , one process, so the turn recorder +
 # logs span design and build CONTINUOUSLY (as if there were no pause).
 #
@@ -17,11 +17,11 @@
 #   <RECORD_DIR>/recorded-artifacts/     cumulative .tdd mirror (design corpus)
 #   <RECORD_DIR>/recorded-build/         per-turn code corpus (build corpus)
 #
-# Pausing/holding: set LAKEBASE_SFTDD_GATE_ANSWER_FILE to a control file. Leave it
+# Pausing/holding: set LAKEBASE_CONSORT_GATE_ANSWER_FILE to a control file. Leave it
 # ABSENT to HOLD at the navigator gate; write Y to it to RESUME into the build.
 #
 # Usage:
-#   LAKEBASE_CONSORT_RECORD_DIR=<dir> LAKEBASE_SFTDD_GATE_ANSWER_FILE=<file> \
+#   LAKEBASE_CONSORT_RECORD_DIR=<dir> LAKEBASE_CONSORT_GATE_ANSWER_FILE=<file> \
 #     run-capture.sh --tiers 2 [--kit-ref <ref>] [--project-name <n>]
 #                    [--project-dir <dir>] [--feature <id>] [--corpus <dir>]
 # Env: DATABRICKS_HOST, GITHUB_OWNER, a CLI profile (same as run-smoke.sh).

--- a/examples/replay/run-smoke.sh
+++ b/examples/replay/run-smoke.sh
@@ -194,7 +194,7 @@ export LAKEBASE_KIT_NPX="$KIT_NPX"
 source "${ORCHESTRATOR_DIR}/lib/pin-local-kit.sh"
 resolve_kit_single_source "${ORCHESTRATOR_DIR}" "${KIT_REF}" || exit 1
 KIT_ROOT="${KIT_SINGLE_ROOT}"
-KIT_LK="$(kit_lk_path "$KIT_ROOT")"
+KIT_LK="$(kit_lk_path "$KIT_ROOT")" || exit 1
 
 # Headless run: the human reviewer at each HITL gate is performed by
 # human-proxy, which validates the gate's artifacts exist + carry their

--- a/examples/replay/run-smoke.sh
+++ b/examples/replay/run-smoke.sh
@@ -194,7 +194,7 @@ export LAKEBASE_KIT_NPX="$KIT_NPX"
 source "${ORCHESTRATOR_DIR}/lib/pin-local-kit.sh"
 resolve_kit_single_source "${ORCHESTRATOR_DIR}" "${KIT_REF}" || exit 1
 KIT_ROOT="${KIT_SINGLE_ROOT}"
-KIT_LK="${KIT_ROOT}/templates/project/common/scripts/lk"
+KIT_LK="$(kit_lk_path "$KIT_ROOT")"
 
 # Headless run: the human reviewer at each HITL gate is performed by
 # human-proxy, which validates the gate's artifacts exist + carry their
@@ -622,7 +622,7 @@ run_plan_sprint() {
   # where the PO's artifacts are provided, and headless the Human Proxy supplies
   # them then (logging each). The recorded file is named independently of the
   # feature id (v1-initial-domain.md -> F1-initial-domain), so each pair is
-  # `<feature_id>\t<recorded source>`, passed via LAKEBASE_SFTDD_SPRINT_REQUESTS.
+  # `<feature_id>\t<recorded source>`, passed via LAKEBASE_CONSORT_SPRINT_REQUESTS.
   # This is the identical state machine a human runs; only the provider differs.
   local iter feature_id spec _pairs=""
   for iter in "${iters[@]}"; do
@@ -631,7 +631,7 @@ run_plan_sprint() {
     [[ -f "$spec" ]] || { err "missing iteration spec: $spec"; exit 2; }
     _pairs+="$(printf '%s\t%s' "$feature_id" "$spec")"$'\n'
   done
-  export LAKEBASE_SFTDD_SPRINT_REQUESTS="$_pairs"
+  export LAKEBASE_CONSORT_SPRINT_REQUESTS="$_pairs"
 
   # c. Drive planning through the deterministic orchestrator (the same CLI the
   # scaffolded /plan command runs). The smoke calls the driver DIRECTLY (as it
@@ -641,7 +641,7 @@ run_plan_sprint() {
   # gate was never approved. Calling the driver here (in this shell, where the env
   # is correct) with an explicit `--gates proxy` is deterministic. The driver runs
   # propose (Spec Author -> feature-proposals.md), author-requests (the Human Proxy
-  # supplies the recorded feature-requests from LAKEBASE_SFTDD_SPRINT_REQUESTS + logs
+  # supplies the recorded feature-requests from LAKEBASE_CONSORT_SPRINT_REQUESTS + logs
   # each), sync-backlog (projects backlog.json from them), then the Human Proxy
   # approves the sprint plan gate (teeth: feature-proposals.md exists + conforms)
   # and it stops at planning-complete.

--- a/examples/replay/run-smoke.sh
+++ b/examples/replay/run-smoke.sh
@@ -202,13 +202,13 @@ KIT_LK="$(kit_lk_path "$KIT_ROOT")" || exit 1
 # /design run through to test-list.json (and /build) without a human, while
 # conformance still hard-blocks a missing/malformed artifact. See SKILL
 # "Headless / Human Proxy mode".
-export LAKEBASE_SFTDD_HUMAN_PROXY=1
+export LAKEBASE_CONSORT_HUMAN_PROXY=1
 
 # Where the Human Proxy reads pre-recorded HIL intake answers in headless mode.
 # /design's intake precondition (consort-intake) facilitates from here when
 # an artifact is missing; this smoke also pre-supplies them (stage_project_intake)
 # for determinism. Same directory the recorded product-overview.md / nfrs.md live in.
-export LAKEBASE_SFTDD_RECORDED_INTAKE_DIR="${ORCHESTRATOR_DIR}"
+export LAKEBASE_CONSORT_RECORDED_INTAKE_DIR="${ORCHESTRATOR_DIR}"
 
 # This smoke is a UI project (every feature is a browser-facing capability:
 # filing a bug, transitioning its status). It is scaffolded with `--ui-track`
@@ -225,7 +225,7 @@ export LAKEBASE_SFTDD_RECORDED_INTAKE_DIR="${ORCHESTRATOR_DIR}"
 # via --agent-model) and applies its own MCP-isolation flags. Driving the CLI
 # directly (rather than a claude -p "/plan" session) keeps gate mode + env
 # deterministic: a claude -p Bash tool does not reliably inherit
-# LAKEBASE_SFTDD_HUMAN_PROXY, which silently flipped the plan gate to interactive.
+# LAKEBASE_CONSORT_HUMAN_PROXY, which silently flipped the plan gate to interactive.
 
 log_kit_ref() { echo "smoke: kit ref = ${KIT_REF:-main} (npx package: ${KIT_NPX})"; }
 
@@ -636,7 +636,7 @@ run_plan_sprint() {
   # c. Drive planning through the deterministic orchestrator (the same CLI the
   # scaffolded /plan command runs). The smoke calls the driver DIRECTLY (as it
   # does for the per-feature loop), not through `claude -p "/plan"`: a claude -p
-  # session's Bash tool does not reliably inherit LAKEBASE_SFTDD_HUMAN_PROXY, so the
+  # session's Bash tool does not reliably inherit LAKEBASE_CONSORT_HUMAN_PROXY, so the
   # command's gate-mode check fell through to `interactive` headless and the plan
   # gate was never approved. Calling the driver here (in this shell, where the env
   # is correct) with an explicit `--gates proxy` is deterministic. The driver runs

--- a/examples/replay/run-to-navigator.sh
+++ b/examples/replay/run-to-navigator.sh
@@ -8,7 +8,7 @@
 # Enter) to resume the SAME run into the live Navigator/Driver build + deploy; the
 # state machine is never abandoned. Use it to review the pristine pre-build state.
 #
-# Set LAKEBASE_SFTDD_AUTO_CONTINUE=1 to auto-confirm the gate (non-interactive / CI).
+# Set LAKEBASE_CONSORT_AUTO_CONTINUE=1 to auto-confirm the gate (non-interactive / CI).
 #
 # Determinism is in code: with no --kit-ref, the kit resolves to this checkout's
 # built dist (offline, stable). See _replay-smoke.sh.

--- a/examples/replay/run-to-release-engineer.sh
+++ b/examples/replay/run-to-release-engineer.sh
@@ -9,7 +9,7 @@
 # to resume the SAME run into the deploy + verify + the PO acceptance gate; the
 # state machine is never abandoned. Use it to review the built, ready-to-ship state.
 #
-# Set LAKEBASE_SFTDD_AUTO_CONTINUE=1 to auto-confirm the gate (non-interactive / CI).
+# Set LAKEBASE_CONSORT_AUTO_CONTINUE=1 to auto-confirm the gate (non-interactive / CI).
 #
 # Determinism is in code: with no --kit-ref, the kit resolves to this checkout's
 # built dist (offline, stable). See _replay-smoke.sh.

--- a/examples/replay/run-to-release-engineer.sh
+++ b/examples/replay/run-to-release-engineer.sh
@@ -18,7 +18,7 @@
 #   run-to-release-engineer.sh --tiers 2 [--kit-ref <ref>] [--project-name <n>]
 #                              [--project-dir <dir>] [--feature <id>] [--corpus <dir>]
 # Env: DATABRICKS_HOST, GITHUB_OWNER, a CLI profile. Override the build corpus
-#      with LAKEBASE_SFTDD_REPLAY_BUILD_DIR.
+#      with LAKEBASE_CONSORT_REPLAY_BUILD_DIR.
 # Exit: 0 ok (resumed past the gate to completion); 1 scaffold failed; 2 a step failed.
 
 SMOKE_NAME="run-to-release-engineer"

--- a/tests/bdd/consort-workflow-smoke.test.ts
+++ b/tests/bdd/consort-workflow-smoke.test.ts
@@ -219,9 +219,9 @@ describe("TDD-workflow smoke: orchestrator supplies intake via the Human Proxy",
   it("hands the PO's feature-requests to the Human Proxy WHEN the state machine asks (not pre-staged)", () => {
     // The PO's artifacts are supplied at the author-requests step, not before:
     // run_plan_sprint records the (feature_id, recorded source) pairs in
-    // LAKEBASE_SFTDD_SPRINT_REQUESTS, and the driver's author-requests step has the
+    // LAKEBASE_CONSORT_SPRINT_REQUESTS, and the driver's author-requests step has the
     // Human Proxy supply them. No bare cp, and no up-front proxy_supply into .tdd.
-    expect(runSmoke).toMatch(/export LAKEBASE_SFTDD_SPRINT_REQUESTS=/);
+    expect(runSmoke).toMatch(/export LAKEBASE_CONSORT_SPRINT_REQUESTS=/);
     expect(runSmoke).not.toMatch(/cp "\$spec"/);
     expect(runSmoke, "no up-front feature-request staging").not.toMatch(
       /proxy_supply "\$spec".*feature-request\.md/,
@@ -229,7 +229,7 @@ describe("TDD-workflow smoke: orchestrator supplies intake via the Human Proxy",
     expect(runSmoke).toMatch(/run_plan_sprint\s*\(\)/);
     const planFn = runSmoke.slice(runSmoke.indexOf("run_plan_sprint() {"));
     expect(planFn, "the recorded request pairs are built in run_plan_sprint").toMatch(
-      /LAKEBASE_SFTDD_SPRINT_REQUESTS/,
+      /LAKEBASE_CONSORT_SPRINT_REQUESTS/,
     );
   });
 });

--- a/tests/bdd/npx-tax-guard.test.ts
+++ b/tests/bdd/npx-tax-guard.test.ts
@@ -60,8 +60,11 @@ describe("npx-tax guard: the canonical logging doc + smoke use lk", () => {
     ]) {
       const smoke = read(rel);
       // Bootstrap routes through the committed lk resolver, pinned via KIT_LK.
-      expect(smoke, `${rel}: defines KIT_LK from the kit's committed lk`).toMatch(
-        /KIT_LK=.*templates\/project\/common\/scripts\/lk/,
+      // KIT_LK resolves through the shared kit_lk_path helper (the scaffold lk now
+      // lives in the @databricks-solutions/lakebase-scm-utils substrate package, not
+      // in-repo), so assert the helper is used rather than a hardcoded lk path.
+      expect(smoke, `${rel}: defines KIT_LK via the shared kit_lk_path resolver`).toMatch(
+        /KIT_LK="?\$\(kit_lk_path /,
       );
       // Tolerate both inline and split-line (`bash "$KIT_LK" \` then bin) forms.
       expect(smoke, `${rel}: runs create-project via lk`).toMatch(/bash "\$KIT_LK"[\s\\]*lakebase-create-project/);

--- a/tests/bdd/replay-layout-guard.test.ts
+++ b/tests/bdd/replay-layout-guard.test.ts
@@ -58,14 +58,38 @@ describe("replay launchers resolve the scaffold lk via the shared helper (anti-d
     );
   });
 
+  it("kit_lk_path fails loud (returns non-zero) when no scaffold lk exists", () => {
+    // Rather than silently returning a dead path and letting a later `bash \"$KIT_LK\"`
+    // die with an opaque \"No such file or directory\", the helper must error + return 1.
+    const lib = fs.readFileSync(LIB, "utf8");
+    expect(lib, "kit_lk_path returns 1 when neither lk path exists").toMatch(/return 1/);
+  });
+
   for (const f of LAUNCHERS) {
-    it(`${f} resolves KIT_LK via kit_lk_path, not the removed in-repo path`, () => {
+    it(`${f} resolves KIT_LK via kit_lk_path and honors its failure`, () => {
       const src = fs.readFileSync(path.join(REPLAY_DIR, f), "utf8");
-      expect(src, `${f} uses the kit_lk_path helper`).toMatch(/KIT_LK="?\$\(kit_lk_path /);
+      // Uses the helper AND bails (|| exit/return) when it fails, so a missing lk
+      // stops the run loudly instead of proceeding with an empty KIT_LK.
+      expect(src, `${f} uses kit_lk_path and bails on failure`).toMatch(
+        /KIT_LK="?\$\(kit_lk_path [^\n]*\)"?\s*\|\|\s*(exit|return)\s+1/,
+      );
       expect(
         src.includes(REMOVED_INREPO_LK),
         `${f} must not hardcode KIT_LK at the removed in-repo lk path`,
       ).toBe(false);
     });
   }
+});
+
+// The resume path (alreadyClaimed) leaves HEAD on the parent tier with dirty tracked
+// .consort/.lakebase run metadata; a plain `git checkout <feature>` aborts and wedges
+// the resume. The checkout must force past that disposable churn (the feature branch
+// carries its own committed state), mirroring the orchestrator's done-phase force.
+describe("replay resume forces past dirty run-metadata on the feature checkout", () => {
+  it("_replay-smoke.sh checks out the claimed feature branch with -f", () => {
+    const src = fs.readFileSync(path.join(REPLAY_DIR, "_replay-smoke.sh"), "utf8");
+    expect(src, "feature-branch checkout uses -f").toMatch(
+      /checkout -f "\$_FEATURE_BRANCH"/,
+    );
+  });
 });

--- a/tests/bdd/replay-layout-guard.test.ts
+++ b/tests/bdd/replay-layout-guard.test.ts
@@ -38,3 +38,34 @@ describe("replay layout: one machinery dir + corpora/ subdir (anti-drift)", () =
     ).toBe(false);
   });
 });
+
+// The scaffold `lk` shim was moved out of this repo (templates/project/common/scripts/lk)
+// into the @databricks-solutions/lakebase-scm-utils substrate package, and made generic
+// (it needs LAKEBASE_KIT_PACKAGE to know which kit to load). A launcher that still points
+// KIT_LK at the removed in-repo path hard-fails EVERY capture/replay/smoke at the first
+// pre-project `lk` call ("No such file or directory"). This guard keeps the resolution on
+// the shared helper so that regression cannot silently return.
+describe("replay launchers resolve the scaffold lk via the shared helper (anti-drift)", () => {
+  const LIB = path.join(REPLAY_DIR, "lib", "pin-local-kit.sh");
+  const LAUNCHERS = ["capture-scenario.sh", "_replay-smoke.sh", "run-smoke.sh"];
+  const REMOVED_INREPO_LK = 'KIT_LK="${KIT_ROOT}/templates/project/common/scripts/lk"';
+
+  it("pin-local-kit.sh provides kit_lk_path() and exports LAKEBASE_KIT_PACKAGE", () => {
+    const lib = fs.readFileSync(LIB, "utf8");
+    expect(lib, "kit_lk_path() helper defined").toMatch(/kit_lk_path\(\)\s*\{/);
+    expect(lib, "resolve_kit_single_source exports LAKEBASE_KIT_PACKAGE").toMatch(
+      /export\s+LAKEBASE_KIT_PACKAGE=/,
+    );
+  });
+
+  for (const f of LAUNCHERS) {
+    it(`${f} resolves KIT_LK via kit_lk_path, not the removed in-repo path`, () => {
+      const src = fs.readFileSync(path.join(REPLAY_DIR, f), "utf8");
+      expect(src, `${f} uses the kit_lk_path helper`).toMatch(/KIT_LK="?\$\(kit_lk_path /);
+      expect(
+        src.includes(REMOVED_INREPO_LK),
+        `${f} must not hardcode KIT_LK at the removed in-repo lk path`,
+      ).toBe(false);
+    });
+  }
+});

--- a/tests/bdd/replay-layout-guard.test.ts
+++ b/tests/bdd/replay-layout-guard.test.ts
@@ -62,7 +62,12 @@ describe("replay launchers resolve the scaffold lk via the shared helper (anti-d
     // Rather than silently returning a dead path and letting a later `bash \"$KIT_LK\"`
     // die with an opaque \"No such file or directory\", the helper must error + return 1.
     const lib = fs.readFileSync(LIB, "utf8");
-    expect(lib, "kit_lk_path returns 1 when neither lk path exists").toMatch(/return 1/);
+    // Scope to the kit_lk_path body (up to its column-0 closing brace), so removing
+    // the loud-fail from THIS helper trips the guard even if a `return 1` survives
+    // elsewhere in the file.
+    const body = lib.match(/kit_lk_path\(\)\s*\{([\s\S]*?)\n\}/);
+    expect(body, "kit_lk_path() helper present").not.toBeNull();
+    expect(body?.[1] ?? "", "kit_lk_path returns 1 when neither lk path exists").toMatch(/return 1/);
   });
 
   for (const f of LAUNCHERS) {


### PR DESCRIPTION
## Problem

The replay/capture launchers cannot run on current `main`. A fresh
`capture-scenario.sh --create` (and the replay/smoke launchers, which share the
same resolver) hard-fails at the first pre-project `lk` call:

```
bash: .../templates/project/common/scripts/lk: No such file or directory
capture-scenario: kit --warm failed
```

`KIT_LK` still points at `templates/project/common/scripts/lk`, a shim that was
removed from this repo — the scaffold `lk` now lives in the
`@databricks-solutions/lakebase-scm-utils` substrate package (see the header of
`examples/replay/lk`) and was made **generic**, so it needs `LAKEBASE_KIT_PACKAGE`
to know which kit to load. This is very likely why the shipped `stockflow` corpus
is still a v0.3.0-beta.14 recording: the capture path is broken, so it cannot be
re-recorded.

## Fix

1. **`lk` resolution.** Resolve `KIT_LK` via a shared `kit_lk_path()` helper in
   `lib/pin-local-kit.sh` (installed substrate path, with the legacy in-repo path
   as a fallback), and export `LAKEBASE_KIT_PACKAGE` from
   `resolve_kit_single_source` so the generic shim resolves the kit for the
   pre-project `--warm` / `lakebase-create-project` calls. A scaffolded project
   reads `.lakebase/kit-package`, but the launchers invoke `lk` before any project
   exists. Applied to `capture-scenario.sh`, `_replay-smoke.sh`, `run-smoke.sh`.

2. **Env-name refresh.** Rename the deprecated `LAKEBASE_SFTDD_{AUTO_CONTINUE,SPRINT_REQUESTS}`
   to the current `LAKEBASE_CONSORT_*` prefix across the active launchers + docs.
   `consortEnv()` reads `CONSORT_*` first (`SFTDD`/`TDD` remain fallbacks), so this
   is behavior-preserving on the current engine; it silences the per-capture
   deprecation warnings and won't break at the scheduled v0.4.0 removal.

## Tests

- New hermetic anti-drift guard in `replay-layout-guard.test.ts`: the launchers
  must resolve `KIT_LK` via `kit_lk_path` (not the removed in-repo path), and
  `pin-local-kit.sh` must define the helper + export `LAKEBASE_KIT_PACKAGE`.
- Updated the two guards that pinned the old state (`npx-tax-guard.test.ts` was
  asserting the removed `lk` path; `consort-workflow-smoke.test.ts` asserted the
  old env name).
- `npm run typecheck` clean; the affected hermetic suites pass. Verified the fix
  end-to-end: with the patched resolver, `lk` resolves the pinned kit and
  `lakebase-create-project` runs, and a live `capture-scenario.sh --create`
  provisions + drives past setup.

## Notes for maintainers

- Scope is the replay harness only; no engine/kit runtime code changes.
- Heads-up (separate from this PR): running the **full `npm test`** inside a
  linked `git worktree` corrupts the worktree's git — several build-lane tests
  (`cycle-record`, `greenOpenCycle`, `cutExperiment`, …) make real `git commit`s
  that land on the current branch instead of an isolated fixture (branch HEAD gets
  rewritten with `green: T1/T2` / `refactor` commits). Worth isolating those
  tests' git ops; happy to file/fix separately.

This pull request and its description were written by Isaac.